### PR TITLE
adding basic logic to discovery rule entity

### DIFF
--- a/airgun/entities/discoveryrule.py
+++ b/airgun/entities/discoveryrule.py
@@ -7,7 +7,6 @@ from airgun.views.discoveryrule import (
     DiscoveryRuleEditView,
     DiscoveryRulesView,
 )
-from airgun.views.host import HostsView
 
 
 class DiscoveryRuleEntity(BaseEntity):
@@ -88,20 +87,6 @@ class DiscoveryRuleEntity(BaseEntity):
         view.flash.assert_no_error()
         view.flash.dismiss()
 
-    def associated_hosts(self, entity_name, host_name):
-        """Associate host to corresponding Discovery rule
-
-        :param str entity_name: name of the discovery rule
-        :param host_name: name of the host which is associated to disc. rule
-        :return: list of table rows of Host entity, each row is dict,
-            where attribute is key with correct value
-        """
-        view = self.navigate_to(self, 'All')
-        view.table.row(
-            name=entity_name)['Actions'].widget.fill('Associated Hosts')
-        view = self.navigate_to(self, 'Associate', host_name=host_name)
-        return view.table.read()
-
 
 @navigator.register(DiscoveryRuleEntity, 'All')
 class ShowAllDiscoveryRules(NavigateStep):
@@ -138,20 +123,3 @@ class EditDiscoveryRule(NavigateStep):
     def step(self, *args, **kwargs):
         entity_name = kwargs.get('entity_name')
         self.parent.table.row(name=entity_name)['Name'].widget.click()
-
-
-@navigator.register(DiscoveryRuleEntity, 'Associate')
-class AssociateHosts(NavigateStep):
-    """Navigate to Associated hosts page.
-
-        Args:
-            host_name: name of the host, which is associated
-    """
-    VIEW = HostsView
-
-    def am_i_here(self, *args, **kwargs):
-        return self.view.is_displayed and self.view.title == 'Hosts'
-
-    def step(self, *args, **kwargs):
-        host_name = kwargs.get('host_name')
-        self.view.search(host_name)

--- a/airgun/entities/discoveryrule.py
+++ b/airgun/entities/discoveryrule.py
@@ -13,39 +13,89 @@ from airgun.views.host import HostsView
 class DiscoveryRuleEntity(BaseEntity):
 
     def create(self, values):
+        """Create new Discovery rule
+
+        :param values: Parameters to be assigned to discovery rule,
+            Name, Search, Host Group and Priority should be provided
+        """
         view = self.navigate_to(self, 'New')
         view.fill(values)
         view.submit.click()
+        view.flash.assert_no_error()
+        view.flash.dismiss()
 
     def delete(self, entity_name):
+        """Delete corresponding Discovery rule
+
+        :param str entity_name: name of the corresponding discovery rule
+        """
         view = self.navigate_to(self, 'All')
         view.table.row(name=entity_name)['Actions'].widget.fill('Delete')
         self.browser.handle_alert()
+        view.flash.assert_no_error()
+        view.flash.dismiss()
 
     def read(self, entity_name):
+        """Reads content of corresponding Discovery rule
+
+        :param str entity_name: name of the corresponding discovery rule
+        :return: dict representing tabs, with nested dicts representing fields
+            and values
+        """
         view = self.navigate_to(self, 'Edit', entity_name=entity_name)
         return view.read()
 
     def read_all(self):
+        """Reads the whole discovery rules table.
+
+        :return: list of table rows, each row is dict,
+            attribute as key with correct value
+        """
         view = self.navigate_to(self, 'All')
         return view.table.read()
 
     def update(self, entity_name, values):
+        """Update existing Discovery rule
+
+        :param str entity_name: name of the corresponding discovery rule
+        :param values: parameters to be changed at discovery rule
+        """
         view = self.navigate_to(self, 'Edit', entity_name=entity_name)
         view.fill(values)
         view.submit.click()
+        view.flash.assert_no_error()
+        view.flash.dismiss()
 
     def enable(self, entity_name):
+        """Enable corresponding Discovery rule
+
+        :param str entity_name: name of the corresponding discovery rule
+        """
         view = self.navigate_to(self, 'All')
         view.table.row(name=entity_name)['Actions'].widget.fill('Enable')
         self.browser.handle_alert()
