### PR TITLE
Unpin pytest and let pinning be controlled by robottelo

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ setup(
         'cached_property',
         'fauxfactory',
         'navmazing==1.1.4',
-        'pytest==3.4.0',
+        'pytest',
         'wait_for',
         'widgetastic.core==0.21.2',
         'widgetastic.patternfly==0.0.33'


### PR DESCRIPTION
We pin pytest in robottelo already, no need to pin in airgun aswell
So that we avoid pinning conflicts or maintaining pinning to be the same in various projects