### PR TITLE
Add domain views/entities and tweak MultiSelect/CustomParameter widgets

### DIFF
--- a/airgun/entities/domain.py
+++ b/airgun/entities/domain.py
@@ -44,9 +44,8 @@ class DomainEntity(BaseEntity):
         view = self.navigate_to(self, 'New')
         view.fill(values)
         view.submit_button.click()
-        if assert_no_errors:
-            view.flash.assert_no_error()
-            assert_no_errors_in_view(view)
+        view.flash.assert_no_error()
+        assert_no_errors_in_view(view)
 
     def search(self, value):
         """Search for 'value' and return domain names that match.
@@ -61,7 +60,7 @@ class DomainEntity(BaseEntity):
         view = self.navigate_to(self, 'Edit', entity_name=entity_name)
         return view.read()
 
-    def update(self, entity_name, values, assert_no_errors=True):
+    def update(self, entity_name, values):
         """
         Update an existing domain.
         """
@@ -69,37 +68,32 @@ class DomainEntity(BaseEntity):
 
         view.fill(values)
         view.submit_button.click()
-        if assert_no_errors:
-            view.flash.assert_no_error()
-            assert_no_errors_in_view(view)
+        view.flash.assert_no_error()
+        assert_no_errors_in_view(view)
 
-    def add_parameter(self, entity_name, param_name, param_value,
-                      assert_no_errors=True):
+    def add_parameter(self, entity_name, param_name, param_value):
         view = self.navigate_to(self, 'Edit', entity_name=entity_name)
         view.parameters.params.add({'name': param_name, 'value': param_value})
         view.submit_button.click()
-        if assert_no_errors:
-            view.flash.assert_no_error()
-            assert_no_errors_in_view(view)
+        view.flash.assert_no_error()
+        assert_no_errors_in_view(view)
 
-    def remove_parameter(self, entity_name, param_name, assert_no_errors=True):
+    def remove_parameter(self, entity_name, param_name):
         view = self.navigate_to(self, 'Edit', entity_name=entity_name)
         view.parameters.params.remove(param_name)
         view.submit_button.click()
-        if assert_no_errors:
-            view.flash.assert_no_error()
-            assert_no_errors_in_view(view)
+        view.flash.assert_no_error()
+        assert_no_errors_in_view(view)
 
-    def delete(self, name, assert_no_errors=True):
+    def delete(self, name):
         view = self.navigate_to(self, 'All')
         self.search(name)
         if not view.table.row_count:
             raise ValueError("Unable to find name '{}'".format(name))
         view.table[0]['Actions'].widget.click()
         self.browser.handle_alert()
-        if assert_no_errors:
-            view.flash.assert_no_error()
-            assert_no_errors_in_view(view)
+        view.flash.assert_no_error()
+        assert_no_errors_in_view(view)
 
 
 @navigator.register(DomainEntity, 'All')

--- a/airgun/entities/domain.py
+++ b/airgun/entities/domain.py
@@ -20,14 +20,13 @@ class DomainEntity(BaseEntity):
         view.submit_button.click()
         view.flash.assert_no_error()
 
-    def search(self, value=None):
+    def search(self, value):
         """Search for 'value' and return domain names that match.
 
         :param value: text to filter (default: no filter)
         """
         view = self.navigate_to(self, 'All')
-        view.search(value or '')
-        return [row['Description'].text for row in view.table.rows()]
+        return view.search(value)
 
     def read(self, entity_name):
         """Return dict with properties of domain."""

--- a/airgun/entities/domain.py
+++ b/airgun/entities/domain.py
@@ -3,11 +3,8 @@ from wait_for import wait_for
 
 from airgun.entities.base import BaseEntity
 from airgun.navigation import NavigateStep, navigator
-from airgun.views.domain import (
-    DomainCreateView,
-    DomainListView,
-    DomainEditView
-)
+from airgun.views.domain import (DomainCreateView, DomainEditView,
+                                 DomainListView)
 
 
 class DomainEntity(BaseEntity):
@@ -111,9 +108,9 @@ class DomainEntity(BaseEntity):
         # Return only non-null entries
         return {key: val for key, val in properties.items() if val}
 
-    def edit(self, domain_name, **kwargs):
+    def update(self, domain_name, **kwargs):
         """
-        Edit an existing domain.
+        Update an existing domain.
 
         Only the kwargs which are passed in will be modified. You must modify
         at least one value.
@@ -173,8 +170,6 @@ class AddNewDomain(NavigateStep):
     prerequisite = NavigateToSibling('All')
 
     def step(self, *args, **kwargs):
-        self.view.browser.wait_for_element(
-            self.parent.create_button, ensure_page_safe=True)
         self.parent.create_button.click()
 
 

