### PR TITLE
Added LCESelectorGroup view

### DIFF
--- a/airgun/views/activationkey.py
+++ b/airgun/views/activationkey.py
@@ -1,8 +1,9 @@
-from widgetastic.widget import Select, Text, TextInput, View
+from widgetastic.widget import ParametrizedView, Select, Text, TextInput, View
 
 from airgun.views.common import (
     AddRemoveResourcesView,
     BaseLoggedInView,
+    LCESelectorGroup,
     SatTab,
     SearchableViewMixin,
 )
@@ -11,7 +12,6 @@ from airgun.widgets import (
     EditableEntry,
     EditableEntrySelect,
     EditableLimitEntry,
-    LCESelector,
     LimitInput,
     SelectActionList,
 )
@@ -36,7 +36,7 @@ class ActivationKeyCreateView(BaseLoggedInView):
     name = TextInput(id='name')
     hosts_limit = LimitInput()
     description = TextInput(id='description')
-    lce = LCESelector()
+    lce = ParametrizedView.nested(LCESelectorGroup)
     content_view = Select(id='content_view_id')
     submit = Text("//button[contains(@ng-click, 'handleSave')]")
 
@@ -52,9 +52,9 @@ class ActivationKeyEditView(BaseLoggedInView):
     description = EditableEntry(name='Description')
     hosts_limit = EditableLimitEntry(name='Host Limit')
     service_level = EditableEntrySelect(name='Service Level')
+    lce = ParametrizedView.nested(LCESelectorGroup)
     action_list = SelectActionList()
     dialog = ConfirmationDialog()
-    lce = LCESelector()
 
     @property
     def is_displayed(self):

