### PR TITLE
Fixed issue with scrolling to elements; Improved logging; Repository helpers, views and widgets

### DIFF
--- a/airgun/entities/domain.py
+++ b/airgun/entities/domain.py
@@ -37,14 +37,13 @@ def assert_no_errors_in_view(view):
 
 
 class DomainEntity(BaseEntity):
-    def create(self, values, assert_no_errors=True):
-        """
-        Create a new domain.
-        """
+    def create(self, values):
+        """Create a new domain."""
         view = self.navigate_to(self, 'New')
         view.fill(values)
         view.submit_button.click()
         view.flash.assert_no_error()
+        view.flash.dismiss()
         assert_no_errors_in_view(view)
 
     def search(self, value):
@@ -61,14 +60,13 @@ class DomainEntity(BaseEntity):
         return view.read()
 
     def update(self, entity_name, values):
-        """
-        Update an existing domain.
-        """
+        """Update an existing domain."""
         view = self.navigate_to(self, 'Edit', entity_name=entity_name)
 
         view.fill(values)
         view.submit_button.click()
         view.flash.assert_no_error()
+        view.flash.dismiss()
         assert_no_errors_in_view(view)
 
     def add_parameter(self, entity_name, param_name, param_value):
@@ -76,6 +74,7 @@ class DomainEntity(BaseEntity):
         view.parameters.params.add({'name': param_name, 'value': param_value})
         view.submit_button.click()
         view.flash.assert_no_error()
+        view.flash.dismiss()
         assert_no_errors_in_view(view)
 
     def remove_parameter(self, entity_name, param_name):
@@ -83,6 +82,7 @@ class DomainEntity(BaseEntity):
         view.parameters.params.remove(param_name)
         view.submit_button.click()
         view.flash.assert_no_error()
+        view.flash.dismiss()
         assert_no_errors_in_view(view)
 
     def delete(self, name):
@@ -93,6 +93,7 @@ class DomainEntity(BaseEntity):
         view.table[0]['Actions'].widget.click()
         self.browser.handle_alert()
         view.flash.assert_no_error()
+        view.flash.dismiss()
         assert_no_errors_in_view(view)
 
 

--- a/airgun/entities/repository.py
+++ b/airgun/entities/repository.py
@@ -53,7 +53,7 @@ class RepositoryEntity(BaseEntity):
         view.progressbar.wait_for_result()
         return view.read()
 
-    def remove_packages(self, product_name, entity_name):
+    def remove_all_packages(self, product_name, entity_name):
         """Remove all packages from repository"""
         view = self.navigate_to(
             self,
@@ -61,8 +61,10 @@ class RepositoryEntity(BaseEntity):
             product_name=product_name,
             entity_name=entity_name,
         )
