### PR TITLE
Adding support for module streams ui

### DIFF
--- a/airgun/entities/contentview.py
+++ b/airgun/entities/contentview.py
@@ -185,6 +185,22 @@ class ContentViewEntity(BaseEntity):
         )
         return view.rpm_packages.search(query, repo=repo)
 
+    def search_version_module_stream(
+            self, entity_name, version_name, query, repo=None):
+        """Search for a module stream inside content view version
+
+        :param str entity_name: content view name
+        :param str version_name: content view version name
+        :param str query: search query for content view version's module stream
+        :param str optional repo: repository name to filter by
+        """
+        view = self.navigate_to(
+            self, 'Version',
+            entity_name=entity_name,
+            version_name=version_name,
+        )
+        return view.module_streams.search(query, repo=repo)
+
     def remove_version(self, entity_name, version_name, completely=True,
                        lces=None):
         """Remove content view version.

--- a/airgun/entities/lifecycleenvironment.py
+++ b/airgun/entities/lifecycleenvironment.py
@@ -68,6 +68,13 @@ class LCEEntity(BaseEntity):
         view.packages.search(package_name, cv=cv_name, repo=repo_name)
         return view.packages.table.read()
 
+    def search_module_stream(self, entity_name, module_name, cv_name=None,
+                             repo_name=None):
+        """Search for specific module stream inside lifecycle environment"""
+        view = self.navigate_to(self, 'Edit', entity_name=entity_name)
+        view.module_streams.search(module_name, cv=cv_name, repo=repo_name)
+        return view.module_streams.table.read()
+
 
 @navigator.register(LCEEntity, 'All')
 class ShowAllLCE(NavigateStep):

--- a/airgun/entities/modulestream.py
+++ b/airgun/entities/modulestream.py
@@ -1,0 +1,74 @@
+
+from airgun.entities.base import BaseEntity
+from airgun.navigation import NavigateStep, navigator
+
+from airgun.views.modulestream import ModuleStreamView, ModuleStreamsDetailsView
+from wait_for import wait_for
+
+
+class ModuleStreamEntity(BaseEntity):
+    """Module Stream entity"""
+
+    def search(self, query):
+        """Search for module stream
+
+        :param str query: search query to type into search field. E.g.
+            ``name = "ant"``.
+        """
+        view = self.navigate_to(self, 'All')
+        return view.search(query)
+
+    def read(self, entity_name):
+        """Read module streams values from Module Stream Details page
+
+        :param str entity_name: the module stream name to read.
+        """
+        view = self.navigate_to(
+            self, 'Details', entity_name=entity_name)
+        return view.read()
+
+
+@navigator.register(ModuleStreamEntity, 'All')
+class ShowAllModuleStreams(NavigateStep):
+    """navigate to Module Streams Page"""
+    VIEW = ModuleStreamView
+
+    def step(self, *args, **kwargs):
+        self.view.menu.select('Content', 'Module Streams')
+
+
+@navigator.register(ModuleStreamEntity, 'Details')
+class ShowModuleStreamsDetails(NavigateStep):
+    """Navigate to Module Stream Details page by clicking on
+    necessary module name in the table
+
+    Args:
+        entity_name: The module name.
+    """
+    VIEW = ModuleStreamsDetailsView
+
+    def prerequisite(self, *args, **kwargs):
+        return self.navigate_to(self.obj, 'All')
+
+    def step(self, *args, **kwargs):
+        entity_name = kwargs.get('entity_name')
+
+        self.parent.search(
+            'name = {0}'.format(entity_name))
+        self.parent.table.row(name=entity_name)['Name'].widget.click()
+
+    def post_navigate(self, _tries, *args, **kwargs):
+        wait_for(
+            lambda: self.am_i_here(*args, **kwargs),
+            timeout=30,
+            delay=1,
+            handle_exception=True,
+            logger=self.view.logger
+        )
+
+    def am_i_here(self, *args, **kwargs):
+        entity_name = kwargs.get('entity_name')
+        return (
+                self.view.is_displayed
+                and self.view.breadcrumb.locations[1].startswith(entity_name)
+        )

--- a/airgun/session.py
+++ b/airgun/session.py
@@ -36,6 +36,7 @@ from airgun.entities.ldap_authentication import LDAPAuthenticationEntity
 from airgun.entities.lifecycleenvironment import LCEEntity
 from airgun.entities.location import LocationEntity
 from airgun.entities.login import LoginEntity
+from airgun.entities.modulestream import ModuleStreamEntity
 from airgun.entities.organization import OrganizationEntity
 from airgun.entities.os import OperatingSystemEntity
 from airgun.entities.oscapcontent import OSCAPContentEntity
@@ -420,6 +421,11 @@ class Session(object):
     def package(self):
         """Instance of Packge entity."""
         return PackageEntity(self.browser)
+
+    @cached_property
+    def modulestream(self):
+        """Instance of Module Stream entity."""
+        return ModuleStreamEntity(self.browser)
 
     @cached_property
     def partitiontable(self):

--- a/airgun/views/contentview.py
+++ b/airgun/views/contentview.py
@@ -260,6 +260,25 @@ class ContentViewVersionPublishView(BaseLoggedInView):
         )
 
 
+class EntitySearchView(SatSecondaryTab):
+    repo_filter = SatSelect(".//select[@ng-model='repository']")
+    searchbox = Search()
+    table = SatTable(".//table")
+
+    def search(self, query, repo=None):
+        """Apply available filters before proceeding with searching.
+
+        :param str query: search query to type into search field.
+        :param str optional repo: filter by repository name
+        :return: list of dicts representing table rows
+        :rtype: list
+        """
+        if repo:
+            self.repo_filter.fill(repo)
+        self.searchbox.search(query)
+        return self.table.read()
+
+
 class ContentViewVersionDetailsView(BaseLoggedInView):
     breadcrumb = BreadCrumb()
 
@@ -280,24 +299,12 @@ class ContentViewVersionDetailsView(BaseLoggedInView):
         table = SatTable('.//table')
 
     @View.nested
-    class rpm_packages(SatSecondaryTab):
+    class rpm_packages(EntitySearchView):
         TAB_NAME = 'rpm Packages'
-        repo_filter = SatSelect(".//select[@ng-model='repository']")
-        searchbox = Search()
-        table = SatTable(".//table")
 
-        def search(self, query, repo=None):
-            """Apply available filters before proceeding with searching.
-
-            :param str query: search query to type into search field.
-            :param str optional repo: filter by repository name
-            :return: list of dicts representing table rows
-            :rtype: list
-            """
-            if repo:
-                self.repo_filter.fill(repo)
-            self.searchbox.search(query)
-            return self.table.read()
+    @View.nested
+    class module_streams(EntitySearchView):
+        TAB_NAME = 'Module Streams'
 
     @View.nested
     class errata(SatSecondaryTab, SearchableViewMixin):

--- a/airgun/views/lifecycleenvironment.py
+++ b/airgun/views/lifecycleenvironment.py
@@ -171,3 +171,28 @@ class LCEEditView(BaseLoggedInView):
                 self.cv_filter.fill(cv)
             self.searchbox.search(query)
             return self.table.read()
+
+    @View.nested
+    class module_streams(SatTab):
+        TAB_NAME = 'Module Streams'
+
+        cv_filter = SatSelect(".//select[@ng-model='contentView']")
+        repo_filter = SatSelect(".//select[@ng-model='repository']")
+        searchbox = Search()
+        table = SatTable(".//table")
+
+        def search(self, query, cv=None, repo=None):
+            """Apply available filters before proceeding with searching.
+
+            :param str query: search query to type into search field.
+            :param str optional cv: filter by content view name
+            :param str optional repo: filter by repository name
+            :return: list of dicts representing table rows
+            :rtype: list
+            """
+            if cv:
+                self.cv_filter.fill(cv)
+            if repo:
+                self.repo_filter.fill(repo)
+            self.searchbox.search(query)
+            return self.table.read()

--- a/airgun/views/modulestream.py
+++ b/airgun/views/modulestream.py
@@ -1,0 +1,78 @@
+
+from widgetastic.widget import (
+    Text,
+    TextInput,
+    View,
+)
+from widgetastic_patternfly import BreadCrumb, Button
+
+from airgun.views.common import (
+    BaseLoggedInView,
+    SatTab,
+    SatTable,
+)
+from airgun.widgets import Search, SatTableWithUnevenStructure
+
+
+class CustomSearch(Search):
+    search_field = TextInput(locator=".//input[@role='combobox']")
+    search_button = Button('Search')
+
+
+class ModuleStreamView(BaseLoggedInView):
+    """Main Module_Streams view"""
+    title = Text("//h2[contains(., 'Module Streams')]")
+    table = SatTable('.//table', column_widgets={'Name': Text("./a")})
+
+    search_box = CustomSearch()
+
+    def search(self, query):
+        """Perform search using search box on the page and return table
+        contents.
+
+        :param str query: search query to type into search field. E.g.
+            ``name = "bar"``.
+        :return: list of dicts representing table rows
+        :rtype: list
+        """
+        self.search_box.search(query)
+        return self.table.read()
+
+    @property
+    def is_displayed(self):
+        """The view is displayed when it's title exists"""
+        return self.browser.wait_for_element(
+            self.title, exception=False) is not None
+
+
+class ModuleStreamsDetailsView(BaseLoggedInView):
+    breadcrumb = BreadCrumb()
+
+    title = Text("//a(., 'Module Streams')]")
+    details_tab = Text("//a[@id='module-stream-tabs-container-tab-1']")
+
+    @property
+    def is_displayed(self):
+        """The view is displayed when it's details ta exists"""
+        breadcrumb_loaded = self.browser.wait_for_element(
+            self.breadcrumb, exception=False)
+
+        return (
+                breadcrumb_loaded
+                and self.breadcrumb.locations[0] == 'Module Streams'
+        )
+
+    @View.nested
+    class details(SatTab):
+        details_table = SatTableWithUnevenStructure(
+            locator='.//table',
+            column_locator='./*')
+
+    @View.nested
+    class repositories(SatTab):
+        table = SatTable(
+            locator=".//table",
+            column_widgets={
+                'Name': Text("./a"),
+            }
+        )