--- a/airgun/views/common.py
+++ b/airgun/views/common.py
@@ -2,6 +2,7 @@ import six
 from widgetastic.widget import (
     NoSuchElementException,
     ParametrizedLocator,
+    ParametrizedView,
     Table,
     Text,
     View,
@@ -9,7 +10,12 @@ from widgetastic.widget import (
 )
 from widgetastic_patternfly import Tab
 
-from airgun.widgets import ContextSelector, SatVerticalNavigation, Search
+from airgun.widgets import (
+    ContextSelector,
+    LCESelector,
+    SatVerticalNavigation,
+    Search,
+)
 
 
 class BaseLoggedInView(View):
@@ -54,6 +60,33 @@ class SatSecondaryTab(Tab):
     """
     ROOT = ParametrizedLocator(
         './/nav[@class="ng-scope"]/following-sibling::div')
+
+
+class LCESelectorGroup(ParametrizedView):
+    ROOT = ".//div[@path-selector='environments']"
+
+    PARAMETERS = ('lce_name',)
+
+    LAST_ENV = ".//div[contains(@class, 'path-selector')]/ul/li[last()]"
+    lce = LCESelector(
+        locator=ParametrizedLocator(
+            "./div[contains(@class, 'path-selector')]/ul"
+            "[li[normalize-space(.)='{lce_name}']]")
+    )
+
+    @classmethod
+    def all(cls, browser):
+        return [(element.text,) for element in browser.elements(cls.LAST_ENV)]
+
+    def fill(self, values=None):
+        if values in (True, False):
+            values = {self.context['lce_name']: values}
+        else:
+            values = {values: True}
+        return self.lce.fill(values)
+
+    def read(self):
+        return self.lce.read()
 
 
 class AddRemoveResourcesView(View):

--- a/airgun/views/common.py
+++ b/airgun/views/common.py
@@ -63,6 +63,19 @@ class SatSecondaryTab(Tab):
 
 
 class LCESelectorGroup(ParametrizedView):
+    """Group of :class:`airgun.widgets.LCESelector`, typically present on page
+    for selecting desired lifecycle environment.
+
+    Usage::
+
+        lce = View.nested(LCESelectorGroup)
+
+        #or
+
+        @View.nested
+        class lce(LCESelectorGroup):
+            pass
+    """
     ROOT = ".//div[@path-selector='environments']"
 
     PARAMETERS = ('lce_name',)
@@ -76,9 +89,31 @@ class LCESelectorGroup(ParametrizedView):
 
     @classmethod
     def all(cls, browser):
+        """Helper method which returns list of tuples with all LCESelector
+        names (last available environment is used as a name). It's required for
+        :meth:`read` to work properly.
+        """
         return [(element.text,) for element in browser.elements(cls.LAST_ENV)]
 
     def fill(self, values=None):
+        """Shortcut to pass the value to included ``lce``
+        :class:`airgun.widgets.LCESelector` widget. Usage remains the same as
+        :class:`airgun.widgets.LCESelector` and
+        :class:`widgetastic.widget.ParametrizedView` required param is filled
+        automatically from passed lifecycle environment's name.
+
+        Example::
+
+            my_view.lce.fill({'PROD': True})
+
+        Value ``True`` or ``False`` means to set corresponding checkbox value
+        to the last checkbox available in widget (last lifecycle environment).
+        If you want to select different lifecycle environment within the same
+        route - pass its name as a value instead::
+
+            my_view.lce.fill({'PROD': 'Library'})
+
+        """
         if values in (True, False):
             values = {self.context['lce_name']: values}
         else:
@@ -86,6 +121,19 @@ class LCESelectorGroup(ParametrizedView):
         return self.lce.fill(values)
 
     def read(self):
+        """Shortcut which returns value of included ``lce``
+        :class:`LCESelector` widget.
+
+        Note that returned result will be wrapped in extra dict due to
+        :class:`widgetastic.widget.ParametrizedView` nature::
+
+            {
+                'DEV': {'Library': False, 'DEV': True},
+                'QA': {'Library': False, 'IT': True},
+                'PROD': {'Library': False, 'PROD': True},
+            }
+
+        """
         return self.lce.read()
 
 

--- a/airgun/widgets.py
+++ b/airgun/widgets.py
@@ -456,6 +456,10 @@ class LCESelector(GenericLocatorWidget):
     )
 
     def __init__(self, parent, locator=None, logger=None):
+        """Allow to specify ``locator`` if needed or use default one otherwise.
+        Locator is needed when multiple :class:`LCESelector` are present,
+        typically as a part of :class:`airgun.views.common.LCESelectorGroup`.
+        """
         if locator is None:
             locator = (
                 ".//div[contains(@class, 'path-selector')]"
@@ -479,8 +483,8 @@ class LCESelector(GenericLocatorWidget):
         return True
 
     def read(self):
-        """Return a list of dictionaries. Each dictionary consists of name and
-        value for each checkbox from the group
+        """Return a dictionary where keys are lifecycle environment names and
+        values are booleans whether they're selected or not.
         """
         checkboxes = {}
         for item in self.browser.elements(self.LABELS):

--- a/airgun/widgets.py
+++ b/airgun/widgets.py
@@ -6,6 +6,7 @@ from widgetastic.widget import (
     Checkbox,
     do_not_read_this_widget,
     GenericLocatorWidget,
+    ParametrizedLocator,
     Select,
     Text,
     TextInput,
@@ -223,6 +224,7 @@ class ContextSelector(Widget):
     LOC_LOCATOR = '//li[@id="location-dropdown"]/ul/li/a[contains(.,{})]'
 
     def select_org(self, org_name):
+        self.logger.info('Selecting Organization %r' % org_name)
         l1e = self.browser.element(self.CURRENT_ORG)
         self.browser.move_to_element(l1e)
         self.browser.click(l1e)
@@ -237,6 +239,7 @@ class ContextSelector(Widget):
         return self.browser.text(self.CURRENT_ORG)
 
     def select_loc(self, loc_name):
+        self.logger.info('Selecting Location %r' % loc_name)
         l1e = self.browser.element(self.CURRENT_LOC)
         self.browser.move_to_element(l1e)
         self.browser.click(l1e)
@@ -427,7 +430,7 @@ class ConfirmationDialog(Widget):
         do_not_read_this_widget()
 
 
-class LCESelector(Widget):
+class LCESelector(GenericLocatorWidget):
     """Group of checkboxes that goes in a line one after another. Usually used
     to specify lifecycle environment
 
@@ -446,11 +449,18 @@ class LCESelector(Widget):
         //ul[@class='path-list']
 
     """
-    ROOT = ".//ul[@class='path-list']"
+    ROOT = ParametrizedLocator("{@locator}")
     LABELS = "./li/label[contains(@class, path-list-item-label)]"
     CHECKBOX = (
         ".//input[@ng-model='item.selected'][parent::label[contains(., '{}')]]"
     )
+
+    def __init__(self, parent, locator=None, logger=None):
+        if locator is None:
+            locator = (
+                ".//div[contains(@class, 'path-selector')]"
+                "//ul[@class='path-list']")
+        super(LCESelector, self).__init__(parent, locator, logger=logger)
 
     def checkbox_selected(self, locator):
         """Identify whether specific checkbox is selected or not"""
@@ -472,11 +482,11 @@ class LCESelector(Widget):
         """Return a list of dictionaries. Each dictionary consists of name and
         value for each checkbox from the group
         """
-        checkboxes = []
+        checkboxes = {}
         for item in self.browser.elements(self.LABELS):
             name = self.browser.text(item)
             value = self.checkbox_selected(self.CHECKBOX.format(name))
-            checkboxes.append({'name': name, 'value': value})
+            checkboxes[name] = value
         return checkboxes
 
     def fill(self, value):


### PR DESCRIPTION
Verified with following test (from #51):
```python
def test_alex(session):
    import random
    ak_name = gen_string('alpha')
    org = entities.Organization().create()
    envs_list = ['STAGING', 'DEV', 'IT', 'UAT', 'PROD']
    for name in envs_list:
        entities.LifecycleEnvironment(name=name, organization=org).create()
    env_name = random.choice(envs_list)
    cv = entities.ContentView(organization=org).create()
    cv.publish()
    promote(
        cv.read().version[0],
        entities.LifecycleEnvironment(name=env_name).search()[0].id
    )
    with session:
        session.organization.select(org_name=org.name)
        session.activationkey.create({
            'name': ak_name,
            'lce': {env_name: True},
            'content_view': cv.name
        })
        assert session.activationkey.read(name)['lce'][env_name][env_name]
```

Test results:
```python
Testing started at 3:06 PM ...
/Users/andrii/workspace/py3a/bin/python "/Applications/PyCharm CE.app/Contents/helpers/pydev/pydevd.py" --multiproc --qt-support=auto --client 127.0.0.1 --port 64115 --file "/Applications/PyCharm CE.app/Contents/helpers/pycharm/_jb_pytest_runner.py" --target test_activationkey.py::test_alex -- -v -s
pydev debugger: process 14172 is connecting

Connected to pydev debugger (build 173.4301.16)
Launching py.test with arguments -v -s test_activationkey.py::test_alex in /Users/andrii/workspace/robottelo/tests/foreman/ui_airgun

2018-03-30 15:06:24 - conftest - DEBUG - Registering custom pytest_namespace

============================= test session starts ==============================
platform darwin -- Python 3.6.4, pytest-3.3.2, py-1.5.2, pluggy-0.6.0 -- /Users/andrii/workspace/py3a/bin/python
cachedir: ../../../.cache
shared_function enabled - OFF - scope:  - storage: file
rootdir: /Users/andrii/workspace/robottelo, inifile:
plugins: wait-for-1.0.9, xdist-1.22.0, services-1.2.1, mock-1.6.3, forked-0.2
collecting ... collected 1 item2018-03-30 15:06:24 - conftest - DEBUG - BZ deselect is disabled in settings


test_activationkey.py::test_alex .


========================== 1 passed in 257.46 seconds ==========================
Process finished with exit code 0
```