+        view.flash.assert_no_error()
+        view.flash.dismiss()
 
     def disable(self, entity_name):
+        """Disable corresponding Discovery rule
+
+        :param str entity_name: name of the corresponding discovery rule
+        """
         view = self.navigate_to(self, 'All')
         view.table.row(name=entity_name)['Actions'].widget.fill('Disable')
         self.browser.handle_alert()
+        view.flash.assert_no_error()
+        view.flash.dismiss()
 
     def associated_hosts(self, entity_name, host_name):
+        """Associate host to corresponding Discovery rule
+
+        :param str entity_name: name of the discovery rule
+        :param host_name: name of the host which is associated to disc. rule
+        :return: list of table rows of Host entity, each row is dict,
+            where attribute is key with correct value
+        """
         view = self.navigate_to(self, 'All')
         view.table.row(
             name=entity_name)['Actions'].widget.fill('Associated Hosts')
@@ -55,6 +105,7 @@ class DiscoveryRuleEntity(BaseEntity):
 
 @navigator.register(DiscoveryRuleEntity, 'All')
 class ShowAllDiscoveryRules(NavigateStep):
+    """Navigate to All Discovery rules screen."""
     VIEW = DiscoveryRulesView
 
     def step(self, *args, **kwargs):
@@ -63,10 +114,8 @@ class ShowAllDiscoveryRules(NavigateStep):
 
 @navigator.register(DiscoveryRuleEntity, 'New')
 class AddNewDiscoveryRule(NavigateStep):
+    """Navigate to Create Discovery rule page."""
     VIEW = DiscoveryRuleCreateView
-
-    def am_i_here(self, *args, **kwargs):
-        return self.view.is_displayed and self.view.name == ''
 
     prerequisite = NavigateToSibling('All')
 
@@ -76,11 +125,12 @@ class AddNewDiscoveryRule(NavigateStep):
 
 @navigator.register(DiscoveryRuleEntity, 'Edit')
 class EditDiscoveryRule(NavigateStep):
-    VIEW = DiscoveryRuleEditView
+    """Navigate to Edit Discovery rule page.
 
-    def am_i_here(self, *args, **kwargs):
-        entity_name = kwargs.get('entity_name')
-        return self.view.is_displayed and self.view.name.text == entity_name
+        Args:
+            entity_name: name of the discovery rule
+    """
+    VIEW = DiscoveryRuleEditView
 
     def prerequisite(self, *args, **kwargs):
         return self.navigate_to(self.obj, 'All')
@@ -92,6 +142,11 @@ class EditDiscoveryRule(NavigateStep):
 
 @navigator.register(DiscoveryRuleEntity, 'Associate')
 class AssociateHosts(NavigateStep):
+    """Navigate to Associated hosts page.
+
+        Args:
+            host_name: name of the host, which is associated
+    """
     VIEW = HostsView
 
     def am_i_here(self, *args, **kwargs):

