### PR TITLE
Implement read widgets by names in Base view

### DIFF
--- a/airgun/entities/contentview.py
+++ b/airgun/entities/contentview.py
@@ -50,10 +50,10 @@ class ContentViewEntity(BaseEntity):
         view = self.navigate_to(self, 'All')
         return view.search(value)
 
-    def read(self, entity_name):
-        """Read content view values"""
+    def read(self, entity_name, widget_names=None):
+        """Read content view values, optionally only the widgets in widget_names will be read."""
         view = self.navigate_to(self, 'Edit', entity_name=entity_name)
-        return view.read()
+        return view.read(widget_names=widget_names)
 
     def update(self, entity_name, values):
         """Update existing content view"""

--- a/airgun/entities/host.py
+++ b/airgun/entities/host.py
@@ -38,10 +38,12 @@ class HostEntity(BaseEntity):
         view = self.navigate_to(self, 'All')
         return view.search(value)
 
-    def get_details(self, entity_name):
-        """Read host values from Host Details page"""
+    def get_details(self, entity_name, widget_names=None):
+        """Read host values from Host Details page, optionally only the widgets in widget_names
+        will be read.
+        """
         view = self.navigate_to(self, 'Details', entity_name=entity_name)
-        return view.read()
+        return view.read(widget_names=widget_names)
 
     def read(self, entity_name):
         """Read host values from Host Edit page"""

--- a/airgun/utils.py
+++ b/airgun/utils.py
@@ -1,0 +1,69 @@
+
+
+def merge_dict(values, new_values):
+    """Update dict values with new values from new_values dict
+
+    Merge example:
+
+        a = {'a': {'c': {'k': 2, 'x': {1: 0}}}}
+        b = {'a': {'c': {'z': 5, 'y': 40, 'x': {2: 1}}}, 'b': {'a': 1, 'l': 2}}
+        update_dict(a, b)
+        # a updated and equal:
+        # {'a': {'c': {'k': 2, 'x': {1: 0, 2: 1}, 'z': 5, 'y': 40}}, 'b': {'a': 1, 'l': 2}}
+    """
+    for key in new_values:
+        if key in values and isinstance(values[key], dict) and isinstance(new_values[key], dict):
+            merge_dict(values[key], new_values[key])
+        else:
+            values[key] = new_values[key]
+
+
+def normalize_dict_values(values):
+    """Transform a widget path:value dict to a regular View read values format.
+
+     This function transform a dictionary from:
+        {'a.b': 1, 'a.z': 10, 'a.c.k': 2, 'a.c.z': 5, 'x.y': 3, 'c': 4}
+     to:
+        {'a': {'b': 1, 'z': 10, 'c': {'k': 2, 'z': 5}}, 'x': {'y': 3}, 'c': 4}
+     """
+    new_values = {}
+    for key, value in values.items():
+        keys = key.split('.')
+        new_key = keys.pop(0)
+        if keys:
+            new_key_value = normalize_dict_values({'.'.join(keys): value})
+        else:
+            new_key_value = value
+        if (new_key in new_values and isinstance(new_values[new_key], dict)
+                and isinstance(new_key_value, dict)):
+            # merge in place the new_values with new_key_value
+            merge_dict(new_values[new_key], new_key_value)
+        else:
+            new_values[new_key] = new_key_value
+    return new_values
+
+
+def get_widget_by_name(widget_root, widget_name):
+    """Return a widget by it's name from widget_root, where widget can be a sub widget.
+
+    :param widget_root: The root Widget instance from where to begin resolving widget_name.
+    :param widget_name: a string representation of the widget instance to find.
+
+    Example:
+         widget_name = 'details'
+         or
+         widget_name = 'details.subscription_status'
+         or
+         widget_name = 'details.subscriptions.resources'
+    """
+    widget = widget_root
+    for sub_widget_name in widget_name.split('.'):
+        name = sub_widget_name
+        if name not in widget.widget_names:
+            name = name.replace(' ', '_')
+            name = name.lower()
+            if name not in widget.widget_names:
+                raise AttributeError('Object <{0}> has no widget name "{1}"'.format(
+                    widget.__class__, sub_widget_name))
+        widget = getattr(widget, name)
+    return widget

--- a/airgun/views/common.py
+++ b/airgun/views/common.py
@@ -27,6 +27,49 @@ from airgun.widgets import (
 )
 
 
