### PR TITLE
Navigation overhaul; support breadcrumb widget to determine current view

### DIFF
--- a/airgun/entities/architecture.py
+++ b/airgun/entities/architecture.py
@@ -3,8 +3,9 @@ from navmazing import NavigateToSibling
 from airgun.entities.base import BaseEntity
 from airgun.navigation import NavigateStep, navigator
 from airgun.views.architecture import (
-    ArchitecturesView,
+    ArchitectureCreateView,
     ArchitectureDetailsView,
+    ArchitecturesView,
 )
 
 
@@ -45,7 +46,7 @@ class ShowAllArchitectures(NavigateStep):
 
 @navigator.register(ArchitectureEntity, 'New')
 class AddNewArchitecture(NavigateStep):
-    VIEW = ArchitectureDetailsView
+    VIEW = ArchitectureCreateView
 
     prerequisite = NavigateToSibling('All')
 

--- a/airgun/entities/computeprofile.py
+++ b/airgun/entities/computeprofile.py
@@ -4,7 +4,8 @@ from airgun.entities.base import BaseEntity
 from airgun.navigation import NavigateStep, navigator
 from airgun.views.computeprofile import (
     ComputeProfileCreateView,
-    ComputeProfileView,
+    ComputeProfileRenameView,
+    ComputeProfilesView,
 )
 
 
@@ -32,8 +33,8 @@ class ComputeProfileEntity(BaseEntity):
 
 
 @navigator.register(ComputeProfileEntity, 'All')
-class ShowAllComputeProfile(NavigateStep):
-    VIEW = ComputeProfileView
+class ShowAllComputeProfiles(NavigateStep):
+    VIEW = ComputeProfilesView
 
     def step(self, *args, **kwargs):
         # TODO: No prereq yet
@@ -52,7 +53,10 @@ class AddNewComputeProfile(NavigateStep):
 
 @navigator.register(ComputeProfileEntity, 'Rename')
 class RenameComputeProfile(NavigateStep):
-    VIEW = ComputeProfileCreateView
+    VIEW = ComputeProfileRenameView
+
+    def am_i_here(self, *args, **kwargs):
+        return self.view.is_displayed
 
     def prerequisite(self, *args, **kwargs):
         return self.navigate_to(self.obj, 'All')

--- a/airgun/entities/hostcollection.py
+++ b/airgun/entities/hostcollection.py
@@ -3,9 +3,9 @@ from navmazing import NavigateToSibling
 from airgun.entities.base import BaseEntity
 from airgun.navigation import NavigateStep, navigator
 from airgun.views.hostcollection import (
-    HostCollectionDetailsView,
+    HostCollectionCreateView,
     HostCollectionEditView,
-    HostCollectionView,
+    HostCollectionsView,
 )
 
 
@@ -40,7 +40,7 @@ class HostCollectionEntity(BaseEntity):
 
 @navigator.register(HostCollectionEntity, 'All')
 class ShowAllHostCollections(NavigateStep):
-    VIEW = HostCollectionView
+    VIEW = HostCollectionsView
 
     def step(self, *args, **kwargs):
         self.view.menu.select('Hosts', 'Host Collections')
@@ -48,7 +48,7 @@ class ShowAllHostCollections(NavigateStep):
 
 @navigator.register(HostCollectionEntity, 'New')
 class AddNewHostCollections(NavigateStep):
-    VIEW = HostCollectionDetailsView
+    VIEW = HostCollectionCreateView
 
     prerequisite = NavigateToSibling('All')
 

--- a/airgun/entities/os.py
+++ b/airgun/entities/os.py
@@ -50,6 +50,9 @@ class AddNewOperatingSystem(NavigateStep):
 class EditOperatingSystem(NavigateStep):
     VIEW = OperatingSystemDetailsView
 
+    def am_i_here(self, *args, **kwargs):
+        return self.view.is_displayed
+
     def prerequisite(self, *args, **kwargs):
         return self.navigate_to(self.obj, 'All')
 

--- a/airgun/entities/partitiontable.py
+++ b/airgun/entities/partitiontable.py
@@ -3,6 +3,7 @@ from navmazing import NavigateToSibling
 from airgun.entities.base import BaseEntity
 from airgun.navigation import NavigateStep, navigator
 from airgun.views.partitiontable import (
+    PartitionTableCreateView,
     PartitionTableEditView,
     PartitionTablesView,
 )
@@ -62,7 +63,7 @@ class ShowAllPartitionTables(NavigateStep):
 
 @navigator.register(PartitionTableEntity, 'New')
 class AddNewPartitionTable(NavigateStep):
-    VIEW = PartitionTableEditView
+    VIEW = PartitionTableCreateView
 
     prerequisite = NavigateToSibling('All')
 
@@ -85,7 +86,7 @@ class EditPartitionTable(NavigateStep):
 
 @navigator.register(PartitionTableEntity, 'Clone')
 class ClonePartitionTable(NavigateStep):
-    VIEW = PartitionTableEditView
+    VIEW = PartitionTableCreateView
 
     def prerequisite(self, *args, **kwargs):
         return self.navigate_to(self.obj, 'All')

--- a/airgun/entities/subnet.py
+++ b/airgun/entities/subnet.py
@@ -2,7 +2,11 @@ from navmazing import NavigateToSibling
 
 from airgun.entities.base import BaseEntity
 from airgun.navigation import NavigateStep, navigator
-from airgun.views.subnet import SubnetView, SubnetDetailsView
+from airgun.views.subnet import (
+    SubnetCreateView,
+    SubnetDetailsView,
+    SubnetsView,
+)
 
 
 class SubnetEntity(BaseEntity):
