### PR TITLE
Added 'Packages' tab to Errata details view

### DIFF
--- a/airgun/views/errata.py
+++ b/airgun/views/errata.py
@@ -86,8 +86,6 @@ class ErrataDetailsView(BaseLoggedInView):
             ".//h3[contains(., 'Solution')]"
             "/following-sibling::p[contains(@class, 'info-paragraph')][1]"
         )
-        affected_packages = ItemsList(
-            ".//h3[contains(., 'Affected Packages')]/following-sibling::ul")
 
     @View.nested
     class content_hosts(SatTab):
@@ -145,6 +143,13 @@ class ErrataDetailsView(BaseLoggedInView):
                 self.cv_filter.fill(cv)
             self.searchbox.search(query)
             return self.table.read()
+
+    @View.nested
+    class packages(SatTab):
+        independent_packages = ItemsList(
+            ".//h3[contains(., 'Independent Packages')]/following-sibling::ul")
+        module_stream_packages = ItemsList(
+            ".//h3[contains(., 'Module Stream Packages')]/following-sibling::ul")
 
     @property
     def is_displayed(self):


### PR DESCRIPTION
Affected packages were moved to a separate tab:
![image](https://user-images.githubusercontent.com/11719030/49938845-be632500-fee3-11e8-80c5-9d0f51e2622b.png)