--- a/airgun/entities/domain.py
+++ b/airgun/entities/domain.py
@@ -8,82 +8,14 @@ from airgun.views.domain import (DomainCreateView, DomainEditView,
 
 
 class DomainEntity(BaseEntity):
-    _DEFAULT_ORG = 'Default Organization'
-    _DEFAULT_LOC = 'Default Location'
-    _CREATE_SUCCESSFUL = 'Successfully created {}.'
-    _UPDATE_SUCCESSFUL = 'Successfully updated {}.'
-    _DELETE_SUCCESSFUL = 'Successfully deleted {}.'
-
-    @staticmethod
-    def _submit_domain_form(view, **kwargs):
-        """Create or update domain.
-
-        Form is the same for both cases, we use 1 method here to fill the form.
-        """
-        dns_domain = kwargs.get('dns_domain')
-        full_name = kwargs.get('full_name')
-        dns_capsule = kwargs.get('dns_capsule')
-        parameters = kwargs.get('parameters')
-        locations = kwargs.get('locations')
-        organizations = kwargs.get('organizations')
-
-        # Fill 'Domain' tab
-        if dns_domain:
-            view.domain.dns_domain.fill(dns_domain)
-        if full_name:
-            view.domain.full_name.fill(full_name)
-        if dns_capsule:
-            view.domain.dns_capsule.fill(dns_capsule)
-
-        # Fill 'Parameters' tab
-        if parameters:
-            params = []
-            for param_name, param_value in parameters.items():
-                params.append({'name': param_name, 'value': param_value})
-            view.parameters.params.fill(params)  # fill overwrites old params
-
-        # Fill locations tab
-        if locations:
-            view.locations.multiselect.set_assigned(locations)
-
-        # Fill organizations tab
-        if organizations:
-            view.organizations.multiselect.set_assigned(organizations)
-
-        view.submit_button.click()
-
-    def create(self, dns_domain, **kwargs):
+    def create(self, values):
         """
         Create a new domain.
-
-        :param dns_domain: str, full DNS domain name
-        :param full_name: (optional) str, full name describing the domain
-        :param dns_capsule: (optional) str of DNS capsule to use
-        :param parameters: (optional) param dict or list of param dicts to set
-            Format: [{'name': str, 'value': str}]
-        :param locations: list of location strings to be assigned.
-            All other locations will be unassigned.
-            Default: ['Default Location']
-        :param organizations: list of org strings to be assigned.
-            All other orgs will be unassigned.
-            Default: ['Default Organization']
         """
         view = self.navigate_to(self, 'New')
-
-        kwargs['dns_domain'] = dns_domain
-
-        if not kwargs.get('locations'):
-            kwargs['locations'] = [self._DEFAULT_LOC]
-        if not kwargs.get('organizations'):
-            kwargs['organizations'] = [self._DEFAULT_ORG]
-
-        self._submit_domain_form(view, **kwargs)
-
-        wait_for(
-            lambda: view.flash.messages, fail_condition=[], timeout=10,
-            delay=2, message='wait for flash success'
-        )
-        view.flash.assert_success_message(self._CREATE_SUCCESSFUL.format(dns_domain))
+        view.fill(values)
+        view.submit_button.click()
+        view.flash.assert_no_error()
 
     def search(self, value=None):
         """Search for 'value' and return domain names that match.
@@ -94,44 +26,19 @@ class DomainEntity(BaseEntity):
         view.search(value or '')
         return [row['Description'].text for row in view.table.rows()]
 
-    def read(self, domain_name):
+    def read(self, entity_name):
         """Return dict with properties of domain."""
-        view = self.navigate_to(self, 'Edit', entity_name=domain_name)
+        view = self.navigate_to(self, 'Edit', entity_name=entity_name)
         return view.read()
 
-    def update(self, domain_name, **kwargs):
+    def update(self, entity_name, values):
         """
         Update an existing domain.
-
-        Only the kwargs which are passed in will be modified. You must modify
-        at least one value.
-
-        :param domain_name: name of domain to update
-        :param dns_domain: (optional) str, full DNS domain name
-        :param full_name: (optional) str, full name describing the domain
-        :param dns_capsule: (optional) str of DNS capsule name
-        :param parameters: (optional) param dict or list of param dicts to set
-            Format: [{'name': str, 'value': str}]
-            Existing params are overwritten.
-        :param locations: (optional) list of location strings to be assigned.
-            All other locations will be unassigned.
-        :param organizations: (optional) list of org strings to be assigned.
-            All other orgs will be unassigned.
         """
-        if not kwargs:
-            raise ValueError('no kwargs given for edit()')
-
-        view = self.navigate_to(self, 'Edit', entity_name=domain_name)
-        self._submit_domain_form(view, **kwargs)
-        wait_for(
-            lambda: view.flash.messages, fail_condition=[], timeout=10,
-            delay=2, message='wait for flash success'
-        )
-
-        # If domain is renamed, flash message contains the new name...
-        updated_name = kwargs.get('dns_domain') or domain_name
-        view.flash.assert_success_message(
-            self._UPDATE_SUCCESSFUL.format(updated_name))
+        view = self.navigate_to(self, 'Edit', entity_name=entity_name)
+        view.fill(values)
+        view.submit_button.click()
+        view.flash.assert_no_error()
 
     def delete(self, name):
         view = self.navigate_to(self, 'All')
@@ -139,11 +46,7 @@ class DomainEntity(BaseEntity):
         row = view.table.row(('Description', name))
         row['Actions'].widget.click()
         self.browser.handle_alert()
-        wait_for(
-            lambda: view.flash.messages, fail_condition=[], timeout=10,
-            delay=2, message='wait for flash success'
-        )
-        view.flash.assert_success_message(self._DELETE_SUCCESSFUL.format(name))
+        view.flash.assert_no_error()
 
 
 @navigator.register(DomainEntity, 'All')

--- a/airgun/entities/domain.py
+++ b/airgun/entities/domain.py
@@ -1,0 +1,192 @@
+from navmazing import NavigateToSibling
+from wait_for import wait_for
+
+from airgun.entities.base import BaseEntity
+from airgun.navigation import NavigateStep, navigator
+from airgun.views.domain import (
+    DomainCreateView,
+    DomainListView,
+    DomainEditView
+)
+
+
+class DomainEntity(BaseEntity):
+    _DEFAULT_ORG = 'Default Organization'
+    _DEFAULT_LOC = 'Default Location'
+    _CREATE_SUCCESSFUL = 'Successfully created {}.'
+    _UPDATE_SUCCESSFUL = 'Successfully updated {}.'
+    _DELETE_SUCCESSFUL = 'Successfully deleted {}.'
+
+    @staticmethod
+    def _submit_domain_form(view, **kwargs):
+        """Create or update domain.
+
+        Form is the same for both cases, we use 1 method here to fill the form.
+        """
+        dns_domain = kwargs.get('dns_domain')
+        full_name = kwargs.get('full_name')
+        dns_capsule = kwargs.get('dns_capsule')
+        parameters = kwargs.get('parameters')
+        locations = kwargs.get('locations')
+        organizations = kwargs.get('organizations')
+
+        # Fill 'Domain' tab
+        if dns_domain:
+            view.domain.dns_domain.fill(dns_domain)
+        if full_name:
+            view.domain.full_name.fill(full_name)
+        if dns_capsule:
+            view.domain.dns_capsule.fill(dns_capsule)
+
+        # Fill 'Parameters' tab
+        if parameters:
+            params = []
+            for param_name, param_value in parameters.items():
+                params.append({'name': param_name, 'value': param_value})
+            view.parameters.params.fill(params)  # fill overwrites old params
+
+        # Fill locations tab
+        if locations:
+            view.locations.multiselect.set_assigned(locations)
+
+        # Fill organizations tab
+        if organizations:
+            view.organizations.multiselect.set_assigned(organizations)
+
+        view.submit_button.click()
+
+    def create(self, dns_domain, **kwargs):
+        """
+        Create a new domain.
+
+        :param dns_domain: str, full DNS domain name
+        :param full_name: (optional) str, full name describing the domain
+        :param dns_capsule: (optional) str of DNS capsule to use
+        :param parameters: (optional) param dict or list of param dicts to set
+            Format: [{'name': str, 'value': str}]
+        :param locations: list of location strings to be assigned.
+            All other locations will be unassigned.
+            Default: ['Default Location']
+        :param organizations: list of org strings to be assigned.
+            All other orgs will be unassigned.
+            Default: ['Default Organization']
+        """
+        view = self.navigate_to(self, 'New')
+
+        kwargs['dns_domain'] = dns_domain
+
+        if not kwargs.get('locations'):
+            kwargs['locations'] = [self._DEFAULT_LOC]
+        if not kwargs.get('organizations'):
+            kwargs['organizations'] = [self._DEFAULT_ORG]
+
+        self._submit_domain_form(view, **kwargs)
+
+        wait_for(
+            lambda: view.flash.messages, fail_condition=[], timeout=10,
+            delay=2, message='wait for flash success'
+        )
+        view.flash.assert_success_message(self._CREATE_SUCCESSFUL.format(dns_domain))
+
+    def search(self, value=None):
+        """Search for 'value' and return domain names that match.
+        
+        :param value: text to filter (default: no filter)
+        """
+        view = self.navigate_to(self, 'All')
+        view.search(value or '')
+        return [row['Description'].text for row in view.table.rows()]
+
+    def read(self, domain_name):
+        """Return dict with properties of domain."""
+        view = self.navigate_to(self, 'Edit', entity_name=domain_name)
+        properties = dict(
+            dns_domain=view.domain.dns_domain.read(),
+            full_name=view.domain.full_name.read(),
+            dns_capsule=view.domain.dns_capsule.read(),
+            parameters=view.parameters.params.read(),
+            locations=view.locations.multiselect.read()['assigned'],
+            organizations=view.organizations.multiselect.read()['assigned']
+        )
+        # Return only non-null entries
+        return {key: val for key, val in properties.items() if val}
+
+    def edit(self, domain_name, **kwargs):
+        """
+        Edit an existing domain.
+
+        Only the kwargs which are passed in will be modified. You must modify
+        at least one value.
+
+        :param domain_name: name of domain to update
+        :param dns_domain: (optional) str, full DNS domain name
+        :param full_name: (optional) str, full name describing the domain
+        :param dns_capsule: (optional) str of DNS capsule name
+        :param parameters: (optional) param dict or list of param dicts to set
+            Format: [{'name': str, 'value': str}]
+            Existing params are overwritten.
+        :param locations: (optional) list of location strings to be assigned.
+            All other locations will be unassigned.
+        :param organizations: (optional) list of org strings to be assigned.
+            All other orgs will be unassigned.
+        """
+        if not kwargs:
+            raise ValueError('no kwargs given for edit()')
+        
+        view = self.navigate_to(self, 'Edit', entity_name=domain_name)
+        self._submit_domain_form(view, **kwargs)
+        wait_for(
+            lambda: view.flash.messages, fail_condition=[], timeout=10,
+            delay=2, message='wait for flash success'
+        )
+
+        # If domain is renamed, flash message contains the new name...
+        updated_name = kwargs.get('dns_domain') or domain_name
+        view.flash.assert_success_message(
+            self._UPDATE_SUCCESSFUL.format(updated_name))
+
+    def delete(self, name):
+        view = self.navigate_to(self, 'All')
+        self.search(name)
+        row = view.table.row(('Description', name))
+        row['Actions'].widget.click()
+        self.browser.handle_alert()
+        wait_for(
+            lambda: view.flash.messages, fail_condition=[], timeout=10,
+            delay=2, message='wait for flash success'
+        )
+        view.flash.assert_success_message(self._DELETE_SUCCESSFUL.format(name))
+
+
+@navigator.register(DomainEntity, 'All')
+class DomainList(NavigateStep):
+    VIEW = DomainListView
+
+    def step(self, *args, **kwargs):
+        self.view.menu.select('Infrastructure', 'Domains')
+
+
+@navigator.register(DomainEntity, 'New')
+class AddNewDomain(NavigateStep):
+    VIEW = DomainCreateView
+
+    prerequisite = NavigateToSibling('All')
+
+    def step(self, *args, **kwargs):
+        self.view.browser.wait_for_element(
+            self.parent.create_button, ensure_page_safe=True)
+        self.parent.create_button.click()
+
+
+@navigator.register(DomainEntity, 'Edit')
+class EditDomain(NavigateStep):
+    VIEW = DomainEditView
+
+    def prerequisite(self, *args, **kwargs):
+        return self.navigate_to(self.obj, 'All')
+
+    def step(self, *args, **kwargs):
+        entity_name = kwargs.get('entity_name')
+        self.parent.search(entity_name)
+        row = self.parent.table.row(('Description', entity_name))
+        row['Description'].widget.click()

--- a/airgun/entities/domain.py
+++ b/airgun/entities/domain.py
@@ -90,7 +90,7 @@ class DomainEntity(BaseEntity):
 
     def search(self, value=None):
         """Search for 'value' and return domain names that match.
-        
+
         :param value: text to filter (default: no filter)
         """
         view = self.navigate_to(self, 'All')
@@ -132,7 +132,7 @@ class DomainEntity(BaseEntity):
         """
         if not kwargs:
             raise ValueError('no kwargs given for edit()')
-        
+
         view = self.navigate_to(self, 'Edit', entity_name=domain_name)
         self._submit_domain_form(view, **kwargs)
         wait_for(

--- a/airgun/entities/domain.py
+++ b/airgun/entities/domain.py
@@ -10,14 +10,15 @@ from airgun.views.domain import (
 
 
 class DomainEntity(BaseEntity):
-    def create(self, values):
+    def create(self, values, assert_no_error=True):
         """
         Create a new domain.
         """
         view = self.navigate_to(self, 'New')
         view.fill(values)
         view.submit_button.click()
-        view.flash.assert_no_error()
+        if assert_no_error:
+            view.flash.assert_no_error()
 
     def search(self, value):
         """Search for 'value' and return domain names that match.
@@ -32,22 +33,41 @@ class DomainEntity(BaseEntity):
         view = self.navigate_to(self, 'Edit', entity_name=entity_name)
         return view.read()
 
-    def update(self, entity_name, values):
+    def update(self, entity_name, values, assert_no_error=True):
         """
         Update an existing domain.
         """
         view = self.navigate_to(self, 'Edit', entity_name=entity_name)
+
         view.fill(values)
         view.submit_button.click()
-        view.flash.assert_no_error()
+        if assert_no_error:
+            view.flash.assert_no_error()
 
-    def delete(self, name):
+    def add_parameter(self, entity_name, param_name, param_value,
+                      assert_no_error=True):
+        view = self.navigate_to(self, 'Edit', entity_name=entity_name)
+        view.parameters.params.add({'name': param_name, 'value': param_value})
+        view.submit_button.click()
+        if assert_no_error:
+            view.flash.assert_no_error()
+
+    def remove_parameter(self, entity_name, param_name, assert_no_error=True):
+        view = self.navigate_to(self, 'Edit', entity_name=entity_name)
+        view.parameters.params.remove(param_name)
+        view.submit_button.click()
+        if assert_no_error:
+            view.flash.assert_no_error()
+
+    def delete(self, name, assert_no_error=True):
         view = self.navigate_to(self, 'All')
         self.search(name)
-        row = view.table.row(('Description', name))
-        row['Actions'].widget.click()
+        if not view.table.row_count:
+            raise ValueError("Unable to find name '{}'".format(name))
+        view.table[0]['Actions'].widget.click()
         self.browser.handle_alert()
-        view.flash.assert_no_error()
+        if assert_no_error:
+            view.flash.assert_no_error()
 
 
 @navigator.register(DomainEntity, 'All')

--- a/airgun/entities/domain.py
+++ b/airgun/entities/domain.py
@@ -1,5 +1,4 @@
 from navmazing import NavigateToSibling
-from wait_for import wait_for
 
 from airgun.entities.base import BaseEntity
 from airgun.navigation import NavigateStep, navigator

--- a/airgun/entities/domain.py
+++ b/airgun/entities/domain.py
@@ -3,8 +3,11 @@ from wait_for import wait_for
 
 from airgun.entities.base import BaseEntity
 from airgun.navigation import NavigateStep, navigator
-from airgun.views.domain import (DomainCreateView, DomainEditView,
-                                 DomainListView)
+from airgun.views.domain import (
+    DomainCreateView,
+    DomainEditView,
+    DomainListView,
+)
 
 
 class DomainEntity(BaseEntity):

--- a/airgun/entities/domain.py
+++ b/airgun/entities/domain.py
@@ -97,16 +97,7 @@ class DomainEntity(BaseEntity):
     def read(self, domain_name):
         """Return dict with properties of domain."""
         view = self.navigate_to(self, 'Edit', entity_name=domain_name)
-        properties = dict(
-            dns_domain=view.domain.dns_domain.read(),
-            full_name=view.domain.full_name.read(),
-            dns_capsule=view.domain.dns_capsule.read(),
-            parameters=view.parameters.params.read(),
-            locations=view.locations.multiselect.read()['assigned'],
-            organizations=view.organizations.multiselect.read()['assigned']
-        )
-        # Return only non-null entries
-        return {key: val for key, val in properties.items() if val}
+        return view.read()
 
     def update(self, domain_name, **kwargs):
         """

--- a/airgun/session.py
+++ b/airgun/session.py
@@ -30,7 +30,6 @@ from airgun.entities.role import RoleEntity
 from airgun.entities.template import ProvisioningTemplateEntity
 from airgun.entities.subnet import SubnetEntity
 from airgun.entities.syncplan import SyncPlanEntity
-from airgun.entities.template import ProvisioningTemplateEntity
 from airgun.entities.user import UserEntity
 from airgun.navigation import navigator
 

--- a/airgun/session.py
+++ b/airgun/session.py
@@ -31,6 +31,7 @@ from airgun.entities.template import ProvisioningTemplateEntity
 from airgun.entities.subnet import SubnetEntity
 from airgun.entities.syncplan import SyncPlanEntity
 from airgun.entities.user import UserEntity
+from airgun.entities.domain import DomainEntity
 
 
 from airgun.navigation import navigator
@@ -230,6 +231,11 @@ class Session(object):
     def contentview(self):
         """Instance of Content View entity."""
         return ContentViewEntity(self.browser)
+
+    @cached_property
+    def domain(self):
+        """Instance of domain entity."""
+        return DomainEntity(self.browser)
 
     @cached_property
     def filter(self):

--- a/airgun/session.py
+++ b/airgun/session.py
@@ -3,7 +3,6 @@ import copy
 import logging
 import os
 import sys
-
 from datetime import datetime
 
 from cached_property import cached_property
@@ -11,17 +10,18 @@ from fauxfactory import gen_string
 
 from airgun import settings
 from airgun.browser import AirgunBrowser, SeleniumBrowserFactory
-from airgun.entities.login import LoginEntity
 from airgun.entities.activationkey import ActivationKeyEntity
 from airgun.entities.architecture import ArchitectureEntity
 from airgun.entities.computeprofile import ComputeProfileEntity
 from airgun.entities.contentcredential import ContentCredentialEntity
 from airgun.entities.contentview import ContentViewEntity
 from airgun.entities.computeresource import ComputeResourceEntity
+from airgun.entities.domain import DomainEntity
 from airgun.entities.hostcollection import HostCollectionEntity
 from airgun.entities.filter import FilterEntity
 from airgun.entities.lifecycleenvironment import LCEEntity
 from airgun.entities.location import LocationEntity
+from airgun.entities.login import LoginEntity
 from airgun.entities.os import OperatingSystemEntity
 from airgun.entities.organization import OrganizationEntity
 from airgun.entities.partitiontable import PartitionTableEntity
@@ -30,12 +30,9 @@ from airgun.entities.role import RoleEntity
 from airgun.entities.template import ProvisioningTemplateEntity
 from airgun.entities.subnet import SubnetEntity
 from airgun.entities.syncplan import SyncPlanEntity
+from airgun.entities.template import ProvisioningTemplateEntity
 from airgun.entities.user import UserEntity
-from airgun.entities.domain import DomainEntity
-
-
 from airgun.navigation import navigator
-
 
 LOGGER = logging.getLogger(__name__)
 

--- a/airgun/views/domain.py
+++ b/airgun/views/domain.py
@@ -1,5 +1,4 @@
-from widgetastic.widget import Text, TextInput, View, GenericLocatorWidget
-from widgetastic_patternfly import Button
+from widgetastic.widget import Text, TextInput, View
 
 from airgun.views.common import BaseLoggedInView, SearchableViewMixin, SatTab
 from airgun.widgets import CustomParameter, FilteredDropdown, MultiSelect, SatTable

--- a/airgun/views/domain.py
+++ b/airgun/views/domain.py
@@ -30,8 +30,15 @@ class DomainListView(BaseLoggedInView, SearchableViewMixin):
 
 
 class DomainCreateView(BaseLoggedInView):
-    submit_button = TextInput(name='commit')
+    # Use 'Text' to make submit_button clickable
+    submit_button = Text(".//input[@name='commit']")
     cancel_button = Text(".//a[@href='/domains']")
+    _name_error = Text(
+        ".//label[@for='name']/../../div[contains(@class,'has-error')]")
+
+    @property
+    def name_error_present(self):
+        return self._name_error.is_displayed
 
     @View.nested
     class domain(SatTab):  # noqa
@@ -42,6 +49,10 @@ class DomainCreateView(BaseLoggedInView):
     @View.nested
     class parameters(SatTab):  # noqa
         params = CustomParameter(id='global_parameters_table')
+        
+        @property
+        def param_error_present(self):
+            return params.param_error_present
 
     @View.nested
     class locations(SatTab):  # noqa

--- a/airgun/views/domain.py
+++ b/airgun/views/domain.py
@@ -17,7 +17,7 @@ class DomainListView(BaseLoggedInView, SearchableViewMixin):
             'Actions': Text(".//a[@data-method='delete']")  # delete button
         }
     )
-    create_button = Button(href='/domains/new')
+    create_button = Text(".//a[@href='/domains/new']")
 
     @property
     def is_displayed(self):
@@ -26,10 +26,8 @@ class DomainListView(BaseLoggedInView, SearchableViewMixin):
 
 
 class DomainCreateView(BaseLoggedInView):
-    form = GenericLocatorWidget('form#new_domain')
-
-    submit_button = Button(name='commit')
-    cancel_button = Button(href='/domains')
+    submit_button = TextInput(name='commit')
+    cancel_button = Text(".//a[@href='/domains']")
 
     @View.nested
     class domain(SatTab):  # noqa
@@ -51,9 +49,14 @@ class DomainCreateView(BaseLoggedInView):
 
     @property
     def is_displayed(self):
+        locator = 'form#new_domain'
         return self.browser.wait_for_element(
-            self.form, exception=False) is not None
+            locator, exception=False) is not None
 
 
 class DomainEditView(DomainCreateView):
