### PR TITLE
Fixes chrome_options warning

### DIFF
--- a/airgun/browser.py
+++ b/airgun/browser.py
@@ -173,7 +173,7 @@ class SeleniumBrowserFactory(object):
             prefs = {'download.prompt_for_download': False}
             options.add_experimental_option("prefs", prefs)
             options.add_argument('disable-web-security')
-            kwargs.update({'chrome_options': options})
+            kwargs.update({'options': options})
             self._webdriver = webdriver.Chrome(**kwargs)
         elif self.browser == 'firefox':
             if binary:


### PR DESCRIPTION
before change
```
(robottelo) dlezz@dlezz:~/projects/robottelo-fork$ pytest -v tests/foreman/ui_airgun/test_product.py::test_positive_end_to_end 
============================================ test session starts =============================================
platform linux -- Python 3.6.6, pytest-4.0.1, py-1.5.4, pluggy-0.8.0 -- /home/dlezz/.pyenv/versions/3.6.6/envs/robottelo/bin/python
cachedir: .pytest_cache
shared_function enabled - ON - scope: ffff - storage: redis
rootdir: /home/dlezz/projects/robottelo-fork, inifile:
plugins: wait-for-1.0.9, xdist-1.22.5, services-1.3.1, mock-1.10.0, forked-0.2, cov-2.5.1
collecting ... 2018-12-12 12:29:38 - conftest - DEBUG - BZ deselect is disabled in settings

collected 1 item                                                                                             

tests/foreman/ui_airgun/test_product.py::test_positive_end_to_end PASSED                               [100%]

============================================== warnings summary ==============================================
tests/foreman/ui_airgun/test_product.py::test_positive_end_to_end
  /home/dlezz/.pyenv/versions/3.6.6/envs/robottelo/lib/python3.6/site-packages/selenium/webdriver/chrome/webdriver.py:50: DeprecationWarning: use options instead of chrome_options
    warnings.warn('use options instead of chrome_options', DeprecationWarning)
  /home/dlezz/.pyenv/versions/3.6.6/envs/robottelo/lib/python3.6/site-packages/widgetastic/widget/select.py:133: DeprecationWarning: The unescape method is deprecated and will be removed in 3.5, use html.unescape() instead.
    for option
  /home/dlezz/.pyenv/versions/3.6.6/envs/robottelo/lib/python3.6/site-packages/widgetastic/widget/select.py:133: DeprecationWarning: The unescape method is deprecated and will be removed in 3.5, use html.unescape() instead.
    for option
  /home/dlezz/.pyenv/versions/3.6.6/envs/robottelo/lib/python3.6/site-packages/widgetastic/widget/select.py:133: DeprecationWarning: The unescape method is deprecated and will be removed in 3.5, use html.unescape() instead.
    for option
  /home/dlezz/.pyenv/versions/3.6.6/envs/robottelo/lib/python3.6/site-packages/widgetastic/widget/select.py:133: DeprecationWarning: The unescape method is deprecated and will be removed in 3.5, use html.unescape() instead.
    for option

-- Docs: https://docs.pytest.org/en/latest/warnings.html
=================================== 1 passed, 5 warnings in 105.63 seconds ===================================
(robottelo) dlezz@dlezz:~/projects/robottelo-fork$ 
```

after change:

