### PR TITLE
[WIP] Red Hat Subscriptions

### DIFF
--- a/airgun/entities/subscription.py
+++ b/airgun/entities/subscription.py
@@ -40,6 +40,7 @@ class SubscriptionEntity(BaseEntity):
 
     def add_manifest(self, manifest_file):
         view = self.navigate_to(self, 'Manage Manifest')
+        view.wait_animation_end()
         view.fill({
             'manifest.manifest_file': manifest_file,
         })
@@ -47,11 +48,13 @@ class SubscriptionEntity(BaseEntity):
 
     def delete_manifest(self):
         view = self.navigate_to(self, 'Delete Manifest Confirmation')
+        view.wait_animation_end()
         view.delete_button.click()
         self._wait_for_process_to_finish('Delete Manifest', has_manifest=False)
 
     def read_delete_manifest_message(self):
         view = self.navigate_to(self, 'Delete Manifest Confirmation')
+        view.wait_animation_end()
         return view.message.read()
 
     def add(self, entity_name, quantity=1):
@@ -108,10 +111,6 @@ class ManageManifest(NavigateStep):
     def step(self, *args, **kwargs):
         self.parent.manage_manifest_button.click()
 
-    def post_navigate(self, _tries, *args, **kwargs):
-        self.view.wait_animation_end()
-        return self.view.is_displayed
-
 
 @navigator.register(SubscriptionEntity, 'Delete Manifest Confirmation')
 class DeleteManifestConfirmation(NavigateStep):
@@ -125,10 +124,6 @@ class DeleteManifestConfirmation(NavigateStep):
                 handle_exception=True, logger=self.view.logger, timeout=10
         )
         self.parent.manifest.delete_button.click()
-
-    def post_navigate(self, _tries, *args, **kwargs):
-        self.view.wait_animation_end()
-        return self.view.is_displayed
 
 
 @navigator.register(SubscriptionEntity, 'Add')

--- a/airgun/entities/subscription.py
+++ b/airgun/entities/subscription.py
@@ -29,7 +29,7 @@ class SubscriptionEntity(BaseEntity):
         wait_for(
                 lambda: self.has_manifest == has_manifest,
                 handle_exception=True, timeout=10,
-                logger=view.progressbar.logger
+                logger=view.logger
         )
         view.flash.dismiss()
 
@@ -97,6 +97,13 @@ class SubscriptionEntity(BaseEntity):
 @navigator.register(SubscriptionEntity, 'All')
 class SubscriptionList(NavigateStep):
     VIEW = SubscriptionListView
+
+    def pre_navigate(self, _tries, *args, **kwargs):
+        super(SubscriptionList, self).pre_navigate(_tries, *args, **kwargs)
+        wait_for(
+                lambda: not self.view.fake_fade_widget.is_displayed,
+                handle_exception=True, logger=self.view.logger, timeout=10 * 60
+        )
 
     def step(self, *args, **kwargs):
         self.view.menu.select('Content', 'Subscriptions')

--- a/airgun/entities/subscription.py
+++ b/airgun/entities/subscription.py
@@ -72,7 +72,7 @@ class SubscriptionEntity(BaseEntity):
 
     def provided_products(self, entity_name):
         view = self.navigate_to(self, 'Details', entity_name=entity_name)
-        return view.details.provided_products
+        return view.details.provided_products.read()
 
     def enabled_products(self, entity_name):
         view = self.navigate_to(self, 'Details', entity_name=entity_name)

--- a/airgun/entities/subscription.py
+++ b/airgun/entities/subscription.py
@@ -1,3 +1,4 @@
+from selenium.common.exceptions import NoSuchElementException
 from navmazing import NavigateToSibling
 from wait_for import wait_for
 
@@ -62,8 +63,8 @@ class SubscriptionEntity(BaseEntity):
         for row in view.table.rows(subscription_name=entity_name):
             row['Quantity to Allocate'].fill(quantity)
         view.submit_button.click()
-        self._wait_for_process_to_finish('Bind entitlements to an allocation',
-                                         has_manifest=True)
+        self._wait_for_process_to_finish(
+                'Bind entitlements to an allocation', has_manifest=True)
 
     def search(self, value):
         view = self.navigate_to(self, 'All')
