### PR TITLE
[6.4.z] Fixed issues with content view filter rule table (#253)

### DIFF
--- a/airgun/views/contentviewfilter.py
+++ b/airgun/views/contentviewfilter.py
@@ -3,6 +3,7 @@ from widgetastic.widget import (
     ConditionalSwitchableView,
     ParametrizedLocator,
     Select,
+    Table,
     Text,
     TextInput,
     View,
@@ -203,7 +204,7 @@ class EditYumFilterView(BaseLoggedInView):
             )
             add_rule = Text(".//button[@ng-click='addRule()']")
             remove_rule = Text(".//button[@ng-click='removeRules(filter)']")
-            table = SatTable(
+            table = Table(
                 locator='//table',
                 column_widgets={
                     0: Checkbox(locator=".//input[@type='checkbox']"),

--- a/airgun/widgets.py
+++ b/airgun/widgets.py
@@ -1208,7 +1208,9 @@ class ACEEditor(Widget):
 
 
 class SatTable(Table):
-    """Satellite version of table. Main difference - in case it's empty, there
+    """DEPRECATED. Please use :class:`widgetastic.widget.Table` instead.
+
+    Satellite version of table. Main difference - in case it's empty, there
     might be just 1 column with appropriate message in table body or no columns
     and rows at all.
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -38,6 +38,7 @@ exclude_patterns = ['_build']
 nitpicky = True
 nitpick_ignore = [
     ('py:class', 'widgetastic.browser.Browser'),
+    ('py:class', 'widgetastic.widget.Table'),
     ('py:class', 'widgetastic.widget.View'),
     ('py:class', 'navmazing.Navigate'),
     ('py:class', 'navmazing.NavigateStep'),

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ setup(
         'navmazing==1.1.4',
         'pytest',
         'wait_for',
-        'widgetastic.core==0.30.0',
+        'widgetastic.core==0.30.3',
         'widgetastic.patternfly==0.0.38'
     ],
     packages=find_packages(exclude=['tests*']),


### PR DESCRIPTION
* Fixed issues with content view filter rule table

* added widgetastic's table reference to doc exceptions list

* resolves issues with 6.4.z content credential tests (closes SatelliteQE/robottelo#6531)

Test results:
```python
pytest tests/foreman/ui_airgun/test_contentcredential.py
============================== test session starts ===============================
platform darwin -- Python 3.6.4, pytest-3.6.1, py-1.6.0, pluggy-0.6.0
shared_function enabled - OFF - scope:  - storage: file
rootdir: /Users/andrii/workspace/robottelo, inifile:
plugins: xdist-1.22.0, services-1.2.1, mock-1.10.0, forked-0.2, env-0.6.2
collecting 16 items                                                              2018-12-10 16:21:48 - conftest - DEBUG - BZ deselect is disabled in settings

collected 16 items

tests/foreman/ui_airgun/test_contentcredential.py ................         [100%]

========================== 16 passed in 1138.06 seconds ==========================
pytest -v tests/foreman/ui_airgun/test_contentview.py -k 'test_positive_add_package_filter or test_positive_update_inclusive_filter_package_version or test_positive_update_filter_affected_repos'
============================== test session starts ===============================
platform darwin -- Python 3.6.4, pytest-3.6.1, py-1.6.0, pluggy-0.6.0 -- /Users/andrii/workspace/py3a/bin/python3.6
cachedir: .pytest_cache
shared_function enabled - OFF - scope:  - storage: file
rootdir: /Users/andrii/workspace/robottelo, inifile:
plugins: xdist-1.22.0, services-1.2.1, mock-1.10.0, forked-0.2, env-0.6.2
collecting 39 items                                                              2018-12-10 17:20:47 - conftest - DEBUG - BZ deselect is disabled in settings

collected 39 items / 36 deselected

tests/foreman/ui_airgun/test_contentview.py::test_positive_add_package_filter PASSED [ 33%]
tests/foreman/ui_airgun/test_contentview.py::test_positive_update_inclusive_filter_package_version PASSED [ 66%]
tests/foreman/ui_airgun/test_contentview.py::test_positive_update_filter_affected_repos PASSED [100%]

=================== 3 passed, 36 deselected in 1332.15 seconds ===================
```