### PR TITLE
Fixed AK subscriptions view; introduced AddRemoveSubscriptionsView

### DIFF
--- a/airgun/views/activationkey.py
+++ b/airgun/views/activationkey.py
@@ -1,7 +1,7 @@
 from widgetastic.widget import ParametrizedView, Select, Text, TextInput, View
 
 from airgun.views.common import (
-    AddRemoveResourcesView,
+    AddRemoveSubscriptionsView,
     BaseLoggedInView,
     LCESelectorGroup,
     SatTab,
@@ -63,9 +63,4 @@ class ActivationKeyEditView(BaseLoggedInView):
 
     @View.nested
     class subscriptions(SatTab):
-
-        @View.nested
-        class resources(AddRemoveResourcesView):
-            checkbox_locator = (
-                './/table//tr[td[normalize-space(.)="%s"]]'
-                '/following-sibling::tr//input[@type="checkbox"]')
+        resources = View.nested(AddRemoveSubscriptionsView)


### PR DESCRIPTION
```python
pytest -v tests/foreman/ui_airgun -k test_positive_create_with_envs
============================= test session starts ==============================
platform darwin -- Python 3.6.4, pytest-3.3.2, py-1.5.2, pluggy-0.6.0 -- /Users/andrii/workspace/py3a/bin/python3.6
cachedir: .cache
shared_function enabled - OFF - scope:  - storage: file
rootdir: /Users/andrii/workspace/robottelo, inifile:
plugins: wait-for-1.0.9, xdist-1.22.0, services-1.2.1, mock-1.6.3, forked-0.2
collected 22 items
2018-04-04 15:31:45 - conftest - DEBUG - BZ deselect is disabled in settings


tests/foreman/ui_airgun/test_activationkey.py::test_positive_create_with_envs[alpha] PASSED [100%]

============================= 21 tests deselected ==============================
================== 1 passed, 21 deselected in 125.14 seconds ===================
```