-    form = GenericLocatorWidget("//form[contains(@id, 'edit_domain_')]")
+    @property
+    def is_displayed(self):
+        locator = "//form[contains(@id, 'edit_domain_')]"
+        return self.browser.wait_for_element(
+            locator, exception=False) is not None

--- a/airgun/views/domain.py
+++ b/airgun/views/domain.py
@@ -1,7 +1,12 @@
 from widgetastic.widget import Text, TextInput, View
 
 from airgun.views.common import BaseLoggedInView, SearchableViewMixin, SatTab
-from airgun.widgets import CustomParameter, FilteredDropdown, MultiSelect, SatTable
+from airgun.widgets import (
+    CustomParameter,
+    FilteredDropdown,
+    MultiSelect,
+    SatTable,
+)
 
 
 class DomainListView(BaseLoggedInView, SearchableViewMixin):

--- a/airgun/views/domain.py
+++ b/airgun/views/domain.py
@@ -1,0 +1,59 @@
+from widgetastic.widget import Text, TextInput, View, GenericLocatorWidget
+from widgetastic_patternfly import Button
+
+from airgun.views.common import BaseLoggedInView, SearchableViewMixin, SatTab
+from airgun.widgets import CustomParameter, FilteredDropdown, MultiSelect, SatTable
+
+
+class DomainListView(BaseLoggedInView, SearchableViewMixin):
+    """List of all domains."""
+    # Delete button isn't the typical "btn"
+    # It sits within a span, we'll access the href via a Text widget
+    table = SatTable(
+        locator='table#domains_list',
+        column_widgets={
+            'Description': Text(".//a[contains(@data-id, '_edit')]"),
+            'Hosts': Text(".//a[@data-id='aid_hosts']"),
+            'Actions': Text(".//a[@data-method='delete']")  # delete button
+        }
+    )
+    create_button = Button(href='/domains/new')
+
+    @property
+    def is_displayed(self):
+        return self.browser.wait_for_element(
+            self.table, exception=False) is not None
+
+
+class DomainCreateView(BaseLoggedInView):
+    form = GenericLocatorWidget('form#new_domain')
+
+    submit_button = Button(name='commit')
+    cancel_button = Button(href='/domains')
+
+    @View.nested
+    class domain(SatTab):  # noqa
+        dns_domain = TextInput(id='domain_name')
+        full_name = TextInput(id='domain_fullname')
+        dns_capsule = FilteredDropdown(id='domain_dns_id')
+
+    @View.nested
+    class parameters(SatTab):  # noqa
+        params = CustomParameter(id='global_parameters_table')
+
+    @View.nested
+    class locations(SatTab):  # noqa
+        multiselect = MultiSelect(id='ms-domain_location_ids')
+     
+    @View.nested
+    class organizations(SatTab):  # noqa
+        multiselect = MultiSelect(id='ms-domain_organization_ids')
+
+    @property
+    def is_displayed(self):
+        return self.browser.wait_for_element(
+            self.form, exception=False) is not None
+
+
+class DomainEditView(DomainCreateView):
+    form = GenericLocatorWidget("//form[contains(@id, 'edit_domain_')]")