--- a/airgun/entities/discoveryrule.py
+++ b/airgun/entities/discoveryrule.py
@@ -1,0 +1,102 @@
+from navmazing import NavigateToSibling
+
+from airgun.entities.base import BaseEntity
+from airgun.navigation import NavigateStep, navigator
+from airgun.views.discoveryrule import (
+    DiscoveryRuleCreateView,
+    DiscoveryRuleEditView,
+    DiscoveryRulesView,
+)
+from airgun.views.host import HostsView
+
+
+class DiscoveryRuleEntity(BaseEntity):
+
+    def create(self, values):
+        view = self.navigate_to(self, 'New')
+        view.fill(values)
+        view.submit.click()
+
+    def delete(self, entity_name):
+        view = self.navigate_to(self, 'All')
+        view.table.row(name=entity_name)['Actions'].widget.fill('Delete')
+        self.browser.handle_alert()
+
+    def read(self, entity_name):
+        view = self.navigate_to(self, 'Edit', entity_name=entity_name)
+        return view.read()
+
+    def read_all(self):
+        view = self.navigate_to(self, 'All')
+        return view.table.read()
+
+    def update(self, entity_name, values):
+        view = self.navigate_to(self, 'Edit', entity_name=entity_name)
+        view.fill(values)
+        view.submit.click()
+
+    def enable(self, entity_name):
+        view = self.navigate_to(self, 'All')
+        view.table.row(name=entity_name)['Actions'].widget.fill('Enable')
+        self.browser.handle_alert()
+
+    def disable(self, entity_name):
+        view = self.navigate_to(self, 'All')
+        view.table.row(name=entity_name)['Actions'].widget.fill('Disable')
+        self.browser.handle_alert()
+
+    def associated_hosts(self, entity_name, host_name):
+        view = self.navigate_to(self, 'All')
+        view.table.row(
+            name=entity_name)['Actions'].widget.fill('Associated Hosts')
+        view = self.navigate_to(self, 'Associate', host_name=host_name)
+        return view.table.read()
+
+
+@navigator.register(DiscoveryRuleEntity, 'All')
+class ShowAllDiscoveryRules(NavigateStep):
+    VIEW = DiscoveryRulesView
+
+    def step(self, *args, **kwargs):
+        self.view.menu.select('Configure', 'Discovery rules')
+
+
+@navigator.register(DiscoveryRuleEntity, 'New')
+class AddNewDiscoveryRule(NavigateStep):
+    VIEW = DiscoveryRuleCreateView
+
+    def am_i_here(self, *args, **kwargs):
+        return self.view.is_displayed and self.view.name == ''
+
+    prerequisite = NavigateToSibling('All')
+
+    def step(self, *args, **kwargs):
+        self.parent.browser.click(self.parent.new)
+
+
+@navigator.register(DiscoveryRuleEntity, 'Edit')
+class EditDiscoveryRule(NavigateStep):
+    VIEW = DiscoveryRuleEditView
+
+    def am_i_here(self, *args, **kwargs):
+        entity_name = kwargs.get('entity_name')
+        return self.view.is_displayed and self.view.name.text == entity_name
+
+    def prerequisite(self, *args, **kwargs):
+        return self.navigate_to(self.obj, 'All')
+
+    def step(self, *args, **kwargs):
+        entity_name = kwargs.get('entity_name')
+        self.parent.table.row(name=entity_name)['Name'].widget.click()
+
+
+@navigator.register(DiscoveryRuleEntity, 'Associate')
+class AssociateHosts(NavigateStep):
+    VIEW = HostsView
+
+    def am_i_here(self, *args, **kwargs):
+        return self.view.is_displayed and self.view.title == 'Hosts'
+
+    def step(self, *args, **kwargs):
+        host_name = kwargs.get('host_name')
+        self.view.search(host_name)

--- a/airgun/session.py
+++ b/airgun/session.py
@@ -16,6 +16,7 @@ from airgun.entities.computeprofile import ComputeProfileEntity
 from airgun.entities.contentcredential import ContentCredentialEntity
 from airgun.entities.contentview import ContentViewEntity
 from airgun.entities.computeresource import ComputeResourceEntity
+from airgun.entities.discoveryrule import DiscoveryRuleEntity
 from airgun.entities.domain import DomainEntity
 from airgun.entities.errata import ErrataEntity
 from airgun.entities.host import HostEntity
@@ -236,6 +237,11 @@ class Session(object):
     def contentview(self):
         """Instance of Content View entity."""
         return ContentViewEntity(self.browser)
+
+    @cached_property
+    def discoveryrule(self):
+        """Instance of Discovery Rule entity."""
+        return DiscoveryRuleEntity(self.browser)
 
     @cached_property
     def domain(self):

--- a/airgun/views/discoveryrule.py
+++ b/airgun/views/discoveryrule.py
@@ -4,6 +4,7 @@ from widgetastic.widget import (
     TextInput,
     View,
 )
