### PR TITLE
CV publish/promote, SatTab and Role improvements

### DIFF
--- a/airgun/entities/contentview.py
+++ b/airgun/entities/contentview.py
@@ -113,6 +113,7 @@ class ContentViewEntity(BaseEntity):
 
 @navigator.register(ContentViewEntity, 'All')
 class ShowAllContentViews(NavigateStep):
+    """Navigate to All Content Views screen."""
     VIEW = ContentViewTableView
 
     def step(self, *args, **kwargs):
@@ -121,6 +122,7 @@ class ShowAllContentViews(NavigateStep):
 
 @navigator.register(ContentViewEntity, 'New')
 class AddNewContentView(NavigateStep):
+    """Navigate to New Content View screen."""
     VIEW = ContentViewCreateView
 
     prerequisite = NavigateToSibling('All')
@@ -131,6 +133,11 @@ class AddNewContentView(NavigateStep):
 
 @navigator.register(ContentViewEntity, 'Edit')
 class EditContentView(NavigateStep):
+    """Navigate to Edit Content View screen.
+
+    Args:
+        entity_name: name of content view
+    """
     VIEW = ContentViewEditView
 
     def prerequisite(self, *args, **kwargs):

--- a/airgun/entities/contentview.py
+++ b/airgun/entities/contentview.py
@@ -83,6 +83,7 @@ class ContentViewEntity(BaseEntity):
             view.fill(values)
         view.save.click()
         view = self.navigate_to(self, 'Edit', entity_name=entity_name)
+        view.versions.searchbox.clear()
         view.versions.table[0]['Status'].widget.wait_for_result()
         view.flash.assert_no_error()
         view.flash.dismiss()
@@ -102,7 +103,9 @@ class ContentViewEntity(BaseEntity):
         view.lce(lce_name).fill(True)
         view.promote.click()
         view = self.navigate_to(self, 'Edit', entity_name=entity_name)
-        view.versions.table[0]['Status'].widget.wait_for_result()
+        view.versions.search(version_name)
+        view.versions.table.row(
+            version=version_name)['Status'].widget.wait_for_result()
         view.flash.assert_no_error()
         view.flash.dismiss()
         return view.versions.table.row(version=version_name).read()

--- a/airgun/entities/filter.py
+++ b/airgun/entities/filter.py
@@ -44,6 +44,12 @@ class FilterEntity(BaseEntity):
 
 @navigator.register(FilterEntity, 'All')
 class ShowAllFilters(NavigateStep):
+    """Navigate to All Role Filters page by pressing 'Filters' button on Roles
+    List view.
+
+    Args:
+        role_name: name of role
+    """
     VIEW = FiltersView
 
     def am_i_here(self, *args, **kwargs):
@@ -66,6 +72,12 @@ class ShowAllFilters(NavigateStep):
 
 @navigator.register(FilterEntity, 'New')
 class AddNewFilter(NavigateStep):
+    """Navigate to role's Create Filter page
+
+    Args:
+        role_name: name of role
+        entity_name: name of filter
+    """
     VIEW = FilterCreateView
 
     def prerequisite(self, *args, **kwargs):
@@ -77,6 +89,12 @@ class AddNewFilter(NavigateStep):
 
 @navigator.register(FilterEntity, 'Edit')
 class EditFilter(NavigateStep):
+    """Navigate to role's Edit Filter page
+
+    Args:
+        role_name: name of role
+        entity_name: name of filter
+    """
     VIEW = FilterDetailsView
 
     def am_i_here(self, *args, **kwargs):

--- a/airgun/entities/role.py
+++ b/airgun/entities/role.py
@@ -2,7 +2,7 @@ from navmazing import NavigateToSibling
 
 from airgun.entities.base import BaseEntity
 from airgun.navigation import NavigateStep, navigator
-from airgun.views.role import RoleDetailsView, RolesView
+from airgun.views.role import RoleCreateView, RoleEditView, RolesView
 
 
 class RoleEntity(BaseEntity):
@@ -38,6 +38,7 @@ class RoleEntity(BaseEntity):
 
 @navigator.register(RoleEntity, 'All')
 class ShowAllRoles(NavigateStep):
+    """Navigate to All Roles page"""
     VIEW = RolesView
 
     def step(self, *args, **kwargs):
@@ -46,7 +47,8 @@ class ShowAllRoles(NavigateStep):
 
 @navigator.register(RoleEntity, 'New')
 class AddNewRole(NavigateStep):
-    VIEW = RoleDetailsView
+    """Navigate to Create New Role page"""
+    VIEW = RoleCreateView
 
     prerequisite = NavigateToSibling('All')
 