### PR DESCRIPTION
**Objective** 

Adding support for elements added for module streams UI 

**Test Result:** 

```
(env) root@okhatavk robottelo (module_streams_ui_tests) $ pytest tests/foreman/ui_airgun/ -v -k 'module_stream' 
============================================================================ test session starts ============================================================================
platform linux -- Python 3.4.8, pytest-4.0.1, py-1.7.0, pluggy-0.8.0 -- /home/okhatavk/Satellite/robottelo/env/bin/python3.4
cachedir: .pytest_cache
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/okhatavk/Satellite/robottelo, inifile:
plugins: xdist-1.24.1, services-1.3.1, mock-1.10.0, forked-0.2, cov-2.6.0
collecting 189 items                                                                                                                                                        2019-01-03 15:24:00 - conftest - DEBUG - BZ deselect is disabled in settings

collected 268 items / 264 deselected                                                                                                                                        

tests/foreman/ui_airgun/test_contentview.py::test_positive_module_stream_end_to_end PASSED                                                                            [ 25%]
tests/foreman/ui_airgun/test_contentview.py::test_positive_search_module_streams_in_content_view PASSED                                                               [ 50%]
tests/foreman/ui_airgun/test_lifecycleenvironment.py::test_positive_search_lce_content_view_module_streams_by_name PASSED                                             [ 75%]
tests/foreman/ui_airgun/test_modulestreams.py::test_positive_module_stream_details_search_in_repo PASSED                                                              [100%]

============================================================================= warnings summary ==============================================================================
tests/foreman/ui_airgun/test_lifecycleenvironment.py::test_positive_search_lce_content_view_module_streams_by_name
  /home/okhatavk/Satellite/robottelo/env/lib/python3.4/site-packages/widgetastic/widget/select.py:130: DeprecationWarning: The value of convert_charrefs will become True in 3.5. You are encouraged to set the value explicitly.
    parser = html_parser.HTMLParser()
  /home/okhatavk/Satellite/robottelo/env/lib/python3.4/site-packages/widgetastic/widget/select.py:133: DeprecationWarning: The unescape method is deprecated and will be removed in 3.5, use html.unescape() instead.
    for option
  /home/okhatavk/Satellite/robottelo/env/lib/python3.4/site-packages/widgetastic/widget/select.py:130: DeprecationWarning: The value of convert_charrefs will become True in 3.5. You are encouraged to set the value explicitly.
    parser = html_parser.HTMLParser()
  /home/okhatavk/Satellite/robottelo/env/lib/python3.4/site-packages/widgetastic/widget/select.py:133: DeprecationWarning: The unescape method is deprecated and will be removed in 3.5, use html.unescape() instead.
    for option

-- Docs: https://docs.pytest.org/en/latest/warnings.html
========================================================== 4 passed, 264 deselected, 4 warnings in 721.67 seconds ===========================================================
(env) root@okhatavk robottelo (module_streams_ui_tests) $ 
```
**Test PR :**
https://github.com/SatelliteQE/robottelo/pull/6602