@@ -76,7 +77,10 @@ class SubscriptionEntity(BaseEntity):
     def enabled_products(self, entity_name):
         view = self.navigate_to(self, 'Details', entity_name=entity_name)
         view.enabled_products.select()
-        return view.enabled_products.enabled_products_list
+        try:
+            return view.enabled_products.enabled_products_list
+        except NoSuchElementException:
+            return []
 
     def update(self, entity_name, values):
         # This operation was never implemented in Robottelo (no test
@@ -90,8 +94,8 @@ class SubscriptionEntity(BaseEntity):
             row['Select all rows'].fill(True)
         view.delete_button.click()
         view.confirm_deletion.confirm()
-        self._wait_for_process_to_finish('Delete Upstream Subscription',
-                                         has_manifest=True)
+        self._wait_for_process_to_finish(
+                'Delete Upstream Subscription', has_manifest=True)
 
 
 @navigator.register(SubscriptionEntity, 'All')

--- a/airgun/entities/subscription.py
+++ b/airgun/entities/subscription.py
@@ -31,7 +31,7 @@ class SubscriptionEntity(BaseEntity):
     @property
     def has_manifest(self):
         view = self.navigate_to(self, 'All')
-        return "disabled" not in view.browser.classes(view.add_button)
+        return not view.add_button.disabled
 
     def add_manifest(self, manifest_file):
         view = self.navigate_to(self, 'Manage Manifest')
@@ -114,8 +114,7 @@ class DeleteManifestConfirmation(NavigateStep):
     def step(self, *args, **kwargs):
         wait_for(
                 lambda: not self.parent.manifest.delete_button.disabled,
-                logger=self.view.logger,
-                timeout=10
+                handle_exception=True, logger=self.view.logger, timeout=10
         )
         self.parent.manifest.delete_button.click()
 

