### PR TITLE
Discovery Rule column PR finally get into downstream

### DIFF
--- a/airgun/entities/discoveryrule.py
+++ b/airgun/entities/discoveryrule.py
@@ -4,7 +4,6 @@ from airgun.entities.base import BaseEntity
 from airgun.navigation import NavigateStep, navigator
 from airgun.views.discoveredhosts import DiscoveredHostsView
 from airgun.views.discoveryrule import (
-    ACTION_COLUMN,
     DiscoveryRuleCreateView,
     DiscoveryRuleEditView,
     DiscoveryRulesView,
@@ -33,7 +32,7 @@ class DiscoveryRuleEntity(BaseEntity):
         """
         view = self.navigate_to(self, 'All')
         view.table.row(
-            name=entity_name)[ACTION_COLUMN].widget.fill('Delete')
+            name=entity_name)['Actions'].widget.fill('Delete')
         self.browser.handle_alert()
         view.flash.assert_no_error()
         view.flash.dismiss()
@@ -75,7 +74,7 @@ class DiscoveryRuleEntity(BaseEntity):
         :param str entity_name: name of the corresponding discovery rule
         """
         view = self.navigate_to(self, 'All')
-        view.table.row(name=entity_name)[ACTION_COLUMN].widget.fill('Enable')
+        view.table.row(name=entity_name)['Actions'].widget.fill('Enable')
         self.browser.handle_alert()
         view.flash.assert_no_error()
         view.flash.dismiss()
@@ -86,7 +85,7 @@ class DiscoveryRuleEntity(BaseEntity):
         :param str entity_name: name of the corresponding discovery rule
         """
         view = self.navigate_to(self, 'All')
-        view.table.row(name=entity_name)[ACTION_COLUMN].widget.fill('Disable')
+        view.table.row(name=entity_name)['Actions'].widget.fill('Disable')
         self.browser.handle_alert()
         view.flash.assert_no_error()
         view.flash.dismiss()
@@ -185,5 +184,5 @@ class DiscoveredRuleHosts(NavigateStep):
             raise ValueError('Please provide a valid action name.'
                              ' action_name: "{0}" not found.')
         entity_name = kwargs.get('entity_name')
-        self.parent.table.row(name=entity_name)[ACTION_COLUMN].widget.fill(
+        self.parent.table.row(name=entity_name)['Actions'].widget.fill(
             action_name)

--- a/airgun/views/discoveryrule.py
+++ b/airgun/views/discoveryrule.py
@@ -17,8 +17,6 @@ from airgun.widgets import (
     SatTable,
 )
 
-ACTION_COLUMN = 6
-
 
 class DiscoveryRulesView(BaseLoggedInView):
     title = Text("//h1[text()='Discovery Rules']")
@@ -27,7 +25,7 @@ class DiscoveryRulesView(BaseLoggedInView):
         './/table',
         column_widgets={
             'Name': Text('./a'),
-            ACTION_COLUMN: ActionsDropdown(
+            'Actions': ActionsDropdown(
                 "./div[contains(@class, 'btn-group')]"),
         }
     )


### PR DESCRIPTION
```
py.test -v /home/ashtayer/Desktop/robottelo/tests/foreman/ui_airgun/test_discoveryrule.py -k delete_rule
==================================================================================== test session starts =====================================================================================
platform linux -- Python 3.6.5, pytest-3.4.0, py-1.5.3, pluggy-0.6.0 -- /usr/bin/python3.6
cachedir: .pytest_cache
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/ashtayer/Desktop/robottelo, inifile:
plugins: services-1.2.1, mock-1.6.3
collected 5 items                                                                                                                                                                            
2018-11-27 17:49:34 - conftest - DEBUG - BZ deselect is disabled in settings


tests/foreman/ui_airgun/test_discoveryrule.py::test_positive_delete_rule_with_non_admin_user PASSED                                                                                    [ 50%]
tests/foreman/ui_airgun/test_discoveryrule.py::test_negative_delete_rule_with_non_admin_user PASSED                                                                                    [100%]

===================================================================================== 3 tests deselected =====================================================================================
========================================================================== 2 passed, 3 deselected in 61.71 seconds ==========================================================================
```