+def _merge_dict(values, new_values):
+    """Update dict values with new values from new_values dict
+
+    Merge example:
+
+        a = {'a': {'c': {'k': 2, 'x': {1: 0}}}}
+        b = {'a': {'c': {'z': 5, 'y': 40, 'x': {2: 1}}}, 'b': {'a': 1, 'l': 2}}
+        update_dict(a, b)
+        # a updated and equal:
+        # {'a': {'c': {'k': 2, 'x': {1: 0, 2: 1}, 'z': 5, 'y': 40}}, 'b': {'a': 1, 'l': 2}}
+    """
+    for key in new_values:
+        if key in values and isinstance(values[key], dict) and isinstance(new_values[key], dict):
+                _merge_dict(values[key], new_values[key])
+        else:
+            values[key] = new_values[key]
+
+
+def _normalize_dict_values(values):
+    """Transform a widget path:value dict to a regular read values format.
+
+     This function transform a dictionary from:
+        {'a.b': 1, 'a.z': 10, 'a.c.k': 2, 'a.c.z': 5, 'x.y': 3, 'c': 4}
+     to:
+        {'a': {'b': 1, 'z': 10, 'c': {'k': 2, 'z': 5}}, 'x': {'y': 3}, 'c': 4}
+     """
+    new_values = {}
+    for key, value in values.items():
+        keys = key.split('.')
+        new_key = keys.pop(0)
+        if keys:
+            new_key_value = _normalize_dict_values({'.'.join(keys): value})
+        else:
+            new_key_value = value
+        if (new_key in new_values and isinstance(new_values[new_key], dict)
+                and isinstance(new_key_value, dict)):
+                # merge in place the new_values with new_key_value
+                _merge_dict(new_values[new_key], new_key_value)
+        else:
+            new_values[new_key] = new_key_value
+    return new_values
+
+
 class BaseLoggedInView(View):
     menu = SatVerticalNavigation(
         './/div[@id="vertical-nav" or contains(@class, "nav-pf-vertical")]/ul')
@@ -74,7 +117,7 @@ class BaseLoggedInView(View):
         values = {}
         for widget_name in widget_names:
             values[widget_name] = self._get_widget_by_name(widget_name).read()
-        return values
+        return _normalize_dict_values(values)
 
 
 class WrongContextAlert(View):


### PR DESCRIPTION
In order to read only the widgets that we need for an entity:

Suppose we have this tests

```python

from nailgun import entities


def test_positive_read_host_details_page(session):
    host = entities.Host(id=20).read()
    os = host.operatingsystem.read()
    domain = host.domain.read()
    org = host.organization.read()
    loc = host.location.read()
    env = host.environment.read()
    arch = host.architecture.read()
    os_name = u'{0} {1}'.format(os.name, os.major)
    host_name = host.name
    with session:
        session.organization.select(org_name=org.name)
        session.location.select(loc_name=loc.name)
        assert session.host.search(host_name)[0]['Name'] == host_name
        values = session.host.get_details(
            host_name, ['properties.properties_table'])
        print('???????????????????????')
        print(values)
        print('???????????????????????')
        assert len(values.keys()) == 1
        properties_values = values['properties.properties_table']
        assert properties_values['Status'] == 'OK'
        assert properties_values['Domain'] == domain.name
        assert properties_values['MAC Address'] == host.mac
        assert properties_values['Puppet Environment'] == env.name
        assert properties_values['Architecture'] == arch.name
        assert properties_values['Operating System'] == os_name
        assert properties_values['Location'] == loc.name
        assert properties_values['Organization'] == org.name


def test_positive_read_content_view(session):
    cv = entities.ContentView(id=35).read()
    with session:
        widget_names = ['details', 'repositories.resources']
        values = session.contentview.read(cv.name, widget_names)
        assert set(values.keys()) == set(widget_names)
        assert values['details']['name'] == cv.name
        assert len(values['repositories.resources']['unassigned']) == 0
        assert len(values['repositories.resources']['assigned']) == 1
        assert values['repositories.resources']['assigned'][0]['Name'] == 'zoo'
        print('???????????????????????')
        print(values)
        print('???????????????????????')

```
test output
```
(robottelo) dlezz@dlezz:~/projects/robottelo-fork$ pytest -v tests/foreman/ui_airgun/test_read_widgets.py 
============================================ test session starts =============================================
platform linux -- Python 3.6.6, pytest-3.6.1, py-1.5.4, pluggy-0.6.0 -- /home/dlezz/.pyenv/versions/robottelo/bin/python3.6
cachedir: .pytest_cache
shared_function enabled - ON - scope: ffff - storage: redis
rootdir: /home/dlezz/projects/robottelo-fork, inifile:
plugins: wait-for-1.0.9, xdist-1.22.5, services-1.3.1, mock-1.10.0, forked-0.2, cov-2.5.1
collecting 2 items                                                                                           2018-12-27 17:52:27 - conftest - DEBUG - BZ deselect is disabled in settings

collected 2 items                                                                                            

tests/foreman/ui_airgun/test_read_widgets.py::test_positive_read_host_details_page PASSED              [ 50%]
tests/foreman/ui_airgun/test_read_widgets.py::test_positive_read_content_view PASSED                   [100%]

========================================= 2 passed in 171.86 seconds =========================================
```
The values return by read in host test:
```
{'properties.properties_table': {'Status': 'OK', 'Build duration': 'N/A', 'Token': 'N/A', 'Domain': 'weejhjakfa', 'MAC Address': 'ac:bc:33:df:ac:17', 'Puppet Environment': 'upYLXm7mlhS1', 'Architecture': 'TTWhTbNSNWR', 'Operating System': 'lcIupt 74', 'PXE Loader': '', 'Location': 'UVmUoFU', 'Organization': 'yWsOKp', 'Owner': 'Admin User'}}
```
The values return by read in content view test
```
{'details': {'name': 'zoo', 'label': 'zoo', 'description': '', 'composite': 'No', 'force_puppet': 'No'}, 'repositories.resources': {'assigned': [{0: False, 'Name': 'zoo', 'Product': 'zoo', 'Last Sync': '2018-12-27 14:36:03 +0200', 'Sync State': 'Success', 'Content': '32 Packages 4 Errata 0 Module Streams'}], 'unassigned': []}}

```