--- a/airgun/entities/subscription.py
+++ b/airgun/entities/subscription.py
@@ -1,0 +1,180 @@
+from selenium.common.exceptions import NoSuchElementException
+
+from navmazing import NavigateToSibling
+from wait_for import wait_for, TimedOutError
+
+from airgun.entities.base import BaseEntity
+from airgun.navigation import NavigateStep, navigator
+from airgun.views.subscription import (
+    SubscriptionListView,
+    ManageManifestView,
+    DeleteManifestConfirmationView,
+    AddSubscriptionView,
+    SubscriptionDetailsView,
+)
+
+
+class SubscriptionEntity(BaseEntity):
+    def _wait_for_process_to_finish(self, has_manifest=False):
+        view = self.navigate_to(self, 'All')
+        view.progressbar.wait_displayed(timeout=20)
+        wait_for(
+                lambda: not view.progressbar.is_displayed,
+                timeout=60*10,
+                logger=view.progressbar.logger
+        )
+        wait_for(
+                lambda: self.has_manifest == has_manifest,
+                timeout=10,
+                logger=view.progressbar.logger
+        )
+        view.flash.dismiss()
+
+    @property
+    def has_manifest(self):
+        view = self.navigate_to(self, 'All')
+        return "disabled" not in view.browser.classes(view.add_button)
+
+    def add_manifest(self, manifest_file):
+        view = self.navigate_to(self, 'Manage Manifest')
+        view.fill({
+            'manifest.manifest_file': manifest_file,
+        })
+        self._wait_for_process_to_finish(has_manifest=True)
+
+    def delete_manifest(self, really=True):
+        view = self.navigate_to(self, 'Delete Manifest Confirmation')
+        if not really:
+            view.cancel_button.click()
+            try:
+                while view.is_displayed:
+                    pass
+            except NoSuchElementException:
+                pass
+            self.navigate_to(self, 'Manage Manifest').close_button.click()
+            return
+
+        view.delete_button.click()
+        self._wait_for_process_to_finish(has_manifest=False)
+
+    def read_delete_manifest_message(self):
+        view = self.navigate_to(self, 'Delete Manifest Confirmation')
+        return view.message.read()
+
+    def add(self, entity_name, quantity=1):
+        view = self.navigate_to(self, 'Add')
+        for row in view.table.rows(subscription_name=entity_name):
+            row['Quantity to Allocate'].fill(quantity)
+        view.submit_button.click()
+        self._wait_for_process_to_finish(has_manifest=True)
+
+    def search(self, value):
+        view = self.navigate_to(self, 'All')
+        return view.search(value)
+
+    def provided_products(self, entity_name):
+        view = self.navigate_to(self, 'Details', subscription=entity_name)
+        return [elem.text
+                for elem
+                in view.details.provided_products.browser.elements("./li")]
+
+    def enabled_products(self, entity_name):
+        locator = ("//div[contains(@class, 'list-group')]"
+                   "//div[contains(@class, 'list-group-item-heading')]"
+                   )
+        view = self.navigate_to(self, 'Details', subscription=entity_name)
+        view.enabled_products.select()
+        try:
+            view.browser.wait_for_element(locator, visible=True)
+        except NoSuchElementException:
+            return []
+        return [elem.text for elem in view.browser.elements(locator)]
+
+    def update(self, entity_name, values):
+        # This operation was never implemented in Robottelo (no test
+        # requires it). It is here for consistency, but raises
+        # exception until it is actually needed
+        raise NotImplementedError("Subscriptions update is not implemented")
+
+    def delete(self, entity_name):
+        view = self.navigate_to(self, 'All')
+        for row in view.table.rows(name=entity_name):
+            row['Select all rows'].fill(True)
+        view.delete_button.click()
+        view.confirm_deletion.confirm()
+        self._wait_for_process_to_finish(has_manifest=True)
+
+
+@navigator.register(SubscriptionEntity, 'All')
+class SubscriptionList(NavigateStep):
+    VIEW = SubscriptionListView
+
+    def step(self, *args, **kwargs):
+        self.view.menu.select('Content', 'Subscriptions')
+
+
+@navigator.register(SubscriptionEntity, 'Manage Manifest')
+class ManageManifest(NavigateStep):
+    VIEW = ManageManifestView
+
+    prerequisite = NavigateToSibling('All')
+
+    def step(self, *args, **kwargs):
+        self.parent.manage_manifest_button.click()
+
+    def post_navigate(self, _tries, *args, **kwargs):
+        return self.view.is_displayed
+
+
+@navigator.register(SubscriptionEntity, 'Delete Manifest Confirmation')
+class DeleteManifestConfirmation(NavigateStep):
+    VIEW = DeleteManifestConfirmationView
+
+    prerequisite = NavigateToSibling('Manage Manifest')
+
+    def step(self, *args, **kwargs):
+        wait_for(
+                lambda: self.view.browser.get_attribute(
+                        "disabled",
+                        self.parent.manifest.delete_button) is None,
+                logger=self.view.logger,
+                timeout=10
+        )
+        self.parent.manifest.delete_button.click()
+
+    def post_navigate(self, _tries, *args, **kwargs):
+        return self.view.is_displayed
+
+
+@navigator.register(SubscriptionEntity, 'Add')
+class AddSubscription(NavigateStep):
+    VIEW = AddSubscriptionView
+
+    prerequisite = NavigateToSibling('All')
+
+    def am_i_here(self, *args, **kwargs):
+        return self.view.browser.selenium.current_url.endswith('/add')
+
+    def step(self, *args, **kwargs):
+        self.parent.add_button.click()
+
+
+@navigator.register(SubscriptionEntity, 'Details')
+class SubscriptionDetails(NavigateStep):
+    VIEW = SubscriptionDetailsView
+
+    def prerequisite(self, *args, **kwargs):
+        return self.navigate_to(self.obj, 'All')
+
+    def am_i_here(self, *args, **kwargs):
+        subscription_name = kwargs.get('subscription')
+        if not subscription_name:
+            raise ValueError('Invalid value of subscription parameter')
+        return (self.view.is_displayed and
+                self.view.breadcrumb.read() == subscription_name)
+
+    def step(self, *args, **kwargs):
+        subscription_name = kwargs.get('subscription')
+        if not subscription_name:
+            raise ValueError('Invalid value of subscription parameter')
+        self.parent.table.row(name=subscription_name)['Name'].widget.click()

--- a/airgun/entities/subscription.py
+++ b/airgun/entities/subscription.py
@@ -1,4 +1,3 @@
-from selenium.common.exceptions import NoSuchElementException
 from navmazing import NavigateToSibling
 from wait_for import wait_for
 