```
(robottelo) dlezz@dlezz:~/projects/robottelo-fork$ pytest -v tests/foreman/ui_airgun/test_product.py::test_positive_end_to_end 
============================================ test session starts =============================================
platform linux -- Python 3.6.6, pytest-4.0.1, py-1.5.4, pluggy-0.8.0 -- /home/dlezz/.pyenv/versions/3.6.6/envs/robottelo/bin/python
cachedir: .pytest_cache
shared_function enabled - ON - scope: ffff - storage: redis
rootdir: /home/dlezz/projects/robottelo-fork, inifile:
plugins: wait-for-1.0.9, xdist-1.22.5, services-1.3.1, mock-1.10.0, forked-0.2, cov-2.5.1
collecting ... 2018-12-12 12:31:54 - conftest - DEBUG - BZ deselect is disabled in settings

collected 1 item                                                                                             

tests/foreman/ui_airgun/test_product.py::test_positive_end_to_end PASSED                               [100%]

============================================== warnings summary ==============================================
tests/foreman/ui_airgun/test_product.py::test_positive_end_to_end
  /home/dlezz/.pyenv/versions/3.6.6/envs/robottelo/lib/python3.6/site-packages/widgetastic/widget/select.py:133: DeprecationWarning: The unescape method is deprecated and will be removed in 3.5, use html.unescape() instead.
    for option
  /home/dlezz/.pyenv/versions/3.6.6/envs/robottelo/lib/python3.6/site-packages/widgetastic/widget/select.py:133: DeprecationWarning: The unescape method is deprecated and will be removed in 3.5, use html.unescape() instead.
    for option
  /home/dlezz/.pyenv/versions/3.6.6/envs/robottelo/lib/python3.6/site-packages/widgetastic/widget/select.py:133: DeprecationWarning: The unescape method is deprecated and will be removed in 3.5, use html.unescape() instead.
    for option
  /home/dlezz/.pyenv/versions/3.6.6/envs/robottelo/lib/python3.6/site-packages/widgetastic/widget/select.py:133: DeprecationWarning: The unescape method is deprecated and will be removed in 3.5, use html.unescape() instead.
    for option

-- Docs: https://docs.pytest.org/en/latest/warnings.html
=================================== 1 passed, 4 warnings in 89.16 seconds ====================================
```
with saucelabs
```
(robottelo) dlezz@dlezz:~/projects/robottelo-fork$ pytest -v tests/foreman/ui_airgun/test_product.py::test_positive_end_to_end 
============================================ test session starts =============================================
platform linux -- Python 3.6.6, pytest-4.0.1, py-1.5.4, pluggy-0.8.0 -- /home/dlezz/.pyenv/versions/3.6.6/envs/robottelo/bin/python
cachedir: .pytest_cache
shared_function enabled - ON - scope: ffff - storage: redis
rootdir: /home/dlezz/projects/robottelo-fork, inifile:
plugins: wait-for-1.0.9, xdist-1.22.5, services-1.3.1, mock-1.10.0, forked-0.2, cov-2.5.1
collecting ... 2018-12-12 12:41:28 - conftest - DEBUG - BZ deselect is disabled in settings

collected 1 item                                                                                             

tests/foreman/ui_airgun/test_product.py::test_positive_end_to_end PASSED                               [100%]

============================================== warnings summary ==============================================
tests/foreman/ui_airgun/test_product.py::test_positive_end_to_end
  /home/dlezz/.pyenv/versions/3.6.6/envs/robottelo/lib/python3.6/site-packages/widgetastic/widget/select.py:133: DeprecationWarning: The unescape method is deprecated and will be removed in 3.5, use html.unescape() instead.
    for option
  /home/dlezz/.pyenv/versions/3.6.6/envs/robottelo/lib/python3.6/site-packages/widgetastic/widget/select.py:133: DeprecationWarning: The unescape method is deprecated and will be removed in 3.5, use html.unescape() instead.
    for option
  /home/dlezz/.pyenv/versions/3.6.6/envs/robottelo/lib/python3.6/site-packages/widgetastic/widget/select.py:133: DeprecationWarning: The unescape method is deprecated and will be removed in 3.5, use html.unescape() instead.
    for option
  /home/dlezz/.pyenv/versions/3.6.6/envs/robottelo/lib/python3.6/site-packages/widgetastic/widget/select.py:133: DeprecationWarning: The unescape method is deprecated and will be removed in 3.5, use html.unescape() instead.
    for option

-- Docs: https://docs.pytest.org/en/latest/warnings.html
================================== 1 passed, 4 warnings in 1764.07 seconds ===================================
(robottelo) dlezz@dlezz:~/projects/robottelo-fork$ 

```
The unescape warning must be handled in widgetastic

