### PR TITLE
Pin pytest==3.4.0 (same as robottelo)

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ setup(
     install_requires=[
         'fauxfactory',
         'navmazing==1.1.4',
-        'pytest==3.3.2',
+        'pytest==3.4.0',
         'six==1.11.0',
         'widgetastic.core==0.21.2',
         'widgetastic.patternfly==0.0.30'


### PR DESCRIPTION
Fixing conflicting pinning of airgun and robottelo:
```
airgun 0.0.1 has requirement pytest==3.3.2, but you'll have pytest 3.4.0 which is incompatible
```