+from widgetastic_patternfly import BreadCrumb
 
 from airgun.views.common import (
     BaseLoggedInView,
@@ -36,36 +37,29 @@ class DiscoveryRulesView(BaseLoggedInView, SearchableViewMixin):
 
 
 class DiscoveryRuleCreateView(BaseLoggedInView):
-    name = TextInput(locator="//input[@id='discovery_rule_name']")
-    search = TextInput(locator="//input[@id='search']")
-    host_group = FilteredDropdown(id='discovery_rule_hostgroup_id')
-    hostname = TextInput(id='discovery_rule_hostname')
-    hosts_limit = TextInput(id='discovery_rule_max_count')
-    priority = TextInput(id='discovery_rule_priority')
-    enabled = Checkbox(id='discovery_rule_enabled')
     submit = Text('//input[@name="commit"]')
-
-    @property
-    def is_displayed(self):
-        return self.browser.wait_for_element(
-            self.name, exception=False) is not None
-
-
-class DiscoveryRuleEditView(BaseLoggedInView):
-    name = TextInput(locator="//input[@id='discovery_rule_name']")
-    search = TextInput(locator="//input[@id='search']")
-    host_group = FilteredDropdown(id='discovery_rule_hostgroup_id')
-    hostname = TextInput(id='discovery_rule_hostname')
-    hosts_limit = TextInput(id='discovery_rule_max_count')
-    priority = TextInput(id='discovery_rule_priority')
-    enabled = Checkbox(id='discovery_rule_enabled')
-    submit = Text("//input[@name='commit']")
     cancel = Text("//a[text()='Cancel']")
+    breadcrumb = BreadCrumb()
 
     @property
     def is_displayed(self):
-        return self.browser.wait_for_element(
-            self.name, exception=False) is not None
+        breadcrumb_loaded = self.browser.wait_for_element(
+            self.breadcrumb, exception=False)
+        return (
+                breadcrumb_loaded
+                and self.breadcrumb.locations[0] == 'Discovery rules'
+                and self.breadcrumb.read() != 'New Discovery Rule'
+        )
+
+    @View.nested
+    class primary(SatTab):
+        name = TextInput(locator="//input[@id='discovery_rule_name']")
+        search = TextInput(locator="//input[@id='search']")
+        host_group = FilteredDropdown(id='discovery_rule_hostgroup_id')
+        hostname = TextInput(id='discovery_rule_hostname')
+        hosts_limit = TextInput(id='discovery_rule_max_count')
+        priority = TextInput(id='discovery_rule_priority')
+        enabled = Checkbox(id='discovery_rule_enabled')
 
     @View.nested
     class locations(SatTab):
@@ -74,3 +68,16 @@ class DiscoveryRuleEditView(BaseLoggedInView):
     @View.nested
     class organizations(SatTab):
         resources = MultiSelect(id='ms-discovery_rule_organization_ids')
+
+
+class DiscoveryRuleEditView(DiscoveryRuleCreateView):
+
+    @property
+    def is_displayed(self):
+        breadcrumb_loaded = self.browser.wait_for_element(
+            self.breadcrumb, exception=False)
+        return (
+            breadcrumb_loaded
+            and self.breadcrumb.locations[0] == 'Discovery rules'
+            and self.breadcrumb.read().startswith('Edit ')
+        )

--- a/airgun/views/discoveryrule.py
+++ b/airgun/views/discoveryrule.py
@@ -9,7 +9,6 @@ from widgetastic_patternfly import BreadCrumb
 from airgun.views.common import (
     BaseLoggedInView,
     SatTab,
-    SearchableViewMixin,
 )
 from airgun.widgets import (
     ActionsDropdown,
@@ -19,7 +18,7 @@ from airgun.widgets import (
 )
 
 
-class DiscoveryRulesView(BaseLoggedInView, SearchableViewMixin):
+class DiscoveryRulesView(BaseLoggedInView):
     title = Text("//h1[text()='Discovery Rules']")
     new = Text("//a[contains(@href, '/discovery_rules/new')]")
     table = SatTable(

--- a/airgun/views/discoveryrule.py
+++ b/airgun/views/discoveryrule.py
@@ -38,7 +38,7 @@ class DiscoveryRulesView(BaseLoggedInView, SearchableViewMixin):
 
 class DiscoveryRuleCreateView(BaseLoggedInView):
     submit = Text('//input[@name="commit"]')
-    cancel = Text("//a[text()='Cancel']")
+    cancel = Text('//a[text()="Cancel"]')
     breadcrumb = BreadCrumb()
 
     @property
@@ -48,13 +48,13 @@ class DiscoveryRuleCreateView(BaseLoggedInView):
         return (
                 breadcrumb_loaded
                 and self.breadcrumb.locations[0] == 'Discovery rules'
-                and self.breadcrumb.read() != 'New Discovery Rule'
+                and self.breadcrumb.read() == 'New Discovery Rule'
         )
 
     @View.nested
     class primary(SatTab):
-        name = TextInput(locator="//input[@id='discovery_rule_name']")
-        search = TextInput(locator="//input[@id='search']")
+        name = TextInput(id='discovery_rule_name')
+        search = TextInput(id='search')
         host_group = FilteredDropdown(id='discovery_rule_hostgroup_id')
         hostname = TextInput(id='discovery_rule_hostname')
         hosts_limit = TextInput(id='discovery_rule_max_count')

--- a/airgun/views/discoveryrule.py
+++ b/airgun/views/discoveryrule.py
@@ -1,0 +1,76 @@
+from widgetastic.widget import (
+    Checkbox,
+    Text,
+    TextInput,
+    View,
+)
+
+from airgun.views.common import (
+    BaseLoggedInView,
+    SatTab,
+    SearchableViewMixin,
+)
+from airgun.widgets import (
+    ActionsDropdown,
+    FilteredDropdown,
+    MultiSelect,
+    SatTable,
+)
+
+
+class DiscoveryRulesView(BaseLoggedInView, SearchableViewMixin):
+    title = Text("//h1[text()='Discovery Rules']")
+    new = Text("//a[contains(@href, '/discovery_rules/new')]")
+    table = SatTable(
+        './/table',
+        column_widgets={
+            'Name': Text('./a'),
+            'Actions': ActionsDropdown("./div[contains(@class, 'btn-group')]"),
+        }
+    )
+
+    @property
+    def is_displayed(self):
+        return self.browser.wait_for_element(
+            self.title, exception=False) is not None
+
+
+class DiscoveryRuleCreateView(BaseLoggedInView):
+    name = TextInput(locator="//input[@id='discovery_rule_name']")
+    search = TextInput(locator="//input[@id='search']")
+    host_group = FilteredDropdown(id='discovery_rule_hostgroup_id')
+    hostname = TextInput(id='discovery_rule_hostname')
+    hosts_limit = TextInput(id='discovery_rule_max_count')
+    priority = TextInput(id='discovery_rule_priority')
+    enabled = Checkbox(id='discovery_rule_enabled')
+    submit = Text('//input[@name="commit"]')
+
+    @property
+    def is_displayed(self):
+        return self.browser.wait_for_element(
+            self.name, exception=False) is not None
+
+
+class DiscoveryRuleEditView(BaseLoggedInView):
+    name = TextInput(locator="//input[@id='discovery_rule_name']")
+    search = TextInput(locator="//input[@id='search']")
+    host_group = FilteredDropdown(id='discovery_rule_hostgroup_id')
+    hostname = TextInput(id='discovery_rule_hostname')
+    hosts_limit = TextInput(id='discovery_rule_max_count')
+    priority = TextInput(id='discovery_rule_priority')
+    enabled = Checkbox(id='discovery_rule_enabled')
+    submit = Text("//input[@name='commit']")
+    cancel = Text("//a[text()='Cancel']")
+
+    @property
+    def is_displayed(self):
+        return self.browser.wait_for_element(
+            self.name, exception=False) is not None
+
+    @View.nested
+    class locations(SatTab):
+        resources = MultiSelect(id='ms-discovery_rule_location_ids')
+
+    @View.nested
+    class organizations(SatTab):
+        resources = MultiSelect(id='ms-discovery_rule_organization_ids')


### PR DESCRIPTION
 and just creation to host group entity

I have to finish Correct Discovered Hosts redirection and Correct Hosts redirection and search. 
And I have some questions about it. Can you please help with it ? @oshtaier 

1.How to make these redirection in entity ? Can you send me some example where else it has been done in project.
And I have some another questions related to tests.  [https://github.com/SatelliteQE/robottelo/pull/6131](url)

2. I don't know how to create a Host() neither in satellite directly or in tests, so how can I create the host with specific organization in test ? Yes I saw you create the fakehost in host_test but I tried to use your fakehost method but it didn't goes well.

3. Is there a way how to make my tests shorter with using `entities.NameOfEntity().create()` instead of working with `session.nameofentity.create({})`, I am asking because I have to work with unique organization, but I don't know how to specify in other entities to be in that specific organization I already tried like `entities.HostGroup(organization=org).create()` but it doesn't work. But you did it in activation key and also in host, so maybe I just need explanation.

4. In ui for all tier2 tests they use two non-admin users with discovery Manager/Reader roles, how can I create them in ui_airgun/