### PR TITLE
Adding Support to create sync plan from product page for some test

### DIFF
--- a/airgun/entities/product.py
+++ b/airgun/entities/product.py
@@ -9,15 +9,27 @@ from airgun.views.product import (
     ProductRepoDiscoveryView,
     ProductTaskDetailsView,
     ProductsTableView,
+    ProductSyncPlanView,
 )
 
 
 class ProductEntity(BaseEntity):
 
-    def create(self, values):
-        """Creates new product from UI"""
+    def create(self, values, sync_plan_values=None):
+        """Creates new product from UI.
+
+        :param sync_plan_values: dict with values for creating sync_plan from
+         product create page
+        """
         view = self.navigate_to(self, 'New')
         view.fill(values)
+        if sync_plan_values:
+            view.create_sync_plan.click()
+            sync_plan_create_view = ProductSyncPlanView(self.browser)
+            sync_plan_create_view.fill(sync_plan_values)
+            sync_plan_create_view.submit.click()
+            view.flash.assert_no_error()
+            view.flash.dismiss()
         view.submit.click()
 
     def delete(self, entity_name):

--- a/airgun/views/product.py
+++ b/airgun/views/product.py
@@ -16,6 +16,7 @@ from airgun.views.common import (
     SearchableViewMixin,
     TaskDetailsView,
 )
+from airgun.views.syncplan import SyncPlanCreateView
 from airgun.widgets import (
     ActionsDropdown,
     ConfirmationDialog,
@@ -80,6 +81,7 @@ class ProductCreateView(BaseLoggedInView):
     ssl_client_cert = Select(id='ssl_client_cert_id')
     ssl_client_key = Select(id='ssl_client_key_id')
     sync_plan = Select(id='sync_plan_id')
+    create_sync_plan = Text("//a[contains(@ng-click, 'openSyncPlanModal')]")
     description = TextInput(id='description')
     submit = Text("//button[contains(@ng-click, 'handleSave')]")
 
@@ -225,3 +227,13 @@ class ProductTaskDetailsView(TaskDetailsView):
                 and self.breadcrumb.locations[2] == 'Tasks'
                 and len(self.breadcrumb.locations) > 3
         )
+
+
+class ProductSyncPlanView(SyncPlanCreateView):
+    title = Text("//h4[contains(., 'New Sync Plan')]")
+    submit = Text("//button[contains(@ng-click, 'ok(syncPlan)')]")
+
+    @property
+    def is_displayed(self):
+        return self.browser.wait_for_element(
+            self.title, exception=False) is not None


### PR DESCRIPTION
**Objective** 
1. Creating and checking whether sync plan create set from product create page 
2. As this really something only can check from UI only, depending test will be added soon in Robottelo   

**Test Result**
https://github.com/SatelliteQE/robottelo/pull/6556#event-2031042920 