### PR TITLE
Fix oscapcontent entity

### DIFF
--- a/airgun/browser.py
+++ b/airgun/browser.py
@@ -569,7 +569,10 @@ class AirgunBrowserPlugin(DefaultPlugin):
         """Invoked after clicking on an element. Ensure page is fully loaded
         before proceeding further.
         """
-        self.ensure_page_safe()
+        # plugin.ensure_page_safe() is invoked from browser click.
+        # we should not invoke it a second time, this can conflict with
+        # ignore_ajax=True usage from browser click
+        pass
 
 
 class AirgunBrowser(Browser):

--- a/airgun/entities/oscapcontent.py
+++ b/airgun/entities/oscapcontent.py
@@ -19,7 +19,8 @@ class OSCAPContentEntity(BaseEntity):
         """
         view = self.navigate_to(self, 'New')
         view.fill(values)
-        view.submit.click()
+        self.browser.click(view.submit, ignore_ajax=True)
+        self.browser.plugin.ensure_page_safe(timeout='60s')
         view.flash.assert_no_error()
         view.flash.dismiss()
 

--- a/airgun/views/oscapcontent.py
+++ b/airgun/views/oscapcontent.py
@@ -54,6 +54,7 @@ class SCAPContentCreateView(BaseLoggedInView):
     class organizations(SatTab):
         resources = MultiSelect(id='ms-scap_content_organization_ids')
 
+    @property
     def is_displayed(self):
         return self.browser.wait_for_element(
             self.create_form, exception=False) is not None

--- a/airgun/widgets.py
+++ b/airgun/widgets.py
@@ -1,9 +1,10 @@
 from jsmin import jsmin
 from wait_for import wait_for
 from widgetastic.exceptions import (
-    NoSuchElementException, WidgetOperationFailed)
-
-
+    NoSuchElementException,
+    WidgetOperationFailed,
+)
+from widgetastic.utils import retry_stale_element
 from widgetastic.widget import (
     Checkbox,
     do_not_read_this_widget,
@@ -477,6 +478,14 @@ class SatFlashMessages(FlashMessages):
         except NoSuchElementException:
             pass
         return result
+
+    @retry_stale_element
+    def assert_no_error(self):
+        return super().assert_no_error()
+
+    @retry_stale_element
+    def dismiss(self):
+        return super().assert_no_error()
 
 
 class SatFlashMessage(FlashMessage):


### PR DESCRIPTION
run many times locally and on Saucelabs , very stable now with this PR
```
(robottelo) dlezz@dlezz:~/projects/robottelo-fork$ pytest -v tests/foreman/ui_airgun/test_oscapcontent.py::test_positive_update tests/foreman/ui_airgun/test_oscappolicy.py::test_positive_check_dashboard tests/foreman/ui_airgun/test_oscaptailoringfile.py::test_positive_associate_tailoring_file_with_scap
============================================ test session starts =============================================
platform linux -- Python 3.6.6, pytest-3.6.1, py-1.5.4, pluggy-0.6.0 -- /home/dlezz/.pyenv/versions/3.6.6/envs/robottelo/bin/python
cachedir: .pytest_cache
shared_function enabled - ON - scope: ffff - storage: file
rootdir: /home/dlezz/projects/robottelo-fork, inifile:
plugins: wait-for-1.0.9, xdist-1.22.5, services-1.3.0, mock-1.10.0, forked-0.2, cov-2.5.1
collecting 3 items                                                                                           2018-10-10 12:44:55 - conftest - DEBUG - BZ deselect is disabled in settings

collected 3 items                                                                                            

tests/foreman/ui_airgun/test_oscapcontent.py::test_positive_update PASSED                              [ 33%]
tests/foreman/ui_airgun/test_oscappolicy.py::test_positive_check_dashboard PASSED                      [ 66%]
tests/foreman/ui_airgun/test_oscaptailoringfile.py::test_positive_associate_tailoring_file_with_scap PASSED [100%]

======================================== 3 passed in 3487.37 seconds =========================================
```