### PR TITLE
Introduce Progress Bar widget and Content View Publish/Promote helpers

### DIFF
--- a/airgun/views/common.py
+++ b/airgun/views/common.py
@@ -98,7 +98,8 @@ class LCESelectorGroup(ParametrizedView):
         class lce(LCESelectorGroup):
             pass
     """
-    ROOT = ".//div[@path-selector='environments']"
+    ROOT = (".//div[@path-selector='environments' or "
+            "@path-selector='availableEnvironments']")
 
     PARAMETERS = ('lce_name',)
 

--- a/airgun/views/contentview.py
+++ b/airgun/views/contentview.py
@@ -1,9 +1,17 @@
-from widgetastic.widget import Checkbox, Text, TextInput, View
+from widgetastic.widget import (
+    Checkbox,
+    ParametrizedView,
+    Text,
+    TextInput,
+    View,
+)
 
 from airgun.views.common import (
     AddRemoveResourcesView,
     BaseLoggedInView,
+    LCESelectorGroup,
     SatTab,
+    SatTable,
     SatTabWithDropdown,
     SearchableViewMixin,
 )
@@ -12,7 +20,9 @@ from airgun.widgets import (
     ConfirmationDialog,
     EditableEntry,
     EditableEntryCheckbox,
+    PublishPromoteProgressBar,
     ReadOnlyEntry,
+    Search,
 )
 
 
@@ -56,7 +66,7 @@ class ContentViewEditView(BaseLoggedInView):
             self.return_to_all, exception=False) is not None
 
     @View.nested
-    class Details(SatTab):
+    class details(SatTab):
         name = EditableEntry(name='Name')
         label = ReadOnlyEntry(name='Label')
         description = EditableEntry(name='Description')
@@ -64,8 +74,64 @@ class ContentViewEditView(BaseLoggedInView):
         force_puppet = EditableEntryCheckbox(name='Force Puppet')
 
     @View.nested
+    class versions(SatTab):
+        searchbox = Search()
+        resources = SatTable(
+            locator='//table',
+            column_widgets={
+                'Version': Text('.//a'),
+                'Status': PublishPromoteProgressBar(),
+                'Actions': ActionsDropdown(
+                    './div[contains(@class, "btn-group")]')
+            },
+        )
+
+        def search(self, version_name):
+            """Searches for content view version.
+
+            Searchbox can't search by version name, only by id, that's why in
+            case version name was passed, it's transformed into recognizable
+            value before filling, for example::
+
+                'Version 1.0' -> 'version = 1'
+            """
+            search_phrase = version_name
+            if version_name.startswith('V') and '.' in version_name:
+                search_phrase = 'version = {}'.format(
+                    version_name.split()[1].split('.')[0])
+            self.searchbox.search(search_phrase)
+            return self.resources.read()
+
+    @View.nested
     class yumrepo(SatTabWithDropdown):
         TAB_NAME = 'Yum Content'
         SUB_ITEM = 'Repositories'
 
         repos = View.nested(AddRemoveResourcesView)
+
+
+class ContentViewVersionPublishView(BaseLoggedInView):
+    version = Text('//div[@label="Version"]/div/span')
+    description = TextInput(id='description')
+    force_metadata_regeneration = Checkbox(id='forceMetadataRegeneration')
+    save = Text('//button[contains(@ng-click, "handleSave()")]')
+    cancel = Text('//button[contains(@ng-click, "handleCancel()")]')
+
+    @property
+    def is_displayed(self):
+        return self.browser.wait_for_element(
+            self.save, exception=False) is not None
+
+
+class ContentViewVersionPromoteView(BaseLoggedInView):
+    lce = ParametrizedView.nested(LCESelectorGroup)
+    description = TextInput(id='description')
+    force_metadata_regeneration = Checkbox(id='forceMetadataRegeneration')
+    promote = Text('//button[contains(@ng-click, "verifySelection()")]')
+    cancel = Text(
+        '//a[contains(@class, "btn")][@ui-sref="content-view.versions"]')
+
+    @property
+    def is_displayed(self):
+        return self.browser.wait_for_element(
+            self.save, exception=False) is not None

--- a/airgun/widgets.py
+++ b/airgun/widgets.py
@@ -1,3 +1,4 @@
+from wait_for import wait_for
 from widgetastic.exceptions import (
     NoSuchElementException, WidgetOperationFailed)
 
@@ -7,6 +8,7 @@ from widgetastic.widget import (
     do_not_read_this_widget,
     GenericLocatorWidget,
     ParametrizedLocator,
+    ParametrizedString,
     Select,
     Table,
     Text,
@@ -1048,3 +1050,119 @@ class SatSubscriptionsTable(SatTable):
             for row in read_rows:
                 row['Repository Name'] = next(titles)
         return read_rows
+
+
+class ProgressBar(GenericLocatorWidget):
+    """Generic progress bar widget.
+
+    Example html representation::
+
+        <div class="progress ng-isolate-scope" type="success" ...>
+          <div class="progress-bar progress-bar-success" aria-valuenow="0"
+           aria-valuemin="0" aria-valuemax="100" aria-valuetext="0%" ...></div>
+        </div>
+
+    Locator example::
+
+        .//div[contains(@class, "progress progress-striped")]
+
+    """
+    PROGRESSBAR = './/div[contains(@class,"progress-bar")]'
+
+    def __init__(self, parent, locator=None, logger=None):
+        """Provide common progress bar locator if it wasn't specified."""
+        Widget.__init__(self, parent, logger=logger)
+        if not locator:
+            locator = './/div[contains(@class, "progress progress-striped")]'
+        self.locator = locator
+
+    @property
+    def is_active(self):
+        """Boolean value whether progress bar is active or not (stopped,
+        pending or any other state).
+        """
+        if 'active' in self.browser.classes(self):
+            return True
+        return False
+
+    @property
+    def progress(self):
+        """String value with current flow rate in percent."""
+        return self.browser.get_attribute('aria-valuetext', self.PROGRESSBAR)
+
+    @property
+    def is_completed(self):
+        """Boolean value whether progress bar is finished or not"""
+        if not self.is_active and self.progress == '100%':
+            return True
+        return False
+
+    def wait_for_result(self, timeout=600, delay=1):
+        """Waits for progress bar to finish. By default checks whether progress
+        bar is completed every second for 10 minutes.
+
+        :param timeout: integer value for timeout in seconds
+        :param delay: float value for delay between attempts in seconds
+        """
+        wait_for(
+            lambda: self.is_completed is True,
+            timeout=timeout,
+            delay=delay,
+            logger=self.logger
+        )
+
+    def read(self):
+        """Returns current progress."""
+        return self.progress
+
+
+class PublishPromoteProgressBar(ProgressBar):
+    """Progress bar for Publish and Promote procedures. They contain status
+    message and link to associated task. Also the progress is displayed
+    slightly differently.
+
+    Example html representation::
+
+        <a ng-href="/foreman_tasks/tasks/71196" ng-hide="hideProgress(version)"
+         href="/foreman_tasks/tasks/...71196">
+
+          <div ng-class="{ active: taskInProgress(version) }"
+           class="progress progress-striped">
+            <div class="progress ng-isolate-scope" animate="false" ...>
+            <div class="progress-bar" aria-valuenow="" aria-valuemin="0"
+             aria-valuemax="100" aria-valuetext="%" ...></div></div>
+          </div>
+          Publishing and promoting to 1 environment.
+        </a>
+        <span ng-show="hideProgress(version)" ...>
+          Published
+          (2018-05-07 18:10:14 +0300)
+        </span>
+
+    Locator example::
+
+        .//div[contains(@class, "progress progress-striped")]
+
+    """
+    ROOT = '.'
+    TASK = Text('.//a[contains(@ng-href, "/foreman_tasks/")]')
+    MESSAGE = Text('.//span[@ng-show="hideProgress(version)"]')
+
+    @property
+    def is_completed(self):
+        """Boolean value whether progress bar is finished or not"""
+        # Value is empty before and after publish, the only way to figure out
+        # whether progress completed or not even started - to check result
+        # message presence
+        # Promoting finishes with `100%`
+        if self.MESSAGE.is_displayed and self.progress in ('100%', '%'):
+            return True
+        return False
+
+    def read(self):
+        """Returns message with either progress or result, depending on its
+        status.
+        """
+        if self.is_completed:
+            return self.MESSAGE.read()
+        return self.TASK.read()

