### PR TITLE
Updated searchbar's actions dropdown locator per recent satellite change

### DIFF
--- a/airgun/widgets.py
+++ b/airgun/widgets.py
@@ -495,7 +495,7 @@ class Search(Widget):
         ".//button[contains(@type,'submit') or contains(@class, 'search-btn') "
         "or @ng-click='table.search(table.searchTerm)']"
     )
-    actions = ActionsDropdown(".//span[contains(@class, 'input-group-btn')]")
+    actions = ActionsDropdown(".//*[self::div or self::span][contains(@class, 'input-group-btn')]")
 
     def fill(self, value):
         return self.search_field.fill(value)


### PR DESCRIPTION
Now we have either `span` or `div`, depending on page style (foreman/katello)
```python
pytest -v tests/foreman/ui_airgun/test_bookmark.py -k test_positive_create_bookmark_public
============================== test session starts ===============================
platform darwin -- Python 3.6.4, pytest-3.6.1, py-1.6.0, pluggy-0.6.0 -- /Users/andrii/workspace/py3a/bin/python3.6
cachedir: .pytest_cache
shared_function enabled - OFF - scope:  - storage: file
rootdir: /Users/andrii/workspace/robottelo, inifile:
plugins: xdist-1.22.0, services-1.2.1, mock-1.10.0, forked-0.2, env-0.6.2
collecting 1 item                                                                2018-12-28 18:09:34 - conftest - DEBUG - BZ deselect is disabled in settings

collected 1 item

tests/foreman/ui_airgun/test_bookmark.py::test_positive_create_bookmark_public PASSED [100%]

=========================== 1 passed in 141.77 seconds ===========================
```