### PR TITLE
Avoid using data-id attr in locators

### DIFF
--- a/airgun/views/domain.py
+++ b/airgun/views/domain.py
@@ -16,8 +16,8 @@ class DomainListView(BaseLoggedInView, SearchableViewMixin):
     table = SatTable(
         locator='table#domains_list',
         column_widgets={
-            'Description': Text(".//a[contains(@data-id, '_edit')]"),
-            'Hosts': Text(".//a[@data-id='aid_hosts']"),
+            'Description': Text("./a"),
+            'Hosts': Text("./a"),
             'Actions': Text(".//a[@data-method='delete']")  # delete button
         }
     )

--- a/airgun/views/puppet_environment.py
+++ b/airgun/views/puppet_environment.py
@@ -27,7 +27,9 @@ class PuppetEnvironmentTableView(BaseLoggedInView, SearchableViewMixin):
     title = Text(".//h1[contains(., 'Puppet Environments')]")
     new = Text(".//a[contains(@href, '/environments/new')]")
     import_environments = Text(
-        ".//a[@data-id='aid_environments_import_environments']")
+        ".//span[contains(@class, 'btn')]"
+        "/a[contains(@href, 'import_environments')]"
+    )
     table = SatTable(
         locator='.//table',
         column_widgets={
@@ -54,7 +56,7 @@ class ImportPuppetEnvironmentView(BaseLoggedInView, SearchableViewMixin):
     updated = Text(".//a[contains(@data-original-title,'updated')]")
     obsolete = Text(".//a[contains(@data-original-title,'obsolete')]")
     update = Text(".//input[@name='commit']")
-    cancel = Text(".//a[@data-id='aid_environments']")
+    cancel = Text(".//a[contains(@class, 'btn') and @href='/environments']")
     table = SatTable(
         locator='.//table',
         column_widgets={


### PR DESCRIPTION
Per https://github.com/theforeman/foreman/pull/5712#issuecomment-409193625 request
```python
pytest tests/foreman/ui_airgun/test_domain.py -k test_positive_create_with_name
============================= test session starts ==============================
platform darwin -- Python 3.6.4, pytest-3.4.0, py-1.5.3, pluggy-0.6.0
shared_function enabled - OFF - scope:  - storage: file
rootdir: /Users/andrii/workspace/robottelo, inifile:
plugins: wait-for-1.0.9, xdist-1.22.0, services-1.2.1, mock-1.6.3, forked-0.2, env-0.6.2
collected 9 items
2018-08-02 20:08:34 - conftest - DEBUG - BZ deselect is disabled in settings


tests/foreman/ui_airgun/test_domain.py .                                 [100%]

============================== 8 tests deselected ==============================
=================== 1 passed, 8 deselected in 39.38 seconds ====================
