### PR TITLE
Fix container entity

### DIFF
--- a/airgun/widgets.py
+++ b/airgun/widgets.py
@@ -334,7 +334,7 @@ class MultiSelect(GenericLocatorWidget):
 class Search(Widget):
     search_field = TextInput(locator=(
         ".//input[@id='search' or @ng-model='table.searchTerm' or "
-        "contains(@ng-model, 'Filter')]"))
+        "contains(@ng-model, 'Filter') or @type='search']"))
     search_button = Text(
         ".//button[contains(@type,'submit') or "
         "@ng-click='table.search(table.searchTerm)']"


### PR DESCRIPTION
Tests failing on search with
```
selenium.common.exceptions.NoSuchElementException: Message: Could not find an element ".//input[@id='search' or @ng-model='table.searchTerm' or contains(@ng-model, 'Filter')]"
```

```
(robottelo) dlezz@dlezz:~/projects/robottelo-fork$ pytest -v tests/foreman/ui_airgun/test_container.py
============================================ test session starts =============================================
platform linux -- Python 3.6.6, pytest-3.6.1, py-1.5.4, pluggy-0.6.0 -- /home/dlezz/.pyenv/versions/3.6.6/envs/robottelo/bin/python
cachedir: .pytest_cache
shared_function enabled - ON - scope: ffff - storage: file
rootdir: /home/dlezz/projects/robottelo-fork, inifile:
plugins: wait-for-1.0.9, xdist-1.22.5, services-1.3.0, mock-1.10.0, forked-0.2, cov-2.5.1
collecting 1 item                                                                                            2018-10-08 16:58:05 - conftest - DEBUG - BZ deselect is disabled in settings

collected 1 item                                                                                             

tests/foreman/ui_airgun/test_container.py::test_positive_create_with_compresource PASSED               [100%]

========================================= 1 passed in 90.90 seconds ==========================================
```