### PR TITLE
Fix host entity

### DIFF
--- a/airgun/entities/host.py
+++ b/airgun/entities/host.py
@@ -1,3 +1,4 @@
+from wait_for import wait_for
 from navmazing import NavigateToSibling
 
 from airgun.entities.base import BaseEntity
@@ -22,8 +23,15 @@ class HostEntity(BaseEntity):
         view = self.navigate_to(self, 'New')
         view.fill(values)
         view.submit.click()
-        view.flash.assert_no_error()
-        view.flash.dismiss()
+        host_view = HostDetailsView(self.browser)
+        wait_for(
+            lambda: host_view.is_displayed is True,
+            timeout=300,
+            delay=10,
+            logger=host_view.logger
+        )
+        host_view.flash.assert_no_error()
+        host_view.flash.dismiss()
 
     def search(self, value):
         """Search for existing host entity"""

--- a/airgun/views/host.py
+++ b/airgun/views/host.py
@@ -137,7 +137,7 @@ class HostCreateView(BaseLoggedInView):
             self.breadcrumb, exception=False)
         return (
                 breadcrumb_loaded
-                and self.breadcrumb.locations[0] == 'Hosts'
+                and self.breadcrumb.locations[0] == 'All Hosts'
                 and self.breadcrumb.read() == 'Create Host'
         )
 
@@ -305,7 +305,7 @@ class HostDetailsView(BaseLoggedInView):
             self.breadcrumb, exception=False)
         return (
                 breadcrumb_loaded
-                and self.breadcrumb.locations[0] == 'Hosts'
+                and self.breadcrumb.locations[0] == 'All Hosts'
                 and self.breadcrumb.read() != 'Create Host'
         )
 
@@ -345,7 +345,7 @@ class HostEditView(HostCreateView):
             self.breadcrumb, exception=False)
         return (
                 breadcrumb_loaded
-                and self.breadcrumb.locations[0] == 'Hosts'
+                and self.breadcrumb.locations[0] == 'All Hosts'
                 and self.breadcrumb.read().starts_with('Edit ')
         )
 


### PR DESCRIPTION
This tests are persistently failing on saucelabs because of latency, as when we submit we are redirected to host details view, semms at that moment we are trying to get the message element, we have to wait untill details page is displayed.  
```
(robottelo) dlezz@dlezz:~/projects/robottelo-fork$ pytest tests/foreman/ui_airgun/test_host.py -v -k "test_positive_create_host_with_parameters or test_positive_delete"
============================================ test session starts =============================================
platform linux -- Python 3.6.6, pytest-3.6.1, py-1.5.4, pluggy-0.6.0 -- /home/dlezz/.pyenv/versions/3.6.6/envs/robottelo/bin/python
cachedir: .pytest_cache
shared_function enabled - ON - scope: ffff - storage: file
rootdir: /home/dlezz/projects/robottelo-fork, inifile:
plugins: wait-for-1.0.9, xdist-1.22.5, services-1.2.1, mock-1.10.0, forked-0.2, cov-2.5.1
collecting 9 items                                                                                           2018-09-20 19:17:25 - conftest - DEBUG - BZ deselect is disabled in settings

collected 9 items / 7 deselected                                                                             

tests/foreman/ui_airgun/test_host.py::test_positive_delete PASSED                                      [ 50%]
tests/foreman/ui_airgun/test_host.py::test_positive_create_host_with_parameters PASSED                 [100%]

================================= 2 passed, 7 deselected in 4833.09 seconds ==================================
```