### PR TITLE
Fix 6.5 menu Nav and alert text locators

### DIFF
--- a/airgun/views/common.py
+++ b/airgun/views/common.py
@@ -28,7 +28,8 @@ from airgun.widgets import (
 
 
 class BaseLoggedInView(View):
-    menu = SatVerticalNavigation('.//div[@id="vertical-nav"]/ul')
+    menu = SatVerticalNavigation(
+        './/div[@id="vertical-nav" or contains(@class, "nav-pf-vertical")]/ul')
     taxonomies = ContextSelector()
     flash = SatFlashMessages(
         locator='//div[@class="toast-notifications-list-pf"]')

--- a/airgun/widgets.py
+++ b/airgun/widgets.py
@@ -590,7 +590,7 @@ class SatFlashMessage(FlashMessage):
 
     @property
     def text(self):
-        return self.browser.text('./span/span', parent=self)
+        return self.browser.text('./span[text()]', parent=self)
 
 
 class ValidationErrors(Widget):


### PR DESCRIPTION
```bash
(robottelo) dlezz@dlezz:~/projects/robottelo-fork$ pytest -v tests/foreman/ui_airgun/test_contentview.py::test_positive_end_to_end
============================================= test session starts =============================================
platform linux -- Python 3.6.6, pytest-3.6.1, py-1.5.4, pluggy-0.6.0 -- /home/dlezz/.pyenv/versions/3.6.6/envs/robottelo/bin/python
cachedir: .pytest_cache
shared_function enabled - ON - scope: ffff - storage: file
rootdir: /home/dlezz/projects/robottelo-fork, inifile:
plugins: wait-for-1.0.9, xdist-1.22.5, services-1.3.0, mock-1.10.0, forked-0.2, cov-2.5.1
collecting 1 item                                                                                             2018-11-08 17:51:35 - conftest - DEBUG - BZ deselect is disabled in settings

collected 1 item                                                                                              

tests/foreman/ui_airgun/test_contentview.py::test_positive_end_to_end PASSED                            [100%]

========================================= 1 passed in 127.34 seconds ==========================================
```
