### PR TITLE
Fix Discovery Rules entity

### DIFF
--- a/airgun/entities/discoveryrule.py
+++ b/airgun/entities/discoveryrule.py
@@ -3,6 +3,7 @@ from navmazing import NavigateToSibling
 from airgun.entities.base import BaseEntity
 from airgun.navigation import NavigateStep, navigator
 from airgun.views.discoveryrule import (
+    ACTION_COLUMN,
     DiscoveryRuleCreateView,
     DiscoveryRuleEditView,
     DiscoveryRulesView,
@@ -29,7 +30,8 @@ class DiscoveryRuleEntity(BaseEntity):
         :param str entity_name: name of the corresponding discovery rule
         """
         view = self.navigate_to(self, 'All')
-        view.table.row(name=entity_name)['Actions'].widget.fill('Delete')
+        view.table.row(
+            name=entity_name)[ACTION_COLUMN].widget.fill('Delete')
         self.browser.handle_alert()
         view.flash.assert_no_error()
         view.flash.dismiss()
@@ -71,7 +73,7 @@ class DiscoveryRuleEntity(BaseEntity):
         :param str entity_name: name of the corresponding discovery rule
         """
         view = self.navigate_to(self, 'All')
-        view.table.row(name=entity_name)['Actions'].widget.fill('Enable')
+        view.table.row(name=entity_name)[ACTION_COLUMN].widget.fill('Enable')
         self.browser.handle_alert()
         view.flash.assert_no_error()
         view.flash.dismiss()
@@ -82,7 +84,7 @@ class DiscoveryRuleEntity(BaseEntity):
         :param str entity_name: name of the corresponding discovery rule
         """
         view = self.navigate_to(self, 'All')
-        view.table.row(name=entity_name)['Actions'].widget.fill('Disable')
+        view.table.row(name=entity_name)[ACTION_COLUMN].widget.fill('Disable')
         self.browser.handle_alert()
         view.flash.assert_no_error()
         view.flash.dismiss()

--- a/airgun/views/discoveryrule.py
+++ b/airgun/views/discoveryrule.py
@@ -1,4 +1,3 @@
-from wait_for import wait_for
 from widgetastic.widget import (
     Checkbox,
     Text,
@@ -63,23 +62,6 @@ class DiscoveryRuleCreateView(BaseLoggedInView):
         hosts_limit = TextInput(id='discovery_rule_max_count')
         priority = TextInput(id='discovery_rule_priority')
         enabled = Checkbox(id='discovery_rule_enabled')
-        AUTOCOMPLETE_LIST = "//ul[contains(@class,'autocomplete')]"
-
-        def fill(self, values):
-            was_change = False
-            if values:
-                search_value = values.pop('search')
-                if search_value is not None:
-                    self.search.fill(search_value)
-                    was_change = True
-                    wait_for(
-                        lambda: self.browser.is_displayed(
-                            self.AUTOCOMPLETE_LIST) is False,
-                        timeout=5,
-                        delay=1,
-                        logger=self.logger
-                    )
-            return super().fill(values) or was_change
 
     @View.nested
     class locations(SatTab):

--- a/airgun/views/discoveryrule.py
+++ b/airgun/views/discoveryrule.py
@@ -1,3 +1,4 @@
+from wait_for import wait_for
 from widgetastic.widget import (
     Checkbox,
     Text,
@@ -17,6 +18,8 @@ from airgun.widgets import (
     SatTable,
 )
 
+ACTION_COLUMN = 6
+
 
 class DiscoveryRulesView(BaseLoggedInView):
     title = Text("//h1[text()='Discovery Rules']")
@@ -25,7 +28,8 @@ class DiscoveryRulesView(BaseLoggedInView):
         './/table',
         column_widgets={
             'Name': Text('./a'),
-            'Actions': ActionsDropdown("./div[contains(@class, 'btn-group')]"),
+            ACTION_COLUMN: ActionsDropdown(
+                "./div[contains(@class, 'btn-group')]"),
         }
     )
 
@@ -59,6 +63,23 @@ class DiscoveryRuleCreateView(BaseLoggedInView):
         hosts_limit = TextInput(id='discovery_rule_max_count')
         priority = TextInput(id='discovery_rule_priority')
         enabled = Checkbox(id='discovery_rule_enabled')
+        AUTOCOMPLETE_LIST = "//ul[contains(@class,'autocomplete')]"
+
+        def fill(self, values):
+            was_change = False
+            if values:
+                search_value = values.pop('search')
+                if search_value is not None:
+                    self.search.fill(search_value)
+                    was_change = True
+                    wait_for(
+                        lambda: self.browser.is_displayed(
+                            self.AUTOCOMPLETE_LIST) is False,
+                        timeout=5,
+                        delay=1,
+                        logger=self.logger
+                    )
+            return super().fill(values) or was_change
 
     @View.nested
     class locations(SatTab):


### PR DESCRIPTION
Actions column name is not present till now and we need this implementation to work properly. 
Autocomplete list was hiding next widgets
```
(robottelo) dlezz@dlezz:~/projects/robottelo-fork$ pytest -v tests/foreman/ui_airgun/test_discoveryrule.py 
============================================ test session starts =============================================
platform linux -- Python 3.6.6, pytest-3.6.1, py-1.5.4, pluggy-0.6.0 -- /home/dlezz/.pyenv/versions/3.6.6/envs/robottelo/bin/python
cachedir: .pytest_cache
shared_function enabled - ON - scope: ffff - storage: file
rootdir: /home/dlezz/projects/robottelo-fork, inifile:
plugins: wait-for-1.0.9, xdist-1.22.5, services-1.2.1, mock-1.10.0, forked-0.2, cov-2.5.1
collecting 9 items                                                                                           2018-10-01 13:35:21 - conftest - DEBUG - BZ deselect is disabled in settings

collected 9 items                                                                                            

tests/foreman/ui_airgun/test_discoveryrule.py::test_positive_create PASSED                             [ 11%]
tests/foreman/ui_airgun/test_discoveryrule.py::test_positive_delete PASSED                             [ 22%]
tests/foreman/ui_airgun/test_discoveryrule.py::test_positive_update PASSED                             [ 33%]
tests/foreman/ui_airgun/test_discoveryrule.py::test_positive_disable_and_enable PASSED                 [ 44%]
tests/foreman/ui_airgun/test_discoveryrule.py::test_positive_create_rule_with_non_admin_user PASSED    [ 55%]
tests/foreman/ui_airgun/test_discoveryrule.py::test_positive_delete_rule_with_non_admin_user PASSED    [ 66%]
tests/foreman/ui_airgun/test_discoveryrule.py::test_positive_view_existing_rule_with_non_admin_user PASSED [ 77%]
tests/foreman/ui_airgun/test_discoveryrule.py::test_negative_delete_rule_with_non_admin_user PASSED    [ 88%]
tests/foreman/ui_airgun/test_discoveryrule.py::test_positive_list_host_based_on_rule_search_query SKIPPED [100%]

=================================== 8 passed, 1 skipped in 289.34 seconds ====================================

```