--- a/airgun/views/domain.py
+++ b/airgun/views/domain.py
@@ -33,12 +33,6 @@ class DomainCreateView(BaseLoggedInView):
     # Use 'Text' to make submit_button clickable
     submit_button = Text(".//input[@name='commit']")
     cancel_button = Text(".//a[@href='/domains']")
-    _name_error = Text(
-        ".//label[@for='name']/../../div[contains(@class,'has-error')]")
-
-    @property
-    def name_error_present(self):
-        return self._name_error.is_displayed
 
     @View.nested
     class domain(SatTab):  # noqa
@@ -49,10 +43,6 @@ class DomainCreateView(BaseLoggedInView):
     @View.nested
     class parameters(SatTab):  # noqa
         params = CustomParameter(id='global_parameters_table')
-        
-        @property
-        def param_error_present(self):
-            return params.param_error_present
 
     @View.nested
     class locations(SatTab):  # noqa

--- a/airgun/views/domain.py
+++ b/airgun/views/domain.py
@@ -44,7 +44,7 @@ class DomainCreateView(BaseLoggedInView):
     @View.nested
     class locations(SatTab):  # noqa
         multiselect = MultiSelect(id='ms-domain_location_ids')
-     
+
     @View.nested
     class organizations(SatTab):  # noqa
         multiselect = MultiSelect(id='ms-domain_organization_ids')