-        view.items_per_page.fill('100')
-        for _ in range(int(view.total_packages.text) // 100 + 1):
+        max_per_page = max([
+            int(el.text) for el in view.items_per_page.all_options])
+        view.items_per_page.fill(str(max_per_page))
+        for _ in range(int(view.total_packages.text) // max_per_page + 1):
             view.select_all.fill(True)
             view.remove_packages.click()
             view.dialog.confirm()
@@ -72,7 +74,7 @@ class RepositoryEntity(BaseEntity):
             raise AssertionError(
                 'Unable to remove all packages from {}'.format(entity_name))
 
-    def remove_puppet_modules(self, product_name, entity_name):
+    def remove_all_puppet_modules(self, product_name, entity_name):
         """Remove all puppet modules from repository"""
         view = self.navigate_to(
             self,
@@ -80,8 +82,11 @@ class RepositoryEntity(BaseEntity):
             product_name=product_name,
             entity_name=entity_name,
         )
-        view.items_per_page.fill('100')
-        for _ in range(int(view.total_puppet_modules.text) // 100 + 1):
+        max_per_page = max([
+            int(el.text) for el in view.items_per_page.all_options])
+        view.items_per_page.fill(str(max_per_page))
+        for _ in range(
+                int(view.total_puppet_modules.text) // max_per_page + 1):
             view.select_all.fill(True)
             view.remove_packages.click()
             view.dialog.confirm()

--- a/airgun/entities/repository.py
+++ b/airgun/entities/repository.py
@@ -5,6 +5,8 @@ from airgun.views.product import ProductTaskDetailsView
 from airgun.views.repository import (
     RepositoryCreateView,
     RepositoryEditView,
+    RepositoryPackagesView,
+    RepositoryPuppetModulesView,
     RepositoriesView,
 )
 
@@ -33,6 +35,8 @@ class RepositoryEntity(BaseEntity):
         view = self.navigate_to(
             self, 'Edit', product_name=product_name, entity_name=entity_name)
         view.fill(values)
+        view.flash.assert_no_error()
+        view.flash.dismiss()
 
     def delete(self, product_name, entity_name):
         """Delete specific product repository"""
@@ -48,6 +52,46 @@ class RepositoryEntity(BaseEntity):
             self, 'Sync', product_name=product_name, entity_name=entity_name)
         view.progressbar.wait_for_result()
         return view.read()
+
+    def remove_packages(self, product_name, entity_name):
+        """Remove all packages from repository"""
+        view = self.navigate_to(
+            self,
+            'Packages',
+            product_name=product_name,
+            entity_name=entity_name,
+        )
+        view.items_per_page.fill('100')
+        for _ in range(int(view.total_packages.text) // 100 + 1):
+            view.select_all.fill(True)
+            view.remove_packages.click()
+            view.dialog.confirm()
+            view.flash.assert_no_error()
+            view.flash.dismiss()
+        if view.total_packages.text != '0':
+            raise AssertionError(
+                'Unable to remove all packages from {}'.format(entity_name))
+
+    def remove_puppet_modules(self, product_name, entity_name):
+        """Remove all puppet modules from repository"""
+        view = self.navigate_to(
+            self,
+            'Puppet Modules',
+            product_name=product_name,
+            entity_name=entity_name,
+        )
+        view.items_per_page.fill('100')
+        for _ in range(int(view.total_puppet_modules.text) // 100 + 1):
+            view.select_all.fill(True)
+            view.remove_packages.click()
+            view.dialog.confirm()
+            view.flash.assert_no_error()
+            view.flash.dismiss()
+        if view.total_puppet_modules.text != '0':
+            raise AssertionError(
+                'Unable to remove all puppet modules from {}'
+                .format(entity_name)
+            )
 
 
 @navigator.register(RepositoryEntity, 'All')
@@ -145,3 +189,57 @@ class SyncRepository(NavigateStep):
         self.parent.search(entity_name)
         self.parent.table.row(name=entity_name)[0].fill(True)
         self.parent.sync.click()
+
+
+@navigator.register(RepositoryEntity, 'Packages')
+class RepositoryPackages(NavigateStep):
+    """Open repository details page and click 'Packages' link from 'Content
+    Counts' table to proceed to Packages page.
+
+    Args:
+        product_name: name of product
+        entity_name: name of repository
+    """
+    VIEW = RepositoryPackagesView
+
+    def am_i_here(self, *args, **kwargs):
+        prod_name = kwargs.get('product_name')
+        repo_name = kwargs.get('entity_name')
+        return (
+            self.view.is_displayed
+            and self.view.breadcrumb.locations[1] == prod_name
+            and self.view.breadcrumb.locations[3] == repo_name
+        )
+
+    def prerequisite(self, *args, **kwargs):
+        return self.navigate_to(self.obj, 'Edit', **kwargs)
+
+    def step(self, *args, **kwargs):
+        self.parent.content_counts.row((0, 'Packages'))[1].widget.click()
+
+
+@navigator.register(RepositoryEntity, 'Puppet Modules')
+class RepositoryPuppetModules(NavigateStep):
+    """Open repository details page and click 'Puppet Modules' link from
+    'Content Counts' table to proceed to Puppet Modules page.
+
+    Args:
+        product_name: name of product
+        entity_name: name of repository
+    """
+    VIEW = RepositoryPuppetModulesView
+
+    def am_i_here(self, *args, **kwargs):
+        prod_name = kwargs.get('product_name')
+        repo_name = kwargs.get('entity_name')
+        return (
+            self.view.is_displayed
+            and self.view.breadcrumb.locations[1] == prod_name
+            and self.view.breadcrumb.locations[3] == repo_name
+        )
+
+    def prerequisite(self, *args, **kwargs):
+        return self.navigate_to(self.obj, 'Edit', **kwargs)
+
+    def step(self, *args, **kwargs):
+        self.parent.content_counts.row((0, 'Puppet Modules'))[1].widget.click()

--- a/airgun/settings.py
+++ b/airgun/settings.py
@@ -45,7 +45,6 @@ class SeleniumSettings(object):
         self.screenshots_path = None
         self.webdriver = None
         self.webdriver_binary = None
-        self.webdriver_desired_capabilities = None
 
 
 class WebdriverCapabilitiesSettings(object):
@@ -81,12 +80,7 @@ class Settings(object):
         logging.getLogger('airgun').setLevel(self.airgun.verbosity)
 
     def _configure_thirdparty_logging(self):
-        loggers = (
-            'selenium.webdriver.remote.remote_connection',
-            'widgetastic_null'
-        )
-        for logger in loggers:
-            logging.getLogger(logger).setLevel(self.airgun.verbosity)
+        logging.getLogger('widgetastic_null').setLevel(self.airgun.verbosity)
 
     def configure(self, settings=None):
         """Parses arg `settings` or settings file if None passed and sets class

--- a/airgun/views/product.py
+++ b/airgun/views/product.py
@@ -126,7 +126,14 @@ class ProductEditView(BaseLoggedInView):
 
     @View.nested
     class repositories(SatTab):
-        pass
+        table = SatTable(
+            locator=".//table",
+            column_widgets={
+                0: Checkbox(
+                    locator="./input[@ng-change='itemSelected(repository)']"),
+                'Name': Text("./a"),
+            }
+        )
 
 
 class ProductRepoDiscoveryView(BaseLoggedInView, SearchableViewMixin):

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -42,6 +42,7 @@ nitpick_ignore = [
     ('py:class', 'navmazing.Navigate'),
     ('py:class', 'navmazing.NavigateStep'),
     ('py:class', 'airgun.views.common.BaseLoggedInView'),
+    ('py:meth', 'widgetastic.browser.Browser.move_to_element'),
     ('py:meth', 'airgun.views.common.BaseLoggedInView.read'),
     ('py:meth', 'navmazing.NavigateStep.go'),
     ('py:meth', 'current_org'),


### PR DESCRIPTION
Summary of changes:
* Fixed issue with taxonomies list hovering page when scrolling bottom-up (see screenshot)
* Removed flooding `selenium.webdriver.remote.remote_connection` messages from debug level which are redundant in 99% cases and were only useful on the earliest stages of development
* Fixed issue with `EditableEntry` widget when it wasn't able to fetch value of entries with similar names (e.g. 'publish via http' because of 'publish via https' present) due to `contains()` nature
* Added helpers, views and widgets for Repository's Packages and Puppet Modules


![image](https://user-images.githubusercontent.com/11719030/41487284-b86e3e18-70f0-11e8-9f1d-baf647e31691.png)