@@ -23,7 +27,7 @@ class SubnetEntity(BaseEntity):
 
 @navigator.register(SubnetEntity, 'All')
 class ShowAllSubnets(NavigateStep):
-    VIEW = SubnetView
+    VIEW = SubnetsView
 
     def step(self, *args, **kwargs):
         # TODO: No prereq yet
@@ -32,7 +36,7 @@ class ShowAllSubnets(NavigateStep):
 
 @navigator.register(SubnetEntity, 'New')
 class AddNewSubnet(NavigateStep):
-    VIEW = SubnetDetailsView
+    VIEW = SubnetCreateView
 
     prerequisite = NavigateToSibling('All')
 

--- a/airgun/entities/template.py
+++ b/airgun/entities/template.py
@@ -3,6 +3,7 @@ from navmazing import NavigateToSibling
 from airgun.entities.base import BaseEntity
 from airgun.navigation import NavigateStep, navigator
 from airgun.views.template import (
+    ProvisioningTemplateCreateView,
     ProvisioningTemplateDetailsView,
     ProvisioningTemplatesView,
 )
@@ -50,7 +51,7 @@ class ShowAllTemplates(NavigateStep):
 
 @navigator.register(ProvisioningTemplateEntity, 'New')
 class AddNewTemplate(NavigateStep):
-    VIEW = ProvisioningTemplateDetailsView
+    VIEW = ProvisioningTemplateCreateView
 
     prerequisite = NavigateToSibling('All')
 
@@ -73,7 +74,7 @@ class EditTemplate(NavigateStep):
 
 @navigator.register(ProvisioningTemplateEntity, 'Clone')
 class CloneTemplate(NavigateStep):
-    VIEW = ProvisioningTemplateDetailsView
+    VIEW = ProvisioningTemplateCreateView
 
     def prerequisite(self, *args, **kwargs):
         return self.navigate_to(self.obj, 'All')

--- a/airgun/entities/user.py
+++ b/airgun/entities/user.py
@@ -2,7 +2,7 @@ from navmazing import NavigateToSibling
 
 from airgun.entities.base import BaseEntity
 from airgun.navigation import NavigateStep, navigator
-from airgun.views.user import UserDetailsView, UsersView
+from airgun.views.user import UserCreateView, UserDetailsView, UsersView
 
 
 class UserEntity(BaseEntity):
@@ -42,7 +42,7 @@ class ShowAllUsers(NavigateStep):
 
 @navigator.register(UserEntity, 'New')
 class AddNewUser(NavigateStep):
-    VIEW = UserDetailsView
+    VIEW = UserCreateView
 
     prerequisite = NavigateToSibling('All')
 

--- a/airgun/navigation.py
+++ b/airgun/navigation.py
@@ -58,14 +58,25 @@ class NavigateStep(navmazing.NavigateStep):
         """Describes if the navigation is already at the requested destination.
 
         By default, airgun relies on view's ``is_displayed`` property to
-        determine whether navigation succeeded. This method may be overridden
-        on specific entity's NavigateStep level for more complex logic if
-        needed.
+        determine whether navigation succeeded. If positional argument
+        ``entity_name`` was passed and view has ``BreadCrumb`` widget, it will
+        also ensure second location in breadcrumb is provided entity name.
+
+        This method may be overridden on specific entity's NavigateStep level
+        for more complex logic if needed.
 
         :return: whether navigator is at requested destination or not.
         :rtype: bool
         """
+        entity_name = kwargs.get('entity_name')
         try:
+            if entity_name and hasattr(self.view, 'breadcrumb'):
+                return (
+                    self.view.is_displayed
+                    and self.view.breadcrumb.locations[1] in (
+                        entity_name,
+                        'Edit {}'.format(entity_name))
+                )
             return self.view.is_displayed
         except (AttributeError, NoSuchElementException):
             return False

--- a/airgun/views/activationkey.py
+++ b/airgun/views/activationkey.py
@@ -5,6 +5,7 @@ from widgetastic.widget import (
     TextInput,
     View,
 )