--- a/airgun/views/os.py
+++ b/airgun/views/os.py
@@ -43,7 +43,7 @@ class OperatingSystemDetailsView(BaseLoggedInView):
     @View.nested
     class parameters(SatTab):
         TAB_NAME = 'Parameters'
-        params = CustomParameter()
+        params = CustomParameter(id='global_parameters_table')
 
         def fill(self, values):
             self.params.fill(values)

--- a/airgun/widgets.py
+++ b/airgun/widgets.py
@@ -974,6 +974,7 @@ class ACEEditor(Widget):
 
     """
     ROOT = "//div[contains(@class, 'ace_editor')]"
+
     def __init__(self, parent, logger=None):
         """Getting id for specific ace editor element"""
         Widget.__init__(self, parent, logger=logger)

--- a/airgun/widgets.py
+++ b/airgun/widgets.py
@@ -547,7 +547,7 @@ class CustomParameter(Table):
             'Actions': Text(locator=".//a[@title='Remove Parameter']")
         }
         super(CustomParameter, self).__init__(
-            *args, **kwargs, column_widgets=column_widgets)
+            *args, column_widgets=column_widgets, **kwargs)
 
     def read(self):
         """Return a list of dictionaries. Each dictionary consists of name and
@@ -562,7 +562,7 @@ class CustomParameter(Table):
 
     def add(self, value):
         """Add single name/value parameter entry to the table.
-        
+
         :param value: dict with format {'name': str, 'value': str}
         """
         self.add_new_value.click()