--- a/setup.py
+++ b/setup.py
@@ -14,10 +14,12 @@ setup(
     author=u'RedHat QE Team',
     url='https://github.com/SatelliteQE/airgun',
     install_requires=[
+        'cached_property',
         'fauxfactory',
         'navmazing==1.1.4',
         'pytest==3.4.0',
         'six==1.11.0',
+        'wait_for',
         'widgetastic.core==0.21.2',
         'widgetastic.patternfly==0.0.30'
     ],


### PR DESCRIPTION
```python
pytest -v tests/foreman/ui_airgun/test_contentview.py -k test_positive_end_to_end
============================= test session starts ==============================
platform darwin -- Python 3.6.4, pytest-3.4.0, py-1.5.3, pluggy-0.6.0 -- /Users/andrii/workspace/py3a/bin/python3.6
cachedir: .pytest_cache
shared_function enabled - OFF - scope:  - storage: file
rootdir: /Users/andrii/workspace/robottelo, inifile:
plugins: wait-for-1.0.9, xdist-1.22.0, services-1.2.1, mock-1.6.3, forked-0.2, env-0.6.2
collected 3 items
2018-05-11 16:37:05 - conftest - DEBUG - BZ deselect is disabled in settings


tests/foreman/ui_airgun/test_contentview.py::test_positive_end_to_end PASSED [100%]

============================== 2 tests deselected ==============================
=================== 1 passed, 2 deselected in 117.09 seconds ===================
```