### PR TITLE
Add react spinner to ENSURE_PAGE_SAFE

### DIFF
--- a/airgun/browser.py
+++ b/airgun/browser.py
@@ -513,11 +513,16 @@ class AirgunBrowserPlugin(DefaultPlugin):
          spinner = document.getElementById("turbolinks-progress")
          return (spinner === null) ? true : spinner.style["display"] == "none"
         }
+        function reactLoadingInvisible() {
+         react = document.querySelector("#reactRoot .loading-state")
+         return react === null
+        }
         return {
             jquery: jqueryInactive(),
             ajax: ajaxInactive(),
             angular: angularNoRequests(),
             spinner: spinnerInvisible(),
+            react: reactLoadingInvisible(),
             document: document.readyState == "complete",
         }
         '''


### PR DESCRIPTION
Some pages (Subscriptions and Red Hat Repositories for certain, maybe some others as well) use new react-based spinner widget. Our ensure_page_safe function did not take it into account and tried to proceed with automation even if page was not ready yet.

Function looks for element with class `loading-state` inside div with id `reactRoot`. That element is on page only when content is being loaded, i.e. it is removed from source on finish (instead of merely making it invisible). `reactRoot` is not present on other pages at all, so function will always return true on them.