### PR TITLE
change widgetastic versions

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -19,8 +19,8 @@ setup(
         'navmazing==1.1.4',
         'pytest',
         'wait_for',
-        'widgetastic.core==0.21.6',
-        'widgetastic.patternfly==0.0.33'
+        'widgetastic.core==0.22.0',
+        'widgetastic.patternfly==0.0.38'
     ],
     packages=find_packages(exclude=['tests*']),
     package_data={'': ['LICENSE']},


### PR DESCRIPTION
test hosts entity
```
(robottelo) dlezz@dlezz:~/projects/robottelo-fork$ pytest -v tests/foreman/ui_airgun/test_host.py
=========================================== test session starts ===========================================
platform linux -- Python 3.6.6, pytest-3.6.1, py-1.5.4, pluggy-0.6.0 -- /home/dlezz/.pyenv/versions/3.6.6/envs/robottelo/bin/python
cachedir: .pytest_cache
shared_function enabled - ON - scope: ffff - storage: file
rootdir: /home/dlezz/projects/robottelo-fork, inifile:
plugins: wait-for-1.0.9, xdist-1.22.5, services-1.2.1, mock-1.10.0, forked-0.2, cov-2.5.1
collecting 9 items                                                                                        2018-10-04 10:09:09 - conftest - DEBUG - BZ deselect is disabled in settings

collected 9 items                                                                                         

tests/foreman/ui_airgun/test_host.py::test_positive_create PASSED                                   [ 11%]
tests/foreman/ui_airgun/test_host.py::test_positive_read_from_details_page PASSED                   [ 22%]
tests/foreman/ui_airgun/test_host.py::test_positive_read_from_edit_page PASSED                      [ 33%]
tests/foreman/ui_airgun/test_host.py::test_positive_delete PASSED                                   [ 44%]
tests/foreman/ui_airgun/test_host.py::test_positive_inherit_puppet_env_from_host_group_when_action PASSED [ 55%]
tests/foreman/ui_airgun/test_host.py::test_positive_create_host_with_parameters PASSED              [ 66%]
tests/foreman/ui_airgun/test_host.py::test_positive_assign_taxonomies PASSED                        [ 77%]
tests/foreman/ui_airgun/test_host.py::test_positive_assign_compliance_policy PASSED                 [ 88%]
tests/foreman/ui_airgun/test_host.py::test_positive_export PASSED                                   [100%]

======================================= 9 passed in 886.48 seconds ========================================
```
test discovery rules entity (Saucelabs)
```
(robottelo) dlezz@dlezz:~/projects/robottelo-fork$ pytest -v tests/foreman/ui_airgun/test_discoveryrule.py
=========================================== test session starts ===========================================
platform linux -- Python 3.6.6, pytest-3.6.1, py-1.5.4, pluggy-0.6.0 -- /home/dlezz/.pyenv/versions/3.6.6/envs/robottelo/bin/python
cachedir: .pytest_cache
shared_function enabled - ON - scope: ffff - storage: file
rootdir: /home/dlezz/projects/robottelo-fork, inifile:
plugins: wait-for-1.0.9, xdist-1.22.5, services-1.2.1, mock-1.10.0, forked-0.2, cov-2.5.1
collecting 9 items                                                                                        2018-10-04 10:44:08 - conftest - DEBUG - BZ deselect is disabled in settings

collected 9 items                                                                                         

tests/foreman/ui_airgun/test_discoveryrule.py::test_positive_create PASSED                          [ 11%]
tests/foreman/ui_airgun/test_discoveryrule.py::test_positive_delete PASSED                          [ 22%]
tests/foreman/ui_airgun/test_discoveryrule.py::test_positive_update PASSED                          [ 33%]
tests/foreman/ui_airgun/test_discoveryrule.py::test_positive_disable_and_enable PASSED              [ 44%]
tests/foreman/ui_airgun/test_discoveryrule.py::test_positive_create_rule_with_non_admin_user PASSED [ 55%]
tests/foreman/ui_airgun/test_discoveryrule.py::test_positive_delete_rule_with_non_admin_user PASSED [ 66%]
tests/foreman/ui_airgun/test_discoveryrule.py::test_positive_view_existing_rule_with_non_admin_user PASSED [ 77%]
tests/foreman/ui_airgun/test_discoveryrule.py::test_negative_delete_rule_with_non_admin_user PASSED [ 88%]
tests/foreman/ui_airgun/test_discoveryrule.py::test_positive_list_host_based_on_rule_search_query SKIPPED [100%]

================================= 8 passed, 1 skipped in 4326.51 seconds ==================================

```