@@ -107,10 +106,7 @@ class SubscriptionEntity(BaseEntity):
         """
         view = self.navigate_to(self, 'Details', entity_name=entity_name)
         view.enabled_products.select()
-        try:
-            return view.enabled_products.enabled_products_list
-        except NoSuchElementException:
-            return []
+        return view.enabled_products.enabled_products_list.read()
 
     def update(self, entity_name, values):
         """Stub method provided for consistency with other Airgun entities.

--- a/airgun/entities/subscription.py
+++ b/airgun/entities/subscription.py
@@ -109,6 +109,7 @@ class ManageManifest(NavigateStep):
         self.parent.manage_manifest_button.click()
 
     def post_navigate(self, _tries, *args, **kwargs):
+        self.view.wait_animation_end()
         return self.view.is_displayed
 
 
@@ -126,6 +127,7 @@ class DeleteManifestConfirmation(NavigateStep):
         self.parent.manifest.delete_button.click()
 
     def post_navigate(self, _tries, *args, **kwargs):
+        self.view.wait_animation_end()
         return self.view.is_displayed
 
 

--- a/airgun/entities/subscription.py
+++ b/airgun/entities/subscription.py
@@ -1,7 +1,7 @@
 from selenium.common.exceptions import NoSuchElementException
 
 from navmazing import NavigateToSibling
-from wait_for import wait_for, TimedOutError
+from wait_for import wait_for
 
 from airgun.entities.base import BaseEntity
 from airgun.navigation import NavigateStep, navigator

--- a/airgun/session.py
+++ b/airgun/session.py
@@ -54,6 +54,7 @@ from airgun.entities.template import ProvisioningTemplateEntity
 from airgun.entities.smart_class_parameter import SmartClassParameterEntity
 from airgun.entities.smart_variable import SmartVariableEntity
 from airgun.entities.subnet import SubnetEntity
+from airgun.entities.subscription import SubscriptionEntity
 from airgun.entities.syncplan import SyncPlanEntity
 from airgun.entities.user import UserEntity
 from airgun.entities.usergroup import UserGroupEntity
@@ -437,6 +438,11 @@ class Session(object):
     def subnet(self):
         """Instance of Subnet entity."""
         return SubnetEntity(self.browser)
+
+    @cached_property
+    def subscription(self):
+        """Instance of Subscription entity."""
+        return SubscriptionEntity(self.browser)
 
     @cached_property
     def syncplan(self):

--- a/airgun/views/subscription.py
+++ b/airgun/views/subscription.py
@@ -86,7 +86,7 @@ class SubscriptionListView(BaseLoggedInView, SubscriptionSearchableViewMixin):
         locator='//div[@id="subscriptions-table"]//table',
         column_widgets={
             'Select all rows': Checkbox(locator=".//input[@type='checkbox']"),
-            'Name': Text(".//a"),
+            'Name': Text("./a"),
         }
     )
     add_button = Button(href='subscriptions/add')

--- a/airgun/views/subscription.py
+++ b/airgun/views/subscription.py
@@ -72,8 +72,7 @@ class SubscriptionListView(BaseLoggedInView, SubscriptionSearchableViewMixin):
 
 
 class ManageManifestView(BaseLoggedInView):
-    _locator = '//h4[@class="modal-title"][text()="Manage Manifest"]'
-    ROOT = _locator + '/ancestor::div[@class="modal-content"]'
+    ROOT = '//div[@class="modal-content"][div/h4[text()="Manage Manifest"]]'
     close_button = Button('Close')
 
     @View.nested
@@ -98,12 +97,12 @@ class ManageManifestView(BaseLoggedInView):
     @property
     def is_displayed(self):
         return self.browser.wait_for_element(
-            self._locator, visible=True, exception=False) is not None
+            self.close_button, visible=True, exception=False) is not None
 
 
 class DeleteManifestConfirmationView(BaseLoggedInView):
-    _locator = '//h4[@class="modal-title"][text()="Confirm delete manifest"]'
-    ROOT = _locator + '/ancestor::div[@class="modal-content"]'
+    ROOT = ('//div[@class="modal-content"]'
+            '[div/h4[text()="Confirm delete manifest"]]')
     message = Text('.//div[@class="modal-body"]')
     delete_button = Button('Delete')
     cancel_button = Button('Cancel')