@@ -56,7 +58,12 @@ class AddNewRole(NavigateStep):
 
 @navigator.register(RoleEntity, 'Edit')
 class EditRole(NavigateStep):
-    VIEW = RoleDetailsView
+    """Navigate to Edit Role page
+
+    Args:
+        entity_name: name of role
+    """
+    VIEW = RoleEditView
 
     def prerequisite(self, *args, **kwargs):
         return self.navigate_to(self.obj, 'All')

--- a/airgun/views/common.py
+++ b/airgun/views/common.py
@@ -1,5 +1,6 @@
 import six
 from widgetastic.widget import (
+    do_not_read_this_widget,
     ParametrizedLocator,
     ParametrizedView,
     Text,
@@ -56,6 +57,13 @@ class SatTab(Tab):
     @property
     def is_displayed(self):
         return 'ng-hide' not in self.parent_browser.classes(self.TAB_LOCATOR)
+
+    def read(self):
+        """Do not attempt to read hidden tab contents"""
+        if not self.is_displayed:
+            # return {}
+            do_not_read_this_widget()
+        return super().read()
 
 
 class SatVerticalTab(SatTab):

--- a/airgun/views/common.py
+++ b/airgun/views/common.py
@@ -61,7 +61,6 @@ class SatTab(Tab):
     def read(self):
         """Do not attempt to read hidden tab contents"""
         if not self.is_displayed:
-            # return {}
             do_not_read_this_widget()
         return super().read()
 

--- a/airgun/views/role.py
+++ b/airgun/views/role.py
@@ -1,4 +1,5 @@
 from widgetastic.widget import Text, TextInput
+from widgetastic_patternfly import BreadCrumb
 
 from airgun.views.common import BaseLoggedInView, SearchableViewMixin
 from airgun.widgets import ActionsDropdown, MultiSelect, SatTable
@@ -21,7 +22,8 @@ class RolesView(BaseLoggedInView, SearchableViewMixin):
             self.title, exception=False) is not None
 
 
-class RoleDetailsView(BaseLoggedInView):
+class RoleEditView(BaseLoggedInView):
+    breadcrumb = BreadCrumb()
     name = TextInput(id='role_name')
     description = TextInput(id='role_description')
     locations = MultiSelect(id='ms-role_location_ids')
@@ -30,5 +32,22 @@ class RoleDetailsView(BaseLoggedInView):
 
     @property
     def is_displayed(self):
-        return self.browser.wait_for_element(
-            self.submit, exception=False) is not None
+        breadcrumb_loaded = self.browser.wait_for_element(
+            self.breadcrumb, exception=False)
+        return (
+                breadcrumb_loaded
+                and self.breadcrumb.locations[0] == 'Roles'
+                and self.breadcrumb.read().starts_with('Edit ')
+        )
+
+class RoleCreateView(RoleEditView):
+
+    @property
+    def is_displayed(self):
+        breadcrumb_loaded = self.browser.wait_for_element(
+            self.breadcrumb, exception=False)
+        return (
+                breadcrumb_loaded
+                and self.breadcrumb.locations[0] == 'Roles'
+                and self.breadcrumb.read() == 'Create Role'
+        )

--- a/airgun/widgets.py
+++ b/airgun/widgets.py
@@ -313,12 +313,29 @@ class Search(Widget):
         "//button[contains(@type,'submit') or "
         "@ng-click='table.search(table.searchTerm)']"
     )
+    clear_query = Text(
+        "//button[contains(@ng-click, 'table.search("") && "
+        "(table.searchCompleted = false)')]"
+    )
 
     def fill(self, value):
         return self.search_field.fill(value)
 
     def read(self):
         return self.search_field.read()
+
+    def clear(self):
+        """Clears search field value if present.
+
+        Uses 'clear' button if available or manually clears text input and
+        pushes 'Search' button otherwise.
+        """
+        if self.clear_query.is_displayed:
+            self.clear_query.click()
+        elif self.search_field.value:
+            self.browser.clear(self.search_field)
+            if self.search_button.is_displayed:
+                self.search_button.click()
 
     def search(self, value):
         # Entity lists with 20+ elements may scroll page a bit and search field


### PR DESCRIPTION
* Updated SatTab's read() method to avoid attempts to read widgets of hidden tab
* Added clear() method for Search widget
* Updated Content View publish and promote methods to clear search query before attempting to read results table, as search query might get cached and actual result might appear filtered out
* Updated Role views to use breadcrumb widget