### PR TITLE
Convert BaseEntity and Location

### DIFF
--- a/airgun/entities/base.py
+++ b/airgun/entities/base.py
@@ -1,8 +1,14 @@
+import attr
 
 
+@attr.s
 class BaseEntity(object):
+    browser = attr.ib()
 
-    def __init__(self, browser):
-        self.browser = browser
-        self.session = browser.extra_objects['session']
-        self.navigate_to = self.session.navigator.navigate
+    @property
+    def session(self):
+        return self.browser.extra_objects['session']
+
+    @property  # could be cached
+    def navigate_to(self):
+            return self.session.navigator.navigate

--- a/airgun/entities/location.py
+++ b/airgun/entities/location.py
@@ -1,26 +1,30 @@
+import attr
+
 from airgun.entities.base import BaseEntity
 from airgun.navigation import NavigateStep, navigator
 from airgun.views.common import BaseLoggedInView
 
 
+@attr.s
 class LocationEntity(BaseEntity):
-    def select(self, loc_name):
-        self.navigate_to(self, 'Context', loc_name=loc_name)
+    name = attr.ib()
+
+    def select(self):
+        self.navigate_to(self, 'Context')
+
+
+class LocationView(BaseLoggedInView):
+    @property
+    def is_displayed(self):
+        current_loc = self.taxonomies.current_loc()
+        return (current_loc == self.context['object'].name
+                if len(self.context['object'].name) <= 30
+                else self.context['object'].name[:27] + '...')
 
 
 @navigator.register(LocationEntity, 'Context')
 class SelectLocationContext(NavigateStep):
     VIEW = BaseLoggedInView
 
-    def am_i_here(self, *args, **kwargs):
-        loc_name = kwargs.get('loc_name')
-        current_loc = self.view.taxonomies.current_loc()
-        if len(loc_name) > 30:
-            loc_name = loc_name[:27] + '...'
-        return current_loc == loc_name
-
     def step(self, *args, **kwargs):
-        loc_name = kwargs.get('loc_name')
-        if not loc_name:
-            raise ValueError('Specify proper value for loc_name parameter')
-        self.view.taxonomies.select_loc(loc_name)
+        self.view.taxonomies.select_loc(self.obj.name)

--- a/airgun/entities/login.py
+++ b/airgun/entities/login.py
@@ -22,6 +22,3 @@ class NavigateToLogin(NavigateStep):
     def step(self, *args, **kwargs):
         # fixme: logout() if logged_in
         pass
-
-    def am_i_here(self, *args, **kwargs):
-        return self.view.is_displayed

--- a/setup.py
+++ b/setup.py
@@ -14,6 +14,7 @@ setup(
     author=u'RedHat QE Team',
     url='https://github.com/SatelliteQE/airgun',
     install_requires=[
+        'attr',
         'fauxfactory',
         'navmazing==1.1.4',
         'pytest==3.3.2',


### PR DESCRIPTION
Work in progress!

Suggestions for entity attribute definition, view classes, and navigation via the entity object linked by the navigation class.

Attr use in classes to define attributes instead of passing during navigation
Properties for things that depend on browser in BaseEntity

Use navmazing.NavigateStep obj property to navigate, don't pass context
implement view with is_displayed instead of am_i_here

This will require test changes I haven't worked out yet.