+from widgetastic_patternfly import BreadCrumb
 
 from airgun.views.common import (
     AddRemoveResourcesView,
@@ -38,7 +39,7 @@ class ActivationKeysView(BaseLoggedInView, SearchableViewMixin):
 
 
 class ActivationKeyCreateView(BaseLoggedInView):
-
+    breadcrumb = BreadCrumb()
     name = TextInput(id='name')
     hosts_limit = LimitInput()
     description = TextInput(id='description')
@@ -48,19 +49,29 @@ class ActivationKeyCreateView(BaseLoggedInView):
 
     @property
     def is_displayed(self):
-        return self.browser.wait_for_element(
-            self.name, exception=False) is not None
+        breadcrumb_loaded = self.browser.wait_for_element(
+            self.breadcrumb, exception=False)
+        return (
+                breadcrumb_loaded
+                and self.breadcrumb.locations[0] == 'Activation Keys'
+                and self.breadcrumb.read() == 'New Activation Key'
+        )
 
 
 class ActivationKeyEditView(BaseLoggedInView):
-    return_to_all = Text("//a[text()='Activation Keys']")
+    breadcrumb = BreadCrumb()
     actions = ActionsDropdown("//div[contains(@class, 'btn-group')]")
     dialog = ConfirmationDialog()
 
     @property
     def is_displayed(self):
-        return self.browser.wait_for_element(
-            self.return_to_all, exception=False) is not None
+        breadcrumb_loaded = self.browser.wait_for_element(
+            self.breadcrumb, exception=False)
+        return (
+            breadcrumb_loaded
+            and self.breadcrumb.locations[0] == 'Activation Keys'
+            and self.breadcrumb.read() != 'New Activation Key'
+        )
 
     @View.nested
     class details(SatTab):

--- a/airgun/views/architecture.py
+++ b/airgun/views/architecture.py
@@ -1,4 +1,5 @@
 from widgetastic.widget import Text, TextInput
+from widgetastic_patternfly import BreadCrumb
 
 from airgun.views.common import BaseLoggedInView, SearchableViewMixin
 from airgun.widgets import MultiSelect, SatTable
@@ -22,11 +23,30 @@ class ArchitecturesView(BaseLoggedInView, SearchableViewMixin):
 
 
 class ArchitectureDetailsView(BaseLoggedInView):
+    breadcrumb = BreadCrumb()
     name = TextInput(locator="//input[@id='architecture_name']")
     submit = Text('//input[@name="commit"]')
     operatingsystems = MultiSelect(id='ms-architecture_operatingsystem_ids')
 
     @property
     def is_displayed(self):
-        return self.browser.wait_for_element(
-            self.name, exception=False) is not None
+        breadcrumb_loaded = self.browser.wait_for_element(
+            self.breadcrumb, exception=False)
+        return (
+            breadcrumb_loaded
+            and self.breadcrumb.locations[0] == 'Architectures'
+            and self.breadcrumb.read().startswith('Edit ')
+        )
+
+
+class ArchitectureCreateView(ArchitectureDetailsView):
+
+    @property
+    def is_displayed(self):
+        breadcrumb_loaded = self.browser.wait_for_element(
+            self.breadcrumb, exception=False)
+        return (
+            breadcrumb_loaded
+            and self.breadcrumb.locations[0] == 'Architectures'
+            and self.breadcrumb.read() == 'Create Architecture'
+        )

--- a/airgun/views/computeprofile.py
+++ b/airgun/views/computeprofile.py
@@ -1,10 +1,11 @@
 from widgetastic.widget import Text, TextInput
+from widgetastic_patternfly import BreadCrumb
 
 from airgun.views.common import BaseLoggedInView, SearchableViewMixin
 from airgun.widgets import ActionsDropdown, SatTable
 
 
-class ComputeProfileView(BaseLoggedInView, SearchableViewMixin):
+class ComputeProfilesView(BaseLoggedInView, SearchableViewMixin):
     title = Text("//h1[text()='Compute Profiles']")
     new = Text("//a[contains(@href, '/compute_profiles/new')]")
     table = SatTable(
@@ -22,10 +23,29 @@ class ComputeProfileView(BaseLoggedInView, SearchableViewMixin):
 
 
 class ComputeProfileCreateView(BaseLoggedInView):
+    breadcrumb = BreadCrumb()
     name = TextInput(locator=".//input[@id='compute_profile_name']")
     submit = Text('//input[@name="commit"]')
 
     @property
     def is_displayed(self):
-        return self.browser.wait_for_element(
-            self.name, exception=False) is not None
+        breadcrumb_loaded = self.browser.wait_for_element(
+            self.breadcrumb, exception=False)
+        return (
+                breadcrumb_loaded
+                and self.breadcrumb.locations[0] == 'Compute Profiles'
+                and self.breadcrumb.read() == 'Create Compute Profile'
+        )
+
+
+class ComputeProfileRenameView(ComputeProfileCreateView):
+
+    @property
+    def is_displayed(self):
+        breadcrumb_loaded = self.browser.wait_for_element(
+            self.breadcrumb, exception=False)
+        return (
+                breadcrumb_loaded
+                and self.breadcrumb.locations[0] == 'Compute profiles'
+                and self.breadcrumb.read() == 'Edit Compute profile'
+        )

--- a/airgun/views/contentcredential.py
+++ b/airgun/views/contentcredential.py
@@ -1,4 +1,5 @@
 from widgetastic.widget import FileInput, Select, Text, TextInput, View
+from widgetastic_patternfly import BreadCrumb
 
 from airgun.views.common import (
     BaseLoggedInView,
@@ -25,6 +26,7 @@ class ContentCredentialsTableView(BaseLoggedInView, SearchableViewMixin):
 
 
 class ContentCredentialCreateView(BaseLoggedInView):
+    breadcrumb = BreadCrumb()
     name = TextInput(id='name')
     content_type = Select(id='content_type')
     content = TextInput(name='content')
@@ -33,19 +35,29 @@ class ContentCredentialCreateView(BaseLoggedInView):
 
     @property
     def is_displayed(self):
-        return self.browser.wait_for_element(
-            self.name, exception=False) is not None
+        breadcrumb_loaded = self.browser.wait_for_element(
+            self.breadcrumb, exception=False)
+        return (
+                breadcrumb_loaded
+                and self.breadcrumb.locations[0] == 'Content Credential'
+                and self.breadcrumb.read() == 'New Content Credential'
+        )
 
 
 class ContentCredentialEditView(BaseLoggedInView):
-    return_to_all = Text("//a[text()='Content Credential']")
+    breadcrumb = BreadCrumb()
     remove = Text("//button[contains(., 'Remove Content Credential')]")
     dialog = ConfirmationDialog()
 
     @property
     def is_displayed(self):
-        return self.browser.wait_for_element(
-            self.return_to_all, exception=False) is not None
+        breadcrumb_loaded = self.browser.wait_for_element(
+            self.breadcrumb, exception=False)
+        return (
+                breadcrumb_loaded
+                and self.breadcrumb.locations[0] == 'Content Credential'
+                and self.breadcrumb.read() != 'New Content Credential'
+        )
 
     @View.nested
     class details(SatTab):

--- a/airgun/views/contentview.py
+++ b/airgun/views/contentview.py
@@ -5,6 +5,7 @@ from widgetastic.widget import (
     TextInput,
     View,
 )
+from widgetastic_patternfly import BreadCrumb
 
 from airgun.views.common import (
     AddRemoveResourcesView,
@@ -38,6 +39,7 @@ class ContentViewTableView(BaseLoggedInView, SearchableViewMixin):
 
 
 class ContentViewCreateView(BaseLoggedInView):
+    breadcrumb = BreadCrumb()
     name = TextInput(id='name')
     label = TextInput(id='label')
     description = TextInput(id='description')
@@ -47,20 +49,30 @@ class ContentViewCreateView(BaseLoggedInView):
 
     @property
     def is_displayed(self):
-        return self.browser.wait_for_element(
-            self.name, exception=False) is not None
+        breadcrumb_loaded = self.browser.wait_for_element(
+            self.breadcrumb, exception=False)
+        return (
+            breadcrumb_loaded
+            and self.breadcrumb.locations[0] == 'Content Views'
+            and self.breadcrumb.read() == 'New Content View'
+        )
 
 
 class ContentViewEditView(BaseLoggedInView):
-    return_to_all = Text("//a[text()='Content Views']")
+    breadcrumb = BreadCrumb()
     publish = Text("//button[contains(., 'Publish New Version')]")
     actions = ActionsDropdown("//div[contains(@class, 'btn-group')]")
     dialog = ConfirmationDialog()
 
     @property
     def is_displayed(self):
-        return self.browser.wait_for_element(
-            self.return_to_all, exception=False) is not None
+        breadcrumb_loaded = self.browser.wait_for_element(
+            self.breadcrumb, exception=False)
+        return (
+            breadcrumb_loaded
+            and self.breadcrumb.locations[0] == 'Content Views'
+            and self.breadcrumb.read() != 'New Content View'
+        )
 
     @View.nested
     class details(SatTab):
@@ -122,7 +134,7 @@ class ContentViewEditView(BaseLoggedInView):
 
 
 class AddNewPuppetModuleView(BaseLoggedInView, SearchableViewMixin):
-    title = Text('//h3/span[text()="Select A New Puppet Module To Add"]')
+    breadcrumb = BreadCrumb()
     table = SatTable(
         locator='.//table',
         column_widgets={
@@ -132,12 +144,17 @@ class AddNewPuppetModuleView(BaseLoggedInView, SearchableViewMixin):
 
     @property
     def is_displayed(self):
-        return self.browser.wait_for_element(
-            self.title, exception=False) is not None
+        breadcrumb_loaded = self.browser.wait_for_element(
+            self.breadcrumb, exception=False)
+        return (
+                breadcrumb_loaded
+                and self.breadcrumb.locations[0] == 'Content Views'
+                and self.breadcrumb.read() == 'Add Puppet Module'
+        )
 
 
 class SelectPuppetModuleVersionView(BaseLoggedInView, SearchableViewMixin):
-    title = Text('//h3/span[contains(., "Select an Available Version of")]')
+    breadcrumb = BreadCrumb()
     table = SatTable(
         locator='.//table',
         column_widgets={
@@ -147,11 +164,17 @@ class SelectPuppetModuleVersionView(BaseLoggedInView, SearchableViewMixin):
 
     @property
     def is_displayed(self):
-        return self.browser.wait_for_element(
-            self.title, exception=False) is not None
+        breadcrumb_loaded = self.browser.wait_for_element(
+            self.breadcrumb, exception=False)
+        return (
+                breadcrumb_loaded
+                and self.breadcrumb.locations[0] == 'Content Views'
+                and self.breadcrumb.read() == 'Version for Module:'
+        )
 
 
 class ContentViewVersionPublishView(BaseLoggedInView):
+    breadcrumb = BreadCrumb()
     version = Text('//div[@label="Version"]/div/span')
     description = TextInput(id='description')
     force_metadata_regeneration = Checkbox(id='forceMetadataRegeneration')
@@ -160,11 +183,17 @@ class ContentViewVersionPublishView(BaseLoggedInView):
 
     @property
     def is_displayed(self):
-        return self.browser.wait_for_element(
-            self.save, exception=False) is not None
+        breadcrumb_loaded = self.browser.wait_for_element(
+            self.breadcrumb, exception=False)
+        return (
+                breadcrumb_loaded
+                and self.breadcrumb.locations[0] == 'Content Views'
+                and self.breadcrumb.read() == 'Publish'
+        )
 
 
 class ContentViewVersionPromoteView(BaseLoggedInView):
+    breadcrumb = BreadCrumb()
     lce = ParametrizedView.nested(LCESelectorGroup)
     description = TextInput(id='description')
     force_metadata_regeneration = Checkbox(id='forceMetadataRegeneration')
@@ -174,5 +203,10 @@ class ContentViewVersionPromoteView(BaseLoggedInView):
 
     @property
     def is_displayed(self):
-        return self.browser.wait_for_element(
-            self.save, exception=False) is not None
+        breadcrumb_loaded = self.browser.wait_for_element(
+            self.breadcrumb, exception=False)
+        return (
+                breadcrumb_loaded
+                and self.breadcrumb.locations[0] == 'Content Views'
+                and self.breadcrumb.read() == 'Promotion'
+        )

--- a/airgun/views/hostcollection.py
+++ b/airgun/views/hostcollection.py
@@ -1,4 +1,5 @@
 from widgetastic.widget import Checkbox, Text, TextInput, View
+from widgetastic_patternfly import BreadCrumb
 
 from airgun.views.common import (
     AddRemoveResourcesView,
@@ -9,7 +10,7 @@ from airgun.views.common import (
 from airgun.widgets import EditableEntry, SatTable
 
 
-class HostCollectionView(BaseLoggedInView, SearchableViewMixin):
+class HostCollectionsView(BaseLoggedInView, SearchableViewMixin):
     title = Text("//h2[contains(., 'Host Collections')]")
     new = Text("//button[contains(@href, '/host_collections/new')]")
     table = SatTable('.//table', column_widgets={'Name': Text('./a')})
@@ -20,7 +21,8 @@ class HostCollectionView(BaseLoggedInView, SearchableViewMixin):
             self.title, exception=False) is not None
 
 
-class HostCollectionDetailsView(BaseLoggedInView):
+class HostCollectionCreateView(BaseLoggedInView):
+    breadcrumb = BreadCrumb()
     name = TextInput(id='name')
     unlimited_hosts = Checkbox(name='limit')
     max_hosts = TextInput(id='max_hosts')
@@ -29,19 +31,32 @@ class HostCollectionDetailsView(BaseLoggedInView):
 
     @property
     def is_displayed(self):
-        return self.browser.wait_for_element(
-            self.name, exception=False) is not None
+        breadcrumb_loaded = self.browser.wait_for_element(
+            self.breadcrumb, exception=False)
+        return (
+                breadcrumb_loaded
+                and self.breadcrumb.locations[0] == 'Host Collections'
+                and self.breadcrumb.read() == 'New Host Collection'
+        )
 
 
 class HostCollectionEditView(BaseLoggedInView):
-    title = Text("//h3[contains(., 'Basic Information')]")
-    name = EditableEntry(name='Name')
-    description = EditableEntry(name='Description')
+    breadcrumb = BreadCrumb()
 
     @property
     def is_displayed(self):
-        return self.browser.wait_for_element(
-            self.title, exception=False) is not None
+        breadcrumb_loaded = self.browser.wait_for_element(
+            self.breadcrumb, exception=False)
+        return (
+                breadcrumb_loaded
+                and self.breadcrumb.locations[0] == 'Host Collections'
+                and self.breadcrumb.read() != 'New Host Collection'
+        )
+
+    @View.nested
+    class details(SatTab):
+        name = EditableEntry(name='Name')
+        description = EditableEntry(name='Description')
 
     @View.nested
     class hosts(SatTab):

--- a/airgun/views/lifecycleenvironment.py
+++ b/airgun/views/lifecycleenvironment.py
@@ -5,6 +5,7 @@ from widgetastic.widget import (
     TextInput,
     View,
 )
+from widgetastic_patternfly import BreadCrumb
 
 from airgun.views.common import BaseLoggedInView, SatTab
 from airgun.widgets import EditableEntry, ReadOnlyEntry, SatTable
@@ -81,6 +82,7 @@ class LCEView(BaseLoggedInView, ParametrizedView):
 
 
 class LCECreateView(BaseLoggedInView):
+    breadcrumb = BreadCrumb()
     name = TextInput(id='name')
     label = TextInput(id='label')
     description = TextInput(id='description')
@@ -88,17 +90,27 @@ class LCECreateView(BaseLoggedInView):
 
     @property
     def is_displayed(self):
-        return self.browser.wait_for_element(
-            self.name, exception=False) is not None
+        breadcrumb_loaded = self.browser.wait_for_element(
+            self.breadcrumb, exception=False)
+        return (
+                breadcrumb_loaded
+                and self.breadcrumb.locations[0] == 'Environments List'
+                and self.breadcrumb.read() == 'New Environment'
+        )
 
 
 class LCEEditView(BaseLoggedInView):
-    return_to_all = Text("//a[text()='Environments']")
+    breadcrumb = BreadCrumb()
 
     @property
     def is_displayed(self):
-        return self.browser.wait_for_element(
-            self.return_to_all, exception=False) is not None
+        breadcrumb_loaded = self.browser.wait_for_element(
+            self.breadcrumb, exception=False)
+        return (
+                breadcrumb_loaded
+                and self.breadcrumb.locations[0] == 'Environments'
+                and self.breadcrumb.read() != 'New Environment'
+        )
 
     @View.nested
     class details(SatTab):

--- a/airgun/views/organization.py
+++ b/airgun/views/organization.py
@@ -1,4 +1,5 @@
 from widgetastic.widget import Checkbox, Text, TextInput, View
+from widgetastic_patternfly import BreadCrumb
 
 from airgun.views.common import (
     BaseLoggedInView,
@@ -32,6 +33,7 @@ class OrganizationsView(BaseLoggedInView, SearchableViewMixin):
 
 
 class OrganizationCreateView(BaseLoggedInView):
+    breadcrumb = BreadCrumb()
     name = TextInput(id='organization_name')
     label = TextInput(id='organization_label')
     description = TextInput(id='organization_description')
@@ -39,29 +41,46 @@ class OrganizationCreateView(BaseLoggedInView):
 
     @property
     def is_displayed(self):
-        return self.browser.wait_for_element(
-            self.submit, exception=False) is not None
+        breadcrumb_loaded = self.browser.wait_for_element(
+            self.breadcrumb, exception=False)
+        return (
+                breadcrumb_loaded
+                and self.breadcrumb.locations[0] == 'Organizations'
+                and self.breadcrumb.read() == 'New Organization'
+        )
 
 
 class OrganizationCreateSelectHostsView(BaseLoggedInView):
+    breadcrumb = BreadCrumb()
     assign_all = Text("//a[text()='Assign All']")
     assign_manually = Text("//a[text()='Manually Assign']")
     proceed = Text("//a[text()='Proceed to Edit']")
 
     @property
     def is_displayed(self):
-        return self.browser.wait_for_element(
-            self.proceed, exception=False) is not None
+        breadcrumb_loaded = self.browser.wait_for_element(
+            self.breadcrumb, exception=False)
+        return (
+                breadcrumb_loaded
+                and self.breadcrumb.locations[0] == 'Organizations'
+                and self.breadcrumb.read() == 'Assign Hosts to'
+        )
 
 
 class OrganizationEditView(BaseLoggedInView):
+    breadcrumb = BreadCrumb()
     submit = Text("//form[contains(@id, 'edit')]//input[@name='commit']")
     cancel = Text("//a[text()='Cancel']")
 
     @property
     def is_displayed(self):
-        return self.browser.wait_for_element(
-            self.submit, exception=False) is not None
+        breadcrumb_loaded = self.browser.wait_for_element(
+            self.breadcrumb, exception=False)
+        return (
+                breadcrumb_loaded
+                and self.breadcrumb.locations[0] == 'Organizations'
+                and self.breadcrumb.read().starts_with('Edit ')
+        )
 
     @View.nested
     class primary(SatVerticalTab):

--- a/airgun/views/os.py
+++ b/airgun/views/os.py
@@ -1,4 +1,5 @@
 from widgetastic.widget import Text, TextInput, View
+from widgetastic_patternfly import BreadCrumb
 
 from airgun.views.common import BaseLoggedInView, SatTab, SearchableViewMixin
 from airgun.widgets import CustomParameter, MultiSelect, SatTable
@@ -22,6 +23,7 @@ class OperatingSystemView(BaseLoggedInView, SearchableViewMixin):
 
 
 class OperatingSystemDetailsView(BaseLoggedInView):
+    breadcrumb = BreadCrumb()
     name = TextInput(locator=".//input[@id='operatingsystem_name']")
     major = TextInput(locator=".//input[@id='operatingsystem_major']")
     architectures = MultiSelect(id='ms-operatingsystem_architecture_ids')
@@ -51,5 +53,10 @@ class OperatingSystemDetailsView(BaseLoggedInView):
 
     @property
     def is_displayed(self):
-        return self.browser.wait_for_element(
-            self.name, exception=False) is not None
+        breadcrumb_loaded = self.browser.wait_for_element(
+            self.breadcrumb, exception=False)
+        return (
+                breadcrumb_loaded
+                and self.breadcrumb.locations[0] == 'Operatingsystems'
+                and self.breadcrumb.read() == 'Edit Operating System'
+        )

--- a/airgun/views/partitiontable.py
+++ b/airgun/views/partitiontable.py
@@ -5,6 +5,7 @@ from widgetastic.widget import (
     TextInput,
     View,
 )
+from widgetastic_patternfly import BreadCrumb
 
 from airgun.views.common import (
     BaseLoggedInView,
@@ -38,6 +39,7 @@ class PartitionTablesView(BaseLoggedInView, SearchableViewMixin):
 
 
 class PartitionTableEditView(BaseLoggedInView):
+    breadcrumb = BreadCrumb()
     name = TextInput(locator="//input[@id='ptable_name']")
     default = Checkbox(id='ptable_default')
     template = ACEEditor()
@@ -77,5 +79,23 @@ class PartitionTableEditView(BaseLoggedInView):
 
     @property
     def is_displayed(self):
-        return self.browser.wait_for_element(
-            self.submit, exception=False) is not None
+        breadcrumb_loaded = self.browser.wait_for_element(
+            self.breadcrumb, exception=False)
+        return (
+                breadcrumb_loaded
+                and self.breadcrumb.locations[0] == 'Ptables'
+                and self.breadcrumb.read().startswith('Edit ')
+        )
+
+
+class PartitionTableCreateView(PartitionTableEditView):
+
+    @property
+    def is_displayed(self):
+        breadcrumb_loaded = self.browser.wait_for_element(
+            self.breadcrumb, exception=False)
+        return (
+            breadcrumb_loaded
+            and self.breadcrumb.locations[0] == 'Ptables'
+            and self.breadcrumb.read() == 'Create Partition Table'
+        )

--- a/airgun/views/product.py
+++ b/airgun/views/product.py
@@ -8,6 +8,7 @@ from widgetastic.widget import (
     TextInput,
     View,
 )
+from widgetastic_patternfly import BreadCrumb
 
 from airgun.views.common import (
     BaseLoggedInView,
@@ -70,6 +71,7 @@ class ProductsTableView(BaseLoggedInView, SearchableViewMixin):
 
 
 class ProductCreateView(BaseLoggedInView):
+    breadcrumb = BreadCrumb()
     name = TextInput(id='name')
     label = TextInput(id='label')
     gpg_key = Select(id='gpg_key_id')
@@ -82,19 +84,30 @@ class ProductCreateView(BaseLoggedInView):
 
     @property
     def is_displayed(self):
-        return self.browser.wait_for_element(
-            self.name, exception=False) is not None
+        breadcrumb_loaded = self.browser.wait_for_element(
+            self.breadcrumb, exception=False)
+        return (
+            breadcrumb_loaded
+            and self.breadcrumb.locations[0] == 'Products'
+            and self.breadcrumb.read() == 'New Product'
+        )
 
 
 class ProductEditView(BaseLoggedInView):
-    return_to_all = Text("//a[text()='Products']")
+    breadcrumb = BreadCrumb()
     actions = ActionsDropdown("//div[contains(@class, 'btn-group')]")
     dialog = ConfirmationDialog()
 
     @property
     def is_displayed(self):
-        return self.browser.wait_for_element(
-            self.return_to_all, exception=False) is not None
+        breadcrumb_loaded = self.browser.wait_for_element(
+            self.breadcrumb, exception=False)
+        return (
+                breadcrumb_loaded
+                and self.breadcrumb.locations[0] == 'Products'
+                and self.breadcrumb.read() not in (
+                    'New Product', 'Discover Repositories')
+        )
 
     @View.nested
     class details(SatTab):
@@ -111,13 +124,19 @@ class ProductEditView(BaseLoggedInView):
 
 
 class ProductRepoDiscoveryView(BaseLoggedInView, SearchableViewMixin):
+    breadcrumb = BreadCrumb()
     repo_type = Select(locator="//select[@ng-model='discovery.contentType']")
     url = TextInput(id='urlToDiscover')
 
     @property
     def is_displayed(self):
-        return self.browser.wait_for_element(
-            self.url, exception=False) is not None
+        breadcrumb_loaded = self.browser.wait_for_element(
+            self.breadcrumb, exception=False)
+        return (
+                breadcrumb_loaded
+                and self.breadcrumb.locations[0] == 'Products'
+                and self.breadcrumb.read() == 'Discover Repositories'
+        )
 
     @View.nested
     class discovered_repos(View):

--- a/airgun/views/subnet.py
+++ b/airgun/views/subnet.py
@@ -1,10 +1,11 @@
 from widgetastic.widget import Text, TextInput
+from widgetastic_patternfly import BreadCrumb
 
 from airgun.views.common import BaseLoggedInView, SearchableViewMixin
 from airgun.widgets import FilteredDropdown, RadioGroup, SatTable
 
 
-class SubnetView(BaseLoggedInView, SearchableViewMixin):
+class SubnetsView(BaseLoggedInView, SearchableViewMixin):
     title = Text("//h1[text()='Subnets']")
     new = Text("//a[contains(@href, '/subnets/new')]")
     table = SatTable(
@@ -25,6 +26,7 @@ class SubnetView(BaseLoggedInView, SearchableViewMixin):
 
 
 class SubnetDetailsView(BaseLoggedInView):
+    breadcrumb = BreadCrumb()
     name = TextInput(id='subnet_name')
     protocol = RadioGroup(locator="//div[label[contains(., 'Protocol')]]")
     network_address = TextInput(id='subnet_network')
@@ -35,5 +37,23 @@ class SubnetDetailsView(BaseLoggedInView):
 
     @property
     def is_displayed(self):
-        return self.browser.wait_for_element(
-            self.name, exception=False) is not None
+        breadcrumb_loaded = self.browser.wait_for_element(
+            self.breadcrumb, exception=False)
+        return (
+                breadcrumb_loaded
+                and self.breadcrumb.locations[0] == 'Subnets'
+                and self.breadcrumb.read().startswith('Edit ')
+        )
+
+
+class SubnetCreateView(SubnetDetailsView):
+
+    @property
+    def is_displayed(self):
+        breadcrumb_loaded = self.browser.wait_for_element(
+            self.breadcrumb, exception=False)
+        return (
+                breadcrumb_loaded
+                and self.breadcrumb.locations[0] == 'Subnets'
+                and self.breadcrumb.read() == 'Create Subnet'
+        )

--- a/airgun/views/syncplan.py
+++ b/airgun/views/syncplan.py
@@ -1,4 +1,5 @@
 from widgetastic.widget import Select, Text, TextInput, View
+from widgetastic_patternfly import BreadCrumb
 
 from airgun.views.common import (
     AddRemoveResourcesView,
@@ -31,6 +32,7 @@ class SyncPlansView(BaseLoggedInView, SearchableViewMixin):
 
 
 class SyncPlanCreateView(BaseLoggedInView):
+    breadcrumb = BreadCrumb()
     name = TextInput(id='name')
     description = TextInput(id='description')
     interval = Select(id='interval')
@@ -39,20 +41,29 @@ class SyncPlanCreateView(BaseLoggedInView):
 
     @property
     def is_displayed(self):
-        return self.browser.wait_for_element(
-            self.name, exception=False) is not None
+        breadcrumb_loaded = self.browser.wait_for_element(
+            self.breadcrumb, exception=False)
+        return (
+                breadcrumb_loaded
+                and self.breadcrumb.locations[0] == 'Sync Plans'
+                and self.breadcrumb.read() == 'New Sync Plan'
+        )
 
 
 class SyncPlanEditView(BaseLoggedInView):
-    # fixme: change all return_to_all instances to use Breadcrumb widget
-    return_to_all = Text("//a[text()='Sync Plans']")
+    breadcrumb = BreadCrumb()
     actions = ActionsDropdown("//div[contains(@class, 'btn-group')]")
     dialog = ConfirmationDialog()
 
     @property
     def is_displayed(self):
-        return self.browser.wait_for_element(
-            self.return_to_all, exception=False) is not None
+        breadcrumb_loaded = self.browser.wait_for_element(
+            self.breadcrumb, exception=False)
+        return (
+                breadcrumb_loaded
+                and self.breadcrumb.locations[0] == 'Sync Plans'
+                and self.breadcrumb.read() != 'New Sync Plan'
+        )
 
     @View.nested
     class details(SatTab):

--- a/airgun/views/template.py
+++ b/airgun/views/template.py
@@ -1,4 +1,5 @@
 from widgetastic.widget import Checkbox, Text, TextInput, View
+from widgetastic_patternfly import BreadCrumb
 
 from airgun.views.common import (
     BaseLoggedInView,
@@ -7,7 +8,11 @@ from airgun.views.common import (
     SearchableViewMixin,
     TemplateEditor,
 )
-from airgun.widgets import ActionsDropdown, FilteredDropdown, MultiSelect
+from airgun.widgets import (
+    ActionsDropdown,
+    FilteredDropdown,
+    MultiSelect,
+)
 
 
 class ProvisioningTemplatesView(BaseLoggedInView, SearchableViewMixin):
@@ -28,13 +33,19 @@ class ProvisioningTemplatesView(BaseLoggedInView, SearchableViewMixin):
 
 
 class ProvisioningTemplateDetailsView(BaseLoggedInView):
+    breadcrumb = BreadCrumb()
     FORM = "//form[contains(@id, 'provisioning_template')]"
     submit = Text('//input[@name="commit"]')
 
     @property
     def is_displayed(self):
-        return self.browser.wait_for_element(
-            self.FORM, exception=False) is not None
+        breadcrumb_loaded = self.browser.wait_for_element(
+            self.breadcrumb, exception=False)
+        return (
+                breadcrumb_loaded
+                and self.breadcrumb.locations[0] == 'Provisioning templates'
+                and self.breadcrumb.read().startswith('Edit ')
+        )
 
     @View.nested
     class template(SatTab):
@@ -63,3 +74,16 @@ class ProvisioningTemplateDetailsView(BaseLoggedInView):
     class organizations(SatTab):
         resources = MultiSelect(
             id='ms-provisioning_template_organization_ids')
+
+
+class ProvisioningTemplateCreateView(ProvisioningTemplateDetailsView):
+
+    @property
+    def is_displayed(self):
+        breadcrumb_loaded = self.browser.wait_for_element(
+            self.breadcrumb, exception=False)
+        return (
+            breadcrumb_loaded
+            and self.breadcrumb.locations[0] == 'Provisioning templates'
+            and self.breadcrumb.read() == 'Create Template'
+        )

--- a/airgun/views/user.py
+++ b/airgun/views/user.py
@@ -1,4 +1,5 @@
 from widgetastic.widget import Checkbox, Text, TextInput, View
+from widgetastic_patternfly import BreadCrumb
 
 from airgun.views.common import BaseLoggedInView, SearchableViewMixin, SatTab
 from airgun.widgets import FilteredDropdown, MultiSelect, SatTable
@@ -22,12 +23,18 @@ class UsersView(BaseLoggedInView, SearchableViewMixin):
 
 
 class UserDetailsView(BaseLoggedInView):
+    breadcrumb = BreadCrumb()
     submit = Text('//input[@name="commit"]')
 
     @property
     def is_displayed(self):
-        return self.browser.wait_for_element(
-            self.submit, exception=False) is not None
+        breadcrumb_loaded = self.browser.wait_for_element(
+            self.breadcrumb, exception=False)
+        return (
+                breadcrumb_loaded
+                and self.breadcrumb.locations[0] == 'Users'
+                and self.breadcrumb.read().starts_with('Edit ')
+        )
 
     @View.nested
     class user(SatTab):
@@ -54,3 +61,16 @@ class UserDetailsView(BaseLoggedInView):
     class roles(SatTab):
         admin = Checkbox(id='user_admin')
         resources = MultiSelect(id='ms-user_role_ids')
+
+
+class UserCreateView(UserDetailsView):
+
+    @property
+    def is_displayed(self):
+        breadcrumb_loaded = self.browser.wait_for_element(
+            self.breadcrumb, exception=False)
+        return (
+                breadcrumb_loaded
+                and self.breadcrumb.locations[0] == 'Users'
+                and self.breadcrumb.read() == 'Create User'
+        )

--- a/airgun/widgets.py
+++ b/airgun/widgets.py
@@ -1100,14 +1100,15 @@ class ProgressBar(GenericLocatorWidget):
         """Boolean value whether progress bar is active or not (stopped,
         pending or any other state).
         """
-        if 'active' in self.browser.classes(self):
+        if 'active' in self.browser.classes(self, check_safe=False):
             return True
         return False
 
     @property
     def progress(self):
         """String value with current flow rate in percent."""
-        return self.browser.get_attribute('aria-valuetext', self.PROGRESSBAR)
+        return self.browser.get_attribute(
+            'aria-valuetext', self.PROGRESSBAR, check_safe=False)
 
     @property
     def is_completed(self):

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ setup(
         'six==1.11.0',
         'wait_for',
         'widgetastic.core==0.21.2',
-        'widgetastic.patternfly==0.0.30'
+        'widgetastic.patternfly==0.0.33'
     ],
     packages=find_packages(exclude=['tests*']),
     package_data={'': ['LICENSE']},


### PR DESCRIPTION
Summary of changes:
* Used breadcrumb widget in navigate step to determine current entity
* Used breadcrumb widget in view's is_displayed for more precise view recognition
* Update for Progressbar widget to avoid default timeout when checking for page save, as it turns out in some rare cases ensure_page_save recognizes page isn't fully loaded when progress bar is active (however in most places it doesn't)
* Small fixes for numerous views, such as adding details tab, dividing 'detailsView' into separate create/edit views etc