### PR TITLE
Added generic ActionsDropdown widget for actions lists

### DIFF
--- a/airgun/entities/activationkey.py
+++ b/airgun/entities/activationkey.py
@@ -19,7 +19,7 @@ class ActivationKeyEntity(BaseEntity):
 
     def delete(self, entity_name):
         view = self.navigate_to(self, 'Edit', entity_name=entity_name)
-        view.action_list.fill('Remove')
+        view.actions.fill('Remove')
         view.dialog.confirm()
 
     def search(self, value, expected_result=None):

--- a/airgun/entities/contentview.py
+++ b/airgun/entities/contentview.py
@@ -18,7 +18,7 @@ class ContentViewEntity(BaseEntity):
 
     def delete(self, entity_name):
         view = self.navigate_to(self, 'Edit', entity_name=entity_name)
-        view.action_list.fill('Remove Content View')
+        view.actions.fill('Remove Content View')
         view.dialog.confirm()
 
     def search(self, value):

--- a/airgun/entities/hostcollection.py
+++ b/airgun/entities/hostcollection.py
@@ -18,7 +18,7 @@ class HostCollectionEntity(BaseEntity):
 
     def delete(self, entity_name):
         view = self.navigate_to(self, 'Edit', entity_name=entity_name)
-        view.action_list.fill('Remove')
+        view.actions.fill('Remove')
         view.dialog.confirm()
 
     def search(self, value):

--- a/airgun/entities/syncplan.py
+++ b/airgun/entities/syncplan.py
@@ -18,7 +18,7 @@ class SyncPlanEntity(BaseEntity):
 
     def delete(self, entity_name):
         view = self.navigate_to(self, 'Edit', entity_name=entity_name)
-        view.action_list.fill('Remove')
+        view.actions.fill('Remove')
         view.dialog.confirm()
 
     def search(self, value):

--- a/airgun/entities/template.py
+++ b/airgun/entities/template.py
@@ -28,6 +28,17 @@ class ProvisioningTemplateEntity(BaseEntity):
         view.fill(values)
         view.submit.click()
 
+    def lock(self, entity_name):
+        view = self.navigate_to(self, 'All')
+        view.search(entity_name)
+        view.actions.fill('Lock')
+
+    def unlock(self, entity_name):
+        view = self.navigate_to(self, 'All')
+        view.search(entity_name)
+        view.actions.fill('Unlock')
+        self.browser.handle_alert()
+
 
 @navigator.register(ProvisioningTemplateEntity, 'All')
 class ShowAllTemplates(NavigateStep):

--- a/airgun/entities/template.py
+++ b/airgun/entities/template.py
@@ -68,4 +68,4 @@ class CloneTemplate(NavigateStep):
 
     def step(self, *args, **kwargs):
         self.parent.search(kwargs.get('entity_name'))
-        self.parent.clone.click()
+        self.parent.actions.fill('Clone')

--- a/airgun/views/activationkey.py
+++ b/airgun/views/activationkey.py
@@ -17,12 +17,12 @@ from airgun.views.common import (
     SearchableViewMixin,
 )
 from airgun.widgets import (
+    ActionsDropdown,
     ConfirmationDialog,
     EditableEntry,
     EditableEntrySelect,
     EditableLimitEntry,
     LimitInput,
-    SelectActionList,
 )
 
 
@@ -57,7 +57,7 @@ class ActivationKeyCreateView(BaseLoggedInView):
 
 class ActivationKeyEditView(BaseLoggedInView):
     return_to_all = Text("//a[text()='Activation Keys']")
-    action_list = SelectActionList()
+    actions = ActionsDropdown("//div[contains(@class, 'btn-group')]")
     dialog = ConfirmationDialog()
 
     @property

--- a/airgun/views/contentview.py
+++ b/airgun/views/contentview.py
@@ -8,11 +8,11 @@ from airgun.views.common import (
     SearchableViewMixin,
 )
 from airgun.widgets import (
+    ActionsDropdown,
     ConfirmationDialog,
     EditableEntry,
     EditableEntryCheckbox,
     ReadOnlyEntry,
-    SelectActionList,
 )
 
 
@@ -47,7 +47,7 @@ class ContentViewCreateView(BaseLoggedInView):
 class ContentViewEditView(BaseLoggedInView):
     return_to_all = Text("//a[text()='Content Views']")
     publish = Text("//button[contains(., 'Publish New Version')]")
-    action_list = SelectActionList()
+    actions = ActionsDropdown("//div[contains(@class, 'btn-group')]")
     dialog = ConfirmationDialog()
 
     @property