@@ -111,7 +110,7 @@ class DeleteManifestConfirmationView(BaseLoggedInView):
     @property
     def is_displayed(self):
         return self.browser.wait_for_element(
-                self._locator, visible=True, exception=False) is not None
+                self.delete_button, visible=True, exception=False) is not None
 
 
 class AddSubscriptionView(BaseLoggedInView):

--- a/airgun/views/subscription.py
+++ b/airgun/views/subscription.py
@@ -65,6 +65,9 @@ class SubscriptionListView(BaseLoggedInView, SubscriptionSearchableViewMixin):
     delete_button = Button('Delete')
     progressbar = ProgressBar('//div[contains(@class,"progress-bar-striped")]')
     confirm_deletion = DeleteSubscriptionConfirmationDialog()
+    # In pre_navigate we wait for element with class `fade` to be not
+    # visible; we need to first define it here
+    fake_fade_widget = Text(".//*[contains(@class, 'fade')]")
 
     @property
     def is_displayed(self):

--- a/airgun/views/subscription.py
+++ b/airgun/views/subscription.py
@@ -1,4 +1,3 @@
-from selenium.common.exceptions import NoSuchElementException
 from wait_for import wait_for
 
 from widgetastic.widget import (
@@ -53,7 +52,7 @@ class SatSubscriptionsViewTable(SatTable):
 class SubscriptionListView(BaseLoggedInView, SubscriptionSearchableViewMixin):
     """List of all subscriptions."""
     table = SatSubscriptionsViewTable(
-        locator='//*[@id="subscriptions-table"]//table',
+        locator='//div[@id="subscriptions-table"]//table',
         column_widgets={
             'Select all rows': Checkbox(locator=".//input[@type='checkbox']"),
             'Name': Text(".//a"),
@@ -67,7 +66,7 @@ class SubscriptionListView(BaseLoggedInView, SubscriptionSearchableViewMixin):
     confirm_deletion = DeleteSubscriptionConfirmationDialog()
     # In pre_navigate we wait for element with class `fade` to be not
     # visible; we need to first define it here
-    fake_fade_widget = Text(".//*[contains(@class, 'fade')]")
+    fake_fade_widget = Text(".//div[contains(@class, 'fade')]")
 
     @property
     def is_displayed(self):
@@ -173,10 +172,7 @@ class SubscriptionDetailsView(BaseLoggedInView):
             locator = ("//div[contains(@class, 'list-group')]"
                        "//div[contains(@class, 'list-group-item-heading')]"
                        )
-            try:
-                self.browser.wait_for_element(locator, visible=True)
-            except NoSuchElementException:
-                return []
+            self.browser.wait_for_element(locator, visible=True)
             return [elem.text for elem in self.browser.elements(locator)]
 
     @property

--- a/airgun/views/subscription.py
+++ b/airgun/views/subscription.py
@@ -12,6 +12,7 @@ from widgetastic_patternfly import BreadCrumb, Button
 from airgun.views.common import BaseLoggedInView, SatTab, SearchableViewMixin
 from airgun.widgets import (
     ConfirmationDialog,
+    ItemsListReadOnly,
     ProgressBar,
     SatTable,
     Search,
@@ -155,13 +156,8 @@ class SubscriptionDetailsView(BaseLoggedInView):
     @View.nested
     class details(SatTab):
 
-        @property
-        def provided_products(self):
-            return [elem.text
-                    for elem
-                    in self.browser.elements(
-                        ("//h2[text()='Provided Products']"
-                         "/following::ul/li"))]
+        provided_products = ItemsListReadOnly(
+                (".//h2[text()='Provided Products']/following::ul"))
 
     @View.nested
     class enabled_products(SatTab):

--- a/airgun/views/subscription.py
+++ b/airgun/views/subscription.py
@@ -1,4 +1,5 @@
 from selenium.common.exceptions import NoSuchElementException
+from wait_for import wait_for
 
 from widgetastic.widget import (
     Checkbox,
@@ -72,7 +73,8 @@ class SubscriptionListView(BaseLoggedInView, SubscriptionSearchableViewMixin):
 
 
 class ManageManifestView(BaseLoggedInView):
-    ROOT = '//div[@class="modal-content"][div/h4[text()="Manage Manifest"]]'
+    ROOT = ('//div[@role="dialog" and @tabindex]'
+            '[div//h4[text()="Manage Manifest"]]')
     close_button = Button('Close')
 
     @View.nested
@@ -96,21 +98,35 @@ class ManageManifestView(BaseLoggedInView):
 
     @property
     def is_displayed(self):
-        return self.browser.wait_for_element(
-            self.close_button, visible=True, exception=False) is not None
+        return (self.browser.wait_for_element(
+                self.close_button, visible=True, exception=False) is not None
+                and 'in' in self.browser.classes(self))
+
+    def wait_animation_end(self):
+        wait_for(
+                lambda: 'in' in self.browser.classes(self),
+                handle_exception=True, logger=self.logger, timeout=10
+        )
 
 
 class DeleteManifestConfirmationView(BaseLoggedInView):
-    ROOT = ('//div[@class="modal-content"]'
-            '[div/h4[text()="Confirm delete manifest"]]')
+    ROOT = ('//div[@role="dialog" and @tabindex]'
+            '[div//h4[text()="Confirm delete manifest"]]')
     message = Text('.//div[@class="modal-body"]')
     delete_button = Button('Delete')
     cancel_button = Button('Cancel')
 
     @property
     def is_displayed(self):
-        return self.browser.wait_for_element(
+        return (self.browser.wait_for_element(
                 self.delete_button, visible=True, exception=False) is not None
+                and 'in' in self.browser.classes(self))
+
+    def wait_animation_end(self):
+        wait_for(
+                lambda: 'in' in self.browser.classes(self),
+                handle_exception=True, logger=self.logger, timeout=10
+        )
 
 
 class AddSubscriptionView(BaseLoggedInView):

--- a/airgun/views/subscription.py
+++ b/airgun/views/subscription.py
@@ -1,0 +1,116 @@
+from widgetastic.widget import (
+    Checkbox,
+    FileInput,
+    Text,
+    TextInput,
+    View,
+)
+from widgetastic_patternfly import BreadCrumb
+
+from airgun.views.common import BaseLoggedInView, SearchableViewMixin, SatTab
+from airgun.widgets import (
+    DeleteSubscriptionConfirmationDialog,
+    SatTable,
+    SatSubscriptionsViewTable,
+    ProgressBar
+)
+
+
+class SubscriptionListView(BaseLoggedInView, SearchableViewMixin):
+    """List of all subscriptions."""
+    table = SatSubscriptionsViewTable(
+        locator='//*[@id="subscriptions-table"]//table',
+        column_widgets={
+            'Select all rows': Checkbox(locator=".//input[@type='checkbox']"),
+            'Name': Text(".//a"),
+        }
+    )
+    add_button = Text("//a[@href='subscriptions/add']")
+    manage_manifest_button = Text("//button[text()='Manage Manifest']")
+    export_csv_button = Text("//button[text()='Export CSV']")
+    delete_button = Text("//button[text()='Delete']")
+    progressbar = ProgressBar('//div[contains(@class, "progress-bar-striped")]')
+    confirm_deletion = DeleteSubscriptionConfirmationDialog()
+
+    @property
+    def is_displayed(self):
+        return self.browser.wait_for_element(
+            'div#subscriptions-table', timeout=10, exception=False) is not None
+
+
+class ManageManifestView(BaseLoggedInView):
+    _locator = '//h4[@class="modal-title"][text()="Manage Manifest"]'
+    ROOT = _locator + '/ancestor::div[@class="modal-content"]'
+    close_button = Text(".//button[text()='Close']")
+
+    @View.nested
+    class manifest(SatTab):
+        red_hat_cdn_url = TextInput(id='cdnUrl')
+        manifest_file = FileInput(id='usmaFile')
+        refresh_button = Text(".//button[text()='Refresh']")
+        delete_button = Text(".//button[text()='Delete']")
+
+    @View.nested
+    class manifest_history(SatTab):
+        TAB_NAME = "Manifest History"
+        table = SatTable(
+                locator="div#manifest-history-tabs table",
+                column_widgets={
+                    'Status': Text(),
+                    'Message': Text(),
+                    'Timestamp': Text()
+                }
+        )
+
+    @property
+    def is_displayed(self):
+        return self.browser.wait_for_element(
+            self._locator, visible=True, exception=False) is not None
+
+
+class DeleteManifestConfirmationView(BaseLoggedInView):
+    _locator = '//h4[@class="modal-title"][text()="Confirm delete manifest"]'
+    ROOT = _locator + '/ancestor::div[@class="modal-content"]'
+    message = Text('.//div[@class="modal-body"]')
+    delete_button = Text(".//button[text()='Delete']")
+    cancel_button = Text(".//button[text()='Cancel']")
+
+    @property
+    def is_displayed(self):
+        return self.browser.wait_for_element(
+                self._locator, visible=True, exception=False) is not None
+
+
+class AddSubscriptionView(BaseLoggedInView):
+    breadcrumb = BreadCrumb()
+    table = SatTable(
+            locator='.//table',
+            column_widgets={
+                'Subscription Name': Text('.//a'),
+                'Quantity to Allocate': TextInput(locator='.//input'),
+            }
+    )
+    submit_button = Text("//button[text()='Submit']")
+    cancel_button = Text("//button[text()='Cancel']")
+
+    @property
+    def is_displayed(self):
+        return self.browser.wait_for_element(
+                self.table, visible=True, exception=False) is not None
+
+
+class SubscriptionDetailsView(BaseLoggedInView):
+    breadcrumb = BreadCrumb()
+
+    @View.nested
+    class details(SatTab):
+        provided_products = Text("//h2[text()='Provided Products']/following::ul")
+
+    @View.nested
+    class enabled_products(SatTab):
+        TAB_NAME = "Enabled Products"
+
+    @property
+    def is_displayed(self):
+        return self.browser.wait_for_element(
+                self.breadcrumb, visible=True, exception=False) is not None

--- a/airgun/views/subscription.py
+++ b/airgun/views/subscription.py
@@ -29,7 +29,7 @@ class SubscriptionListView(BaseLoggedInView, SearchableViewMixin):
     manage_manifest_button = Text("//button[text()='Manage Manifest']")
     export_csv_button = Text("//button[text()='Export CSV']")
     delete_button = Text("//button[text()='Delete']")
-    progressbar = ProgressBar('//div[contains(@class, "progress-bar-striped")]')
+    progressbar = ProgressBar('//div[contains(@class,"progress-bar-striped")]')
     confirm_deletion = DeleteSubscriptionConfirmationDialog()
 
     @property
@@ -104,7 +104,8 @@ class SubscriptionDetailsView(BaseLoggedInView):
 
     @View.nested
     class details(SatTab):
-        provided_products = Text("//h2[text()='Provided Products']/following::ul")
+        provided_products = Text(("//h2[text()='Provided Products']"
+                                  "/following::ul"))
 
     @View.nested
     class enabled_products(SatTab):

--- a/airgun/widgets.py
+++ b/airgun/widgets.py
@@ -1246,6 +1246,7 @@ class SatSubscriptionsTable(SatTable):
                 row['Repository Name'] = next(titles)
         return read_rows
 
+
 class SatSubscriptionsViewTable(SatTable):
     """Table used on Red Hat Subscriptions page. It's mostly the same as
     normal table, but when search returns no results, it does display single
@@ -1255,7 +1256,7 @@ class SatSubscriptionsViewTable(SatTable):
     """
     @property
     def has_rows(self):
-        return self.tbody_row.read() != "No subscriptions match your search criteria."
+        return self.tbody_row.read() != "No subscriptions match your search criteria."  # noqa: E501
 
 
 class SatTableWithUnevenStructure(SatTable):

--- a/airgun/widgets.py
+++ b/airgun/widgets.py
@@ -334,12 +334,10 @@ class MultiSelect(GenericLocatorWidget):
 class Search(Widget):
     search_field = TextInput(locator=(
         ".//input[@id='search' or @ng-model='table.searchTerm' or "
-        "contains(@ng-model, 'Filter') or "
-        "starts-with(@id, 'downshift-')]"))
+        "contains(@ng-model, 'Filter')]"))
     search_button = Text(
         ".//button[contains(@type,'submit') or "
-        "@ng-click='table.search(table.searchTerm)' or "
-        "text()='Search']"
+        "@ng-click='table.search(table.searchTerm)']"
     )
 
     def fill(self, value):
@@ -828,11 +826,6 @@ class ConfirmationDialog(Widget):
         do_not_read_this_widget()
 
 
-class DeleteSubscriptionConfirmationDialog(ConfirmationDialog):
-    confirm_dialog = Text(".//button[text()='Delete']")
-    cancel_dialog = Text(".//button[text()='Cancel']")
-
-
 class LCESelector(GenericLocatorWidget):
     """Group of checkboxes that goes in a line one after another. Usually used
     to specify lifecycle environment
@@ -1245,18 +1238,6 @@ class SatSubscriptionsTable(SatTable):
             for row in read_rows:
                 row['Repository Name'] = next(titles)
         return read_rows
-
-
-class SatSubscriptionsViewTable(SatTable):
-    """Table used on Red Hat Subscriptions page. It's mostly the same as
-    normal table, but when search returns no results, it does display single
-    row with message.
-    Not to be confused with SatSubscriptionsTable, which is not used on
-    that page
-    """
-    @property
-    def has_rows(self):
-        return self.tbody_row.read() != "No subscriptions match your search criteria."  # noqa: E501
 
 
 class SatTableWithUnevenStructure(SatTable):

--- a/airgun/widgets.py
+++ b/airgun/widgets.py
@@ -334,10 +334,12 @@ class MultiSelect(GenericLocatorWidget):
 class Search(Widget):
     search_field = TextInput(locator=(
         ".//input[@id='search' or @ng-model='table.searchTerm' or "
-        "contains(@ng-model, 'Filter')]"))
+        "contains(@ng-model, 'Filter') or "
+        "starts-with(@id, 'downshift-')]"))
     search_button = Text(
         ".//button[contains(@type,'submit') or "
-        "@ng-click='table.search(table.searchTerm)']"
+        "@ng-click='table.search(table.searchTerm)' or "
+        "text()='Search']"
     )
 
     def fill(self, value):
@@ -826,6 +828,11 @@ class ConfirmationDialog(Widget):
         do_not_read_this_widget()
 
 
+class DeleteSubscriptionConfirmationDialog(ConfirmationDialog):
+    confirm_dialog = Text(".//button[text()='Delete']")
+    cancel_dialog = Text(".//button[text()='Cancel']")
+
+
 class LCESelector(GenericLocatorWidget):
     """Group of checkboxes that goes in a line one after another. Usually used
     to specify lifecycle environment
@@ -1238,6 +1245,17 @@ class SatSubscriptionsTable(SatTable):
             for row in read_rows:
                 row['Repository Name'] = next(titles)
         return read_rows
+
+class SatSubscriptionsViewTable(SatTable):
+    """Table used on Red Hat Subscriptions page. It's mostly the same as
+    normal table, but when search returns no results, it does display single
+    row with message.
+    Not to be confused with SatSubscriptionsTable, which is not used on
+    that page
+    """
+    @property
+    def has_rows(self):
+        return self.tbody_row.read() != "No subscriptions match your search criteria."
 
 
 class SatTableWithUnevenStructure(SatTable):


### PR DESCRIPTION
I started working on Content -> Subscriptions, but it turned out to be more complex than I initially thought. Airgun side that covers adding and removing manifest is in this push request, but I would like to raise some questions before I move forward:

1. When deleting manifest, at one point there are three buttons labeled "Delete" on one page - one above the main table, one in Manage Manifest popup and one in final confirmation popup. It seems that `DeleteManifestConfirmation.delete_button` refers to some other button than the one it should, which is probably caused by my locators not being specific enough.
How can I ensure that correct button is selected? These popups don't have ids and all look about the same, with only difference being in title. My Xpath expressions start with dot, which is supposed to mean "current element" - but how it is selected? How can I debug how "current element" changes during execution of test and what it points to at any given time?

2. When adding or removing manifest, info flash popup and progress bar appear. My current approach  for waiting until operation finishes will fail, as info popup will be found and script will proceed. Can I somehow wait until element disappear? Or can I wait until popup message of given type / content appears?

3. Should I somehow handle "Entitlements" column in main table? It seems that old robottelo did not, so I can probably skip it. If I should cover it, is there anything in Airgun that I can reuse? That column is kind of special, as each cell only displays value, but changes itself into input on click.

4. When uploading manifest, I need to dismiss flash popups, as they cover UI elements that user might want to access (e.g. to remove manifest). How can I do it from robottelo test code? It seems that `view` is not exposed outside of Airgun. Or is dismissing them from Airgun OK?

5. I would welcome some suggestions what widgets I may use on Subscription details page (URL: `$HOST/subscriptions/$ID/`). This is static page with content that can only be read.