@@ -865,9 +865,9 @@ class EditableEntry(GenericLocatorWidget):
         if locator and name or not locator and not name:
             raise TypeError('Please specify either locator or name')
         locator = (
-                locator or
-                ".//dt[contains(., '{}')]"
-                "/following-sibling::dd[1]".format(name)
+            locator or
+            ".//dt[contains(., '{}')]"
+            "/following-sibling::dd[1]".format(name)
         )
         super(EditableEntry, self).__init__(parent, locator, logger)
 
@@ -943,10 +943,10 @@ class ReadOnlyEntry(GenericLocatorWidget):
         if locator and name or not locator and not name:
             raise TypeError('Please specify either locator or name')
         locator = (
-                locator or
-                ".//dt[contains(., '{}')]"
-                "/following-sibling::dd[not(contains(@class, 'ng-hide'))]"
-                "[1]".format(name)
+            locator or
+            ".//dt[contains(., '{}')]"
+            "/following-sibling::dd[not(contains(@class, 'ng-hide'))]"
+            "[1]".format(name)
         )
         super(ReadOnlyEntry, self).__init__(parent, locator, logger)
 

--- a/airgun/widgets.py
+++ b/airgun/widgets.py
@@ -297,27 +297,6 @@ class MultiSelect(GenericLocatorWidget):
                 self.assigned.fill(value)
         return True
 
