### PR TITLE
Fixes job invocation view

### DIFF
--- a/airgun/views/job_invocation.py
+++ b/airgun/views/job_invocation.py
@@ -89,8 +89,7 @@ class JobInvocationCreateView(BaseLoggedInView):
             View.__init__(self, parent, logger=logger)
             if self.expander.is_displayed:
                 self.expander.click()
-                self.browser.wait_for_element(
-                    self.effective_user, visible=True)
+                self.browser.wait_for_element(self.effective_user, visible=True, exception=False)
 
     schedule = RadioGroup(locator="//div[label[text()='Schedule']]")
     schedule_content = ConditionalSwitchableView(reference='schedule')


### PR DESCRIPTION
The test was failing in automation (locally also) with
```
   raise NoSuchElementException(
>                   'Failed waiting for element with {} in {}'.format(locator, parent))
E               selenium.common.exceptions.NoSuchElementException: Message: Failed waiting for element with TextInput(locator=".//input[contains(@name, '[effective_user]')]") in None
```
seems some base/framework changes was made since test creation
```
(robottelo) dlezz@dlezz:~/projects/robottelo-fork$ pytest -v tests/foreman/ui_airgun/test_hostcollection.py::test_negative_install_via_custom_remote_execution 
============================================ test session starts =============================================
platform linux -- Python 3.6.6, pytest-4.0.2, py-1.5.4, pluggy-0.8.0 -- /home/dlezz/.pyenv/versions/robottelo/bin/python3.6
cachedir: .pytest_cache
shared_function enabled - ON - scope: ffff - storage: redis
rootdir: /home/dlezz/projects/robottelo-fork, inifile:
plugins: wait-for-1.0.9, xdist-1.22.5, timeout-1.3.3, services-1.3.1, mock-1.10.0, forked-0.2, cov-2.5.1
collecting ... 2019-01-22 17:38:05 - conftest - DEBUG - BZ deselect is disabled in settings

collected 1 item                                                                                             

tests/foreman/ui_airgun/test_hostcollection.py::test_negative_install_via_custom_remote_execution PASSED [100%]

========================================= 1 passed in 90.56 seconds ==========================================

```