### PR TITLE
Introduced EditableLimitableEntry widget

### DIFF
--- a/airgun/entities/activationkey.py
+++ b/airgun/entities/activationkey.py
@@ -3,7 +3,7 @@ from navmazing import NavigateToSibling
 from airgun.entities.base import BaseEntity
 from airgun.navigation import NavigateStep, navigator
 from airgun.views.activationkey import (
-    ActivationKeyDetailsView,
+    ActivationKeyCreateView,
     ActivationKeyEditView,
     ActivationKeyView,
 
@@ -49,7 +49,7 @@ class ShowAllActivationKeys(NavigateStep):
 
 @navigator.register(ActivationKeyEntity, 'New')
 class AddNewActivationKey(NavigateStep):
-    VIEW = ActivationKeyDetailsView
+    VIEW = ActivationKeyCreateView
 
     prerequisite = NavigateToSibling('All')
 

--- a/airgun/views/activationkey.py
+++ b/airgun/views/activationkey.py
@@ -1,4 +1,4 @@
-from widgetastic.widget import Checkbox, Select, Text, TextInput, View
+from widgetastic.widget import Select, Text, TextInput, View
 
 from airgun.views.common import (
     AddRemoveResourcesView,

--- a/airgun/views/activationkey.py
+++ b/airgun/views/activationkey.py
@@ -10,6 +10,7 @@ from airgun.widgets import (
     ConfirmationDialog,
     EditableEntry,
     EditableEntrySelect,
+    EditableLimitableEntry,
     LCESelector,
     SelectActionList,
 )
@@ -49,7 +50,7 @@ class ActivationKeyEditView(BaseLoggedInView):
     return_to_all = Text("//a[text()='Activation Keys']")
     name = EditableEntry(name='Name')
     description = EditableEntry(name='Description')
-    host_limit = EditableEntry(name='Host Limit')
+    host_limit = EditableLimitableEntry(name='Host Limit')
     service_level = EditableEntrySelect(name='Service Level')
     action_list = SelectActionList()
     dialog = ConfirmationDialog()

--- a/airgun/views/activationkey.py
+++ b/airgun/views/activationkey.py
@@ -10,8 +10,9 @@ from airgun.widgets import (
     ConfirmationDialog,
     EditableEntry,
     EditableEntrySelect,
-    EditableLimitableEntry,
+    EditableLimitEntry,
     LCESelector,
+    LimitInput,
     SelectActionList,
 )
 
@@ -30,15 +31,14 @@ class ActivationKeyView(BaseLoggedInView, SearchableViewMixin):
             self.title, exception=False) is not None
 
 
-class ActivationKeyDetailsView(BaseLoggedInView):
+class ActivationKeyCreateView(BaseLoggedInView):
 
     name = TextInput(id='name')
+    hosts_limit = LimitInput()
     description = TextInput(id='description')
-    unlimited_hosts = Checkbox(name='limit')
-    max_hosts = TextInput(id='max_hosts')
-    submit = Text("//button[contains(@ng-click, 'handleSave')]")
     lce = LCESelector()
     content_view = Select(id='content_view_id')
+    submit = Text("//button[contains(@ng-click, 'handleSave')]")
 
     @property
     def is_displayed(self):
@@ -50,7 +50,7 @@ class ActivationKeyEditView(BaseLoggedInView):
     return_to_all = Text("//a[text()='Activation Keys']")
     name = EditableEntry(name='Name')
     description = EditableEntry(name='Description')
-    host_limit = EditableLimitableEntry(name='Host Limit')
+    hosts_limit = EditableLimitEntry(name='Host Limit')
     service_level = EditableEntrySelect(name='Service Level')
     action_list = SelectActionList()
     dialog = ConfirmationDialog()

--- a/airgun/views/common.py
+++ b/airgun/views/common.py
@@ -24,6 +24,17 @@ class SatTab(Tab):
         @View.nested
         class mytab(SatTab):
             TAB_NAME = 'My Tab'
+
+    Note that ``TAB_NAME`` is optional and if it's absent - capitalized class
+    name is used instead, which is useful for simple tab names like
+    'Subscriptions'::
+
+        @View.nested
+        class subscriptions(SatTab):
+            # no need to specify 'TAB_NAME', it will be set to 'Subscriptions'
+            # automatically
+            pass
+
     """
     ROOT = ParametrizedLocator(
         './/div[contains(@class, "page-content") or '
@@ -55,8 +66,8 @@ class AddRemoveResourcesView(View):
         class resources(AddRemoveResourcesView): pass
 
     Note that locator for checkboxes of resources in tables can be overwritten
-    for rare cases like Subscriptions where every table entry may take more
-    than one line::
+    for rare cases like Subscriptions where every entry consists of multiple
+    table rows::
 
         @View.nested
         class resources(AddRemoveResourcesView):

--- a/airgun/widgets.py
+++ b/airgun/widgets.py
@@ -506,6 +506,12 @@ class LimitInput(Widget):
          ng-required="!activationKey.unlimited_hosts" type="number" min="1"
          max="2147483648"...>
 
+    Locator example::
+
+        No locator accepted as widget consists of multiple other widgets in
+        different parts of DOM. Please use View's ``ROOT`` for proper isolation
+        if needed.
+
     """
     unlimited = Checkbox(
         locator=(

--- a/airgun/widgets.py
+++ b/airgun/widgets.py
@@ -3,6 +3,7 @@ from widgetastic.exceptions import (
 
 
 from widgetastic.widget import (
+    Checkbox,
     do_not_read_this_widget,
     GenericLocatorWidget,
     Select,
@@ -549,3 +550,26 @@ class EditableEntrySelect(EditableEntry):
     but by select list
     """
     edit_field = Select(locator=".//select")
+
+
+class EditableLimitableEntry(EditableEntry):
+    """Variant of :class:`EditableEntry` which has input shown only in case
+    'Unlimited' checkbox unchecked.
+    """
+    unlimited = Checkbox(locator=".//input[@type='checkbox']")
+    edit_field = TextInput(
+        locator=".//*[self::input or self::textarea][not(@type='checkbox')]")
+
+    def fill(self, value):
+        """Handle 'Unlimited' checkbox before trying to fill input.
+
+        :param value: either 'Unlimited' (case insensitive) to check off
+            corresponding checkbox or value to fill input with.
+        """
+        self.edit_button.click()
+        if value.lower() == 'unlimited':
+            self.unlimited.fill(True)
+        else:
+            self.unlimited.fill(False)
+            self.edit_field.fill(value)
+        self.save_button.click()

--- a/airgun/widgets.py
+++ b/airgun/widgets.py
@@ -518,7 +518,7 @@ class LimitInput(Widget):
     def fill(self, value):
         """Handle 'Unlimited' checkbox before trying to fill text input.
 
-        :param value: either 'Unlimited' (case insensitive) to check off
+        :param value: either 'Unlimited' (case insensitive) to select
             corresponding checkbox or value to fill text input with.
         """
         if self.read().lower() == str(value).lower():
@@ -531,7 +531,7 @@ class LimitInput(Widget):
         return True
 
     def read(self):
-        """Return either 'Unlimited' if corresponding checkbox is checked off
+        """Return either 'Unlimited' if corresponding checkbox is selected
         or text input value otherwise.
         """
         if self.unlimited.read():
@@ -594,12 +594,13 @@ class EditableEntry(GenericLocatorWidget):
 
 
 class EditableEntrySelect(EditableEntry):
-    """Should be used in case EditableEntry widget represented not by a field,
-    but by select list
+    """Should be used in case :class:`EditableEntry` widget represented not by
+    a field, but by select list.
     """
     edit_field = Select(locator=".//select")
 
 
 class EditableLimitEntry(EditableEntry):
-    """:class:`EditableEntry` which contains :class:`LimitInput` inside."""
+    """Should be used in case :class:`EditableEntry` widget represented not by
+    a field, but by :class:`LimitInput` widget."""
     edit_field = LimitInput()


### PR DESCRIPTION
```python
pytest -v tests/foreman/ui_airgun/test_activationkey.py -k test_negative_usage_limit
============================= test session starts ==============================
platform darwin -- Python 3.6.4, pytest-3.3.2, py-1.5.2, pluggy-0.6.0 -- /Users/andrii/workspace/py3a/bin/python3.6
cachedir: .cache
shared_function enabled - OFF - scope:  - storage: file
rootdir: /Users/andrii/workspace/robottelo, inifile:
plugins: wait-for-1.0.9, xdist-1.22.0, services-1.2.1, mock-1.6.3, forked-0.2
collected 6 items
2018-03-23 15:30:47 - conftest - DEBUG - BZ deselect is disabled in settings


tests/foreman/ui_airgun/test_activationkey.py::test_negative_usage_limit PASSED [100%]

============================== 5 tests deselected ==============================
=================== 1 passed, 5 deselected in 312.34 seconds ===================
```