-    def set_assigned(self, desired_values):
-        """Sets the assigned items to exactly match 'desired_values'.
-
-        If any undesired values are present in the 'assigned' list, they
-        are removed.
-
-        :param values: list of strings representing item names
-        """
-        current_values = self.assigned.read()
-        if current_values != desired_values:
-            self.fill(
-                {
-                    'assigned': desired_values,
-                    'unassigned': [
-                        val for val in current_values
-                        if val not in desired_values
-                    ]
-                }
-            )
-        return True
-
     def read(self):
         """Returns a dict with current lists values."""
         return {

--- a/airgun/widgets.py
+++ b/airgun/widgets.py
@@ -533,21 +533,21 @@ class CustomParameter(Table):
     """
     add_new_value = Text("..//a[contains(text(),'+ Add Parameter')]")
 
-    def __init__(self, *args, **kwargs):
+    def __init__(self, parent, locator=None, id=None, logger=None):
         """Supports initialization via ``locator=`` or ``id=``"""
-        locator = kwargs.get('locator')
-        id = kwargs.pop('id')
         if locator and id or not locator and not id:
             raise ValueError('Please specify either locator or id')
-        kwargs['locator'] = locator or ".//table[@id='{}']".format(id)
+        locator = locator or ".//table[@id='{}']".format(id)
 
         column_widgets = {
             'Name': TextInput(locator=".//input[@placeholder='Name']"),
             'Value': TextInput(locator=".//textarea[@placeholder='Value']"),
             'Actions': Text(locator=".//a[@title='Remove Parameter']")
         }
-        super(CustomParameter, self).__init__(
-            *args, column_widgets=column_widgets, **kwargs)
+        super(CustomParameter, self).__init__(parent,
+                                              locator=locator,
+                                              logger=logger,
+                                              column_widgets=column_widgets)
 
     def read(self):
         """Return a list of dictionaries. Each dictionary consists of name and

--- a/airgun/widgets.py
+++ b/airgun/widgets.py
@@ -618,6 +618,7 @@ class CustomParameter(Table):
         for param in params_to_fill:
             self.add(param)
 
+
 class ActionsDropdown(GenericLocatorWidget):
     """List of actions, expandable via button with caret. Usually comes with
     button attached on left side, representing either most common action or

--- a/airgun/widgets.py
+++ b/airgun/widgets.py
@@ -334,9 +334,9 @@ class Search(Widget):
         if hasattr(self.parent, 'flash'):
             # large flash messages may hide the search button
             self.parent.flash.dismiss()
-        wait_for(lambda: self.search_button.is_displayed, timeout=5, delay=0.1)
         self.fill(value)
-        self.search_button.click()
+        if self.search_button.is_displayed:
+            self.search_button.click()
 
 
 class SatVerticalNavigation(VerticalNavigation):

--- a/airgun/widgets.py
+++ b/airgun/widgets.py
@@ -331,9 +331,12 @@ class Search(Widget):
             'arguments[0].scrollIntoView(false);',
             self.browser.element(self.search_field.locator),
         )
+        if hasattr(self.parent, 'flash'):
+            # large flash messages may hide the search button
+            self.parent.flash.dismiss()
+        wait_for(lambda: self.search_button.is_displayed, timeout=5, delay=0.1)
         self.fill(value)
-        if self.search_button.is_displayed:
-            self.search_button.click()
+        self.search_button.click()
 
 
 class SatVerticalNavigation(VerticalNavigation):
@@ -511,7 +514,6 @@ class CustomParameter(Table):
 
     """
     add_new_value = Text("..//a[contains(text(),'+ Add Parameter')]")
-    _table_error = Text(".//tr[contains(@class,'has-error')]/td/span")
 
     def __init__(self, parent, locator=None, id=None, logger=None):
         """Supports initialization via ``locator=`` or ``id=``"""
@@ -530,10 +532,6 @@ class CustomParameter(Table):
                                               locator=locator,
                                               logger=logger,
                                               column_widgets=column_widgets)
-
-    @property
-    def param_error_present(self):
-        return self._table_error.is_displayed
 
     def read(self):
         """Return a list of dictionaries. Each dictionary consists of name and


### PR DESCRIPTION
* Add views, entity, navigation for Infrastructure -> Domains
* Add `set_assigned` method to `MultiSelect` widget
* Change `CustomParameter` to inherit from `Table` widget so that its easier to repeatedly add values to the param list and read from each row. Update `OperatingSystemDetailsView` to pass in `id` when invoking `CustomParameter`
* Add `wait_for` to requirements, since its now being used in the `DomainEntity` CRUD methods