### PR TITLE
Fix AddRemoveSubscriptionsView

### DIFF
--- a/airgun/views/contentviewfilter.py
+++ b/airgun/views/contentviewfilter.py
@@ -307,7 +307,7 @@ class EditYumFilterView(BaseLoggedInView):
             :param dict optional filters: dictionary containing widget names
                 and values to set (like with regular `fill()`)
             """
-            return self.AddTab.fill(errata_id, filters)
+            return self.add_tab.fill(errata_id, filters)
 
         def read(self):
             """Read values from tabs depending on errata filter type (by id or
@@ -316,8 +316,8 @@ class EditYumFilterView(BaseLoggedInView):
             if self.erratum_date_range.is_displayed:
                 return {'erratum_date_range': self.erratum_date_range.read()}
             return {
-                'assigned': self.ListRemoveTab.read(),
-                'unassigned': self.AddTab.read(),
+                'assigned': self.list_remove_tab.read(),
+                'unassigned': self.add_tab.read(),
             }
 
     @content_tabs.register(

--- a/airgun/views/contentviewfilter.py
+++ b/airgun/views/contentviewfilter.py
@@ -11,6 +11,7 @@ from widgetastic_patternfly import BreadCrumb, Button
 
 from airgun.views.common import (
     AddRemoveResourcesView,
+    AddTab,
     BaseLoggedInView,
     SatSecondaryTab,
     SearchableViewMixin,
@@ -21,7 +22,6 @@ from airgun.widgets import (
     RadioGroup,
     SatSelect,
     SatTable,
-    Search,
 )
 
 ACTIONS_COLUMN = 4
@@ -223,8 +223,7 @@ class EditYumFilterView(BaseLoggedInView):
         """
 
         @View.nested
-        class AddTab(SatSecondaryTab):
-            TAB_NAME = 'Add'
+        class add_tab(AddTab):
             security = Checkbox(locator=".//input[@ng-model='types.security']")
             enhancement = Checkbox(
                 locator=".//input[@ng-model='types.enhancement']")
@@ -236,14 +235,8 @@ class EditYumFilterView(BaseLoggedInView):
                 locator=".//input[@ng-model='rule.start_date']")
             end_date = DatePickerInput(
                 locator=".//input[@ng-model='rule.end_date']")
-            searchbox = Search()
-            add_button = Text(
-                './/div[@data-block="list-actions"]'
-                '//button[contains(@ng-click, "add")]'
-            )
             select_all = Checkbox(
                 locator=".//table//th[@class='row-select']/input")
-            table = SatTable(locator=".//table")
 
             def search(self, query=None, filters=None):
                 """Custom search which supports all errata filters.
@@ -281,9 +274,6 @@ class EditYumFilterView(BaseLoggedInView):
 
             def fill(self, errata_id=None, filters=None):
                 self.add(errata_id, filters)
-
-            def read(self):
-                return self.table.read()
 
         @View.nested
         class erratum_date_range(SatSecondaryTab):


### PR DESCRIPTION
Fixes regression in AddRemoveSubscriptionsView introduced by #211 (it was not refactored according to AddRemoveResourcesView changes)
Test results:
```python
pytest -v tests/foreman/ui_airgun/test_activationkey.py -k test_positive_add_rh_product
============================= test session starts ==============================
platform darwin -- Python 3.6.4, pytest-3.6.1, py-1.6.0, pluggy-0.6.0 -- /Users/andrii/workspace/py3a/bin/python3.6
cachedir: .pytest_cache
shared_function enabled - OFF - scope:  - storage: file
rootdir: /Users/andrii/workspace/robottelo, inifile:
plugins: xdist-1.22.0, services-1.2.1, mock-1.10.0, forked-0.2, env-0.6.2
collecting 23 items                                                            2018-10-18 14:10:28 - conftest - DEBUG - BZ deselect is disabled in settings

collected 23 items / 22 deselected

tests/foreman/ui_airgun/test_activationkey.py::test_positive_add_rh_product PASSED [100%]

================== 1 passed, 22 deselected in 571.30 seconds ===================
pytest -v tests/foreman/ui_airgun/test_activationkey.py -k test_positive_create_with_host_collection
============================= test session starts ==============================
platform darwin -- Python 3.6.4, pytest-3.6.1, py-1.6.0, pluggy-0.6.0 -- /Users/andrii/workspace/py3a/bin/python3.6
cachedir: .pytest_cache
shared_function enabled - OFF - scope:  - storage: file
rootdir: /Users/andrii/workspace/robottelo, inifile:
plugins: xdist-1.22.0, services-1.2.1, mock-1.10.0, forked-0.2, env-0.6.2
collecting 23 items                                                            2018-10-18 13:57:29 - conftest - DEBUG - BZ deselect is disabled in settings

collected 23 items / 22 deselected

tests/foreman/ui_airgun/test_activationkey.py::test_positive_create_with_host_collection PASSED [100%]

================== 1 passed, 22 deselected in 129.42 seconds ===================
```