### PR TITLE
Fixed angular pending requests in ENSURE_PAGE_SAFE script

### DIFF
--- a/airgun/browser.py
+++ b/airgun/browser.py
@@ -508,10 +508,16 @@ class AirgunBrowserPlugin(DefaultPlugin):
             Ajax.activeRequestCount < 1
         }
         function angularNoRequests() {
-         return (typeof angular === "undefined" ||
-          typeof angular.element(document).injector() === "undefined") ? true :
-          angular.element(document).injector().get(
-           "$http").pendingRequests.length < 1
+         if (typeof angular === "undefined") {
+           return true
+         } else if (typeof angular.element(
+             document).injector() === "undefined") {
+           injector = angular.injector(["ng"]);
+           return injector.get("$http").pendingRequests.length < 1
+         } else {
+           return angular.element(document).injector().get(
+             "$http").pendingRequests.length < 1
+         }
         }
         function spinnerInvisible() {
          spinner = document.getElementById("turbolinks-progress")


### PR DESCRIPTION
It seems changes in #175 were not enough. Airgun doesn't wait for the page loading in RHAI pages. I tried the solution from https://stackoverflow.com/a/13402028 and now `ENSURE_PAGE_SAFE` works as expected on RHAI pages.