--- a/airgun/views/syncplan.py
+++ b/airgun/views/syncplan.py
@@ -7,6 +7,7 @@ from airgun.views.common import (
     SearchableViewMixin,
 )
 from airgun.widgets import (
+    ActionsDropdown,
     ConfirmationDialog,
     DateTime,
     EditableEntry,
@@ -14,7 +15,6 @@ from airgun.widgets import (
     EditableDateTime,
     EditableEntrySelect,
     ReadOnlyEntry,
-    SelectActionList,
 )
 
 
@@ -48,7 +48,7 @@ class SyncPlanCreateView(BaseLoggedInView):
 class SyncPlanEditView(BaseLoggedInView):
     # fixme: change all return_to_all instances to use Breadcrumb widget
     return_to_all = Text("//a[text()='Sync Plans']")
-    action_list = SelectActionList()
+    actions = ActionsDropdown("//div[contains(@class, 'btn-group')]")
     dialog = ConfirmationDialog()
 
     @property

--- a/airgun/views/template.py
+++ b/airgun/views/template.py
@@ -6,7 +6,7 @@ from airgun.views.common import (
     SearchableViewMixin,
     TemplateEditor,
 )
-from airgun.widgets import FilteredDropdown, MultiSelect
+from airgun.widgets import ActionsDropdown, FilteredDropdown, MultiSelect
 
 
 class ProvisioningTemplateView(BaseLoggedInView, SearchableViewMixin):
@@ -14,10 +14,7 @@ class ProvisioningTemplateView(BaseLoggedInView, SearchableViewMixin):
     new = Text("//a[contains(@href, '/templates/provisioning_templates/new')]")
     edit = Text(
         "//a[contains(@href, 'edit') and contains(@href, 'templates')]")
-    clone = Text(
-        "//td[div[@class='btn-group']]"
-        "//span[contains(@class, 'default')]/a[text()='Clone']"
-    )
+    actions = ActionsDropdown("//div[@class='btn-group']")
 
     @property
     def is_displayed(self):

--- a/airgun/views/template.py
+++ b/airgun/views/template.py
@@ -14,7 +14,7 @@ class ProvisioningTemplateView(BaseLoggedInView, SearchableViewMixin):
     new = Text("//a[contains(@href, '/templates/provisioning_templates/new')]")
     edit = Text(
         "//a[contains(@href, 'edit') and contains(@href, 'templates')]")
-    actions = ActionsDropdown("//div[@class='btn-group']")
+    actions = ActionsDropdown("//td/div[contains(@class, 'btn-group')]")
 
     @property
     def is_displayed(self):

--- a/airgun/widgets.py
+++ b/airgun/widgets.py
@@ -538,7 +538,6 @@ class ActionsDropdown(GenericLocatorWidget):
 
     Locator example::
 
-        //span[@class='input-group-btn']
         //div[contains(@class, 'dropdown')]
         //div[contains(@class, 'btn-group')]
 
@@ -578,7 +577,8 @@ class ActionsDropdown(GenericLocatorWidget):
                 self.ITEM_LOCATOR.format(item), parent=self).click()
         else:
             raise ValueError(
-                'Specified {} not found in items lists. Available items are {}'
+                'Specified action "{}" not found in actions list. Available'
+                ' actions are {}'
                 .format(item, self.items)
             )
 


### PR DESCRIPTION
```python
pytest -v tests/foreman/ui_airgun/{test_activationkey.py,test_provisioningtemplate.py} -k 'test_positive_delete or test_positive_clone'
============================= test session starts ==============================
platform darwin -- Python 3.6.4, pytest-3.4.0, py-1.5.3, pluggy-0.6.0 -- /Users/andrii/workspace/py3a/bin/python3.6
cachedir: .pytest_cache
shared_function enabled - OFF - scope:  - storage: file
rootdir: /Users/andrii/workspace/robottelo, inifile:
plugins: wait-for-1.0.9, xdist-1.22.0, services-1.2.1, mock-1.6.3, forked-0.2
collected 27 items
2018-04-24 19:18:46 - conftest - DEBUG - BZ deselect is disabled in settings


tests/foreman/ui_airgun/test_activationkey.py::test_positive_delete PASSED [ 20%]
tests/foreman/ui_airgun/test_activationkey.py::test_positive_delete_with_env PASSED [ 40%]
tests/foreman/ui_airgun/test_activationkey.py::test_positive_delete_with_cv PASSED [ 60%]
tests/foreman/ui_airgun/test_activationkey.py::test_positive_delete_with_system PASSED [ 80%]
tests/foreman/ui_airgun/test_provisioningtemplate.py::test_positive_clone PASSED [100%]

============================= 22 tests deselected ==============================
================== 5 passed, 22 deselected in 526.30 seconds ===================
```