### PR TITLE
Add support for chrome in docker

### DIFF
--- a/airgun/browser.py
+++ b/airgun/browser.py
@@ -255,6 +255,7 @@ class SeleniumBrowserFactory(object):
             self._docker.image = 'selenium/standalone-chrome'
             self._docker.capabilities = \
                 webdriver.DesiredCapabilities.CHROME.copy()
+            self._docker.capabilities.update({'args': 'start-maximized'})
         else:
             self._docker.image = 'selenium/standalone-firefox'
             self._docker.capabilities = \

--- a/airgun/session.py
+++ b/airgun/session.py
@@ -133,7 +133,9 @@ class Session(object):
         self._factory = SeleniumBrowserFactory(test_name=self.name)
         try:
             selenium_browser = self._factory.get_browser()
-            selenium_browser.maximize_window()
+            if not (self._factory.provider == 'docker' and
+                    self._factory.browser == 'chrome'):
+                selenium_browser.maximize_window()
             self.browser = AirgunBrowser(selenium_browser, self)
 
             self.browser.url = 'https://' + settings.satellite.hostname


### PR DESCRIPTION
* use webdriver config to select firefox or chrome (firefox being the default)
* select the docker image (`selenium/standalone-<browser>`)that matches the version of the used selenium-python-module, but fallback to the image tagged latest if no match was found
* docker images will **not** be pulled automatically from docker-registry
* workaround for an issue with maximizing the chrome window in docker (see SeleniumHQ/docker-selenium#559)