### PR TITLE
Adding support to module streams actions on host page

### DIFF
--- a/airgun/entities/contenthost.py
+++ b/airgun/entities/contenthost.py
@@ -64,8 +64,8 @@ class ContentHostEntity(BaseEntity):
 
         :param entity_name: content host name to remotely execute package
             action on
-        :param action_type: remote action to execute. This is dict with containing 'Action'
-            and 'is_Customize' keys. Action key value can be one of
+        :param action_type: remote action to execute. This is dict with containing 'action'
+            and 'is_customize' keys. Action key value can be one of
             5: 'Enable', 'Disable', 'Install', 'Update', 'Remove', 'Reset'
         :param module_name: Module Stream name to remotely
             install/upgrade/remove (depending on `action_type`)
@@ -82,7 +82,7 @@ class ContentHostEntity(BaseEntity):
                 view = JobInvocationCreateView(view.browser)
                 view.submit.click()
         view = JobInvocationStatusView(view.browser)
-        view.wait_for_result()
+        view.wait_for_result(timeout=120)
         return view.read()
 
     def search_package(self, entity_name, package_name):

--- a/airgun/entities/contenthost.py
+++ b/airgun/entities/contenthost.py
@@ -117,10 +117,12 @@ class ContentHostEntity(BaseEntity):
         view = self.navigate_to(self, 'Edit', entity_name=entity_name)
         view.errata.search(errata_id)
         view.errata.table.row(id=errata_id)[0].widget.fill(True)
-        if install_via == 'rex_customize':
-            view.errata.apply_selected.fill('via remote execution - customize first')
+        if install_via == 'katello':
+            view.errata.apply_selected.fill('via Katello agent')
         elif install_via == 'rex':
             view.errata.apply_selected.fill('via remote execution')
+        elif install_via == 'rex_customize':
+            view.errata.apply_selected.fill('via remote execution - customize first')
         else:
             view.errata.apply_selected.fill('Apply Selected')
             view.dialog.confirm()

--- a/airgun/entities/contenthost.py
+++ b/airgun/entities/contenthost.py
@@ -83,10 +83,10 @@ class ContentHostEntity(BaseEntity):
         view.packages_installed.search(package_name)
         return view.packages_installed.table.read()
 
-    def search_module_stream(self, entity_name, module_name):
+    def search_module_stream(self, entity_name, module_name, status='All'):
         """Search for specific package installed in content host"""
         view = self.navigate_to(self, 'Edit', entity_name=entity_name)
-        view.module_streams.search(module_name)
+        view.module_streams.search(module_name, status)
         return view.module_streams.table.read()
 
     def install_errata(self, entity_name, errata_id):

--- a/airgun/entities/contenthost.py
+++ b/airgun/entities/contenthost.py
@@ -102,7 +102,7 @@ class ContentHostEntity(BaseEntity):
             query = module_name
         else:
             query = 'name = {} and stream = {}'.format(module_name, stream_version)
-            view.module_streams.search(query, status)
+        view.module_streams.search(query, status)
         return view.module_streams.table.read()
 
     def install_errata(self, entity_name, errata_id, install_via=None):

--- a/airgun/entities/contenthost.py
+++ b/airgun/entities/contenthost.py
@@ -99,7 +99,7 @@ class ContentHostEntity(BaseEntity):
         """Search for specific package installed in content host"""
         view = self.navigate_to(self, 'Edit', entity_name=entity_name)
         if stream_version is None:
-            view.module_streams.search(module_name, status)
+            query = module_name
         else:
             query = 'name = {} and stream = {}'.format(module_name, stream_version)
             view.module_streams.search(query, status)
@@ -117,12 +117,13 @@ class ContentHostEntity(BaseEntity):
         view = self.navigate_to(self, 'Edit', entity_name=entity_name)
         view.errata.search(errata_id)
         view.errata.table.row(id=errata_id)[0].widget.fill(True)
-        if install_via == 'katello':
-            view.errata.apply_selected.fill('via Katello agent')
-        elif install_via == 'rex':
-            view.errata.apply_selected.fill('via remote execution')
-        elif install_via == 'rex_customize':
-            view.errata.apply_selected.fill('via remote execution - customize first')
+        install_via_dict = {
+            'katello': 'via Katello agent',
+            'rex': 'via remote execution',
+            'rex_customize': 'via remote execution - customize first',
+        }
+        if install_via is not None:
+            view.errata.apply_selected.fill(install_via_dict[install_via])
         else:
             view.errata.apply_selected.fill('Apply Selected')
             view.dialog.confirm()

--- a/airgun/entities/hostcollection.py
+++ b/airgun/entities/hostcollection.py
@@ -181,8 +181,8 @@ class HostCollectionEntity(BaseEntity):
         """Manage module streams (install, remove, update, reset)
 
         :param str entity_name:  The host collection name.
-        :param action_type: remote action to execute. This is dict with containing 'Action'
-            and 'is_Customize' keys. Action key value can be one of 5:
+        :param action_type: remote action to execute. This is dict with containing 'action'
+            and 'is_customize' keys. Action key value can be one of 5:
             'Enable', 'Disable', 'Install', 'Update', 'Remove', 'Reset'
         :param str module_name:  The name of module on which action is performed
         :param str stream_version:  The version of module on which action is performed
@@ -200,7 +200,7 @@ class HostCollectionEntity(BaseEntity):
                 view = JobInvocationCreateView(view.browser)
                 view.submit.click()
         view = JobInvocationStatusView(view.browser)
-        view.wait_for_result(timeout=60)
+        view.wait_for_result(timeout=120)
         return view.read()
 
     def change_assigned_content(self, entity_name, lce, content_view):

--- a/airgun/entities/hostcollection.py
+++ b/airgun/entities/hostcollection.py
@@ -180,9 +180,8 @@ class HostCollectionEntity(BaseEntity):
                               stream_version, customize=False, customize_values=None):
         """ Manage module streams
         :param str entity_name:  The host collection name.
-        :param action_type: remote action to execute. This is dict with containing 'action'
-            and 'is_customize' keys. Action key value can be one of 5:
-            'Enable', 'Disable', 'Install', 'Update', 'Remove', 'Reset'
+        :param action_type: remote action to execute on content host. Action value can be one of
+            them e.g. 'Enable', 'Disable', 'Install', 'Update', 'Remove', 'Reset'
         :param str module_name:  The name of module on which action is performed
         :param str stream_version:  The version of module on which action is performed
         :param customize: special action type which should call on content host module streams
@@ -205,7 +204,7 @@ class HostCollectionEntity(BaseEntity):
         if customize:
             view = JobInvocationCreateView(view.browser)
             view.fill(customize_values)
-            view.submit.click
+            view.submit.click()
         view = JobInvocationStatusView(view.browser)
         view.wait_for_result()
         return view.read()

--- a/airgun/entities/hostcollection.py
+++ b/airgun/entities/hostcollection.py
@@ -176,31 +176,38 @@ class HostCollectionEntity(BaseEntity):
             )
             return job_status_view.overview.read()
 
-    def manage_module_streams(self, entity_name, action_type,
-                              module_name, stream_version):
-        """Manage module streams (install, remove, update, reset)
-
+    def manage_module_streams(self, entity_name, action_type, module_name,
+                              stream_version, customize=False, customize_values=None):
+        """ Manage module streams
         :param str entity_name:  The host collection name.
         :param action_type: remote action to execute. This is dict with containing 'action'
             and 'is_customize' keys. Action key value can be one of 5:
             'Enable', 'Disable', 'Install', 'Update', 'Remove', 'Reset'
         :param str module_name:  The name of module on which action is performed
         :param str stream_version:  The version of module on which action is performed
+        :param customize: special action type which should call on content host module streams
+            tab to run some custom expression related to module streams
+        :param customize_values: need to pass if run some custom command expression in content host
+
         :returns job status view values
 
         """
+        if customize_values is None:
+            customize_values = {}
         view = self.navigate_to(self, 'Edit', entity_name=entity_name)
         view.details.manage_module_streams.click()
         view = HostCollectionManageModuleStreamsView(view.browser)
         view.search('name = {} and stream = {}'.format(module_name, stream_version))
+        if customize:
+            action_type = dict(is_customize=customize, action=action_type)
         view.table.row(
             name=module_name, stream=stream_version)['Actions'].fill(action_type)
-        if isinstance(action_type, dict):
-            if 'is_customize' in action_type and action_type['is_customize']:
-                view = JobInvocationCreateView(view.browser)
-                view.submit.click()
+        if customize:
+            view = JobInvocationCreateView(view.browser)
+            view.fill(customize_values)
+            view.submit.click
         view = JobInvocationStatusView(view.browser)
-        view.wait_for_result(timeout=120)
+        view.wait_for_result()
         return view.read()
 
     def change_assigned_content(self, entity_name, lce, content_view):

--- a/airgun/entities/hostcollection.py
+++ b/airgun/entities/hostcollection.py
@@ -182,14 +182,13 @@ class HostCollectionEntity(BaseEntity):
         :param str entity_name:  The host collection name.
         :param action_type: remote action to execute on content host. Action value can be one of
             them e.g. 'Enable', 'Disable', 'Install', 'Update', 'Remove', 'Reset'
-        :param str module_name:  The name of module on which action is performed
-        :param str stream_version:  The version of module on which action is performed
-        :param customize: special action type which should call on content host module streams
-            tab to run some custom expression related to module streams
-        :param customize_values: need to pass if run some custom command expression in content host
+        :param str module_name: Module Stream name to remotely
+            install/upgrade/remove (depending on `action_type`)
+        :param str stream_version:  String with Stream Version of Module
+        :param customize: Boolean indicating if additional custom action should be called
+        :param customize_values: Dict with custom actions to run. Mandatory if customize is True
 
-        :returns job status view values
-
+        :returns Returns a dict containing job status details
         """
         if customize_values is None:
             customize_values = {}
@@ -197,8 +196,7 @@ class HostCollectionEntity(BaseEntity):
         view.details.manage_module_streams.click()
         view = HostCollectionManageModuleStreamsView(view.browser)
         view.search('name = {} and stream = {}'.format(module_name, stream_version))
-        if customize:
-            action_type = dict(is_customize=customize, action=action_type)
+        action_type = dict(is_customize=customize, action=action_type)
         view.table.row(
             name=module_name, stream=stream_version)['Actions'].fill(action_type)
         if customize:

--- a/airgun/entities/job_invocation.py
+++ b/airgun/entities/job_invocation.py
@@ -1,3 +1,4 @@
+
 from navmazing import NavigateToSibling
 from wait_for import wait_for
 

--- a/airgun/entities/job_invocation.py
+++ b/airgun/entities/job_invocation.py
@@ -1,4 +1,3 @@
-
 from navmazing import NavigateToSibling
 from wait_for import wait_for
 

--- a/airgun/views/contenthost.py
+++ b/airgun/views/contenthost.py
@@ -32,6 +32,7 @@ from airgun.widgets import (
     EditableEntrySelect,
     ReadOnlyEntry,
     Search,
+    CustomActionDropDown
 )
 
 
@@ -77,20 +78,6 @@ class StatusIcon(GenericLocatorWidget):
     def read(self):
         """Returns current icon color"""
         return self.color
-
-
-class ModuleStreamActionDropDown(ActionsDropdown):
-    """Custom drop down for module streams tab in content host page"""
-    customize_check_box = Checkbox(id="customize")
-
-    def fill(self, item):
-        value = item
-        if isinstance(item, dict):
-            if item.get('is_customize'):
-                self.open()
-                self.customize_check_box.click()
-            value = item['action']
-        self.select(value)
 
 
 class InstallableUpdatesCellView(View):
@@ -297,7 +284,7 @@ class ContentHostDetailsView(BaseLoggedInView):
             locator='//table',
             column_widgets={
                 'Name': Text('.//a'),
-                'Actions': ModuleStreamActionDropDown(".//div[contains(@class, 'dropdown')]")
+                'Actions': CustomActionDropDown(".//div[contains(@class, 'dropdown')]")
             },
         )
 

--- a/airgun/views/contenthost.py
+++ b/airgun/views/contenthost.py
@@ -79,6 +79,18 @@ class StatusIcon(GenericLocatorWidget):
         return self.color
 
 
+class UnEvenActionDropDown(ActionsDropdown):
+    """"""
+    customize_check_box = Checkbox(id="customize")
+
+    def fill(self, item):
+        if isinstance(item, dict):
+            if 'is_customize' in item and item['is_customize']:
+                self.open()
+                self.customize_check_box.click()
+            self.select(item['action'])
+
+
 class InstallableUpdatesCellView(View):
     """Installable Updates Table Cell View for content host view Table"""
     ROOT = '.'
@@ -284,7 +296,7 @@ class ContentHostDetailsView(BaseLoggedInView):
             locator='//table',
             column_widgets={
                 'Name': Text('.//a'),
-                'Actions': ActionsDropdown(".//div[contains(@class, 'dropdown')]")
+                'Actions': UnEvenActionDropDown(".//div[contains(@class, 'dropdown')]")
             },
         )
 

--- a/airgun/views/contenthost.py
+++ b/airgun/views/contenthost.py
@@ -275,6 +275,34 @@ class ContentHostDetailsView(BaseLoggedInView):
             return self.table.read()
 
     @View.nested
+    class module_streams(SatTab):
+        TAB_NAME = 'Module Streams'
+        status_filter = Select(
+            locator='.//select[@ng-model="nutupaneParams.status"]')
+        searchbox = Search()
+        table = SatTable(
+            locator='//table',
+            column_widgets={
+                'Name': Text('.//a'),
+                'Actions': ActionsDropdown(".//div[contains(@class, 'dropdown')]")
+            },
+        )
+
+        def search(self, query, status='All'):
+            """Searches for Module Streams. Apply available filters before
+            proceeding with searching. By default 'All' is passed
+
+            :param str query: search query to type into search field.
+            :param str optional status: filter by status of module stream on host
+            :return: list of dicts representing table rows
+            :rtype: list
+            """
+            if status is not None:
+                self.status_filter.fill(status)
+            self.searchbox.search(query)
+            return self.table.read()
+
+    @View.nested
     class repository_sets(SatTab, SearchableViewMixin):
         TAB_NAME = 'Repository Sets'
 

--- a/airgun/views/contenthost.py
+++ b/airgun/views/contenthost.py
@@ -25,6 +25,7 @@ from airgun.views.common import (
 )
 from airgun.widgets import (
     ActionsDropdown,
+    ActionDropdownWithCheckbox,
     ConfirmationDialog,
     EditableEntry,
     EditableEntryCheckbox,
@@ -32,7 +33,6 @@ from airgun.widgets import (
     EditableEntrySelect,
     ReadOnlyEntry,
     Search,
-    CustomActionDropDown
 )
 
 
@@ -284,7 +284,7 @@ class ContentHostDetailsView(BaseLoggedInView):
             locator='//table',
             column_widgets={
                 'Name': Text('.//a'),
-                'Actions': CustomActionDropDown(".//div[contains(@class, 'dropdown')]")
+                'Actions': ActionDropdownWithCheckbox(".//div[contains(@class, 'dropdown')]")
             },
         )
 

--- a/airgun/views/contenthost.py
+++ b/airgun/views/contenthost.py
@@ -79,16 +79,18 @@ class StatusIcon(GenericLocatorWidget):
         return self.color
 
 
-class UnEvenActionDropDown(ActionsDropdown):
-    """"""
+class ModuleStreamActionDropDown(ActionsDropdown):
+    """Custom drop down for module streams tab in content host page"""
     customize_check_box = Checkbox(id="customize")
 
     def fill(self, item):
+        value = item
         if isinstance(item, dict):
-            if 'is_customize' in item and item['is_customize']:
+            if item.get('is_customize'):
                 self.open()
                 self.customize_check_box.click()
-            self.select(item['action'])
+            value = item['action']
+        self.select(value)
 
 
 class InstallableUpdatesCellView(View):
@@ -287,16 +289,15 @@ class ContentHostDetailsView(BaseLoggedInView):
             return self.table.read()
 
     @View.nested
-    class module_streams(SatTab):
+    class module_streams(SatTab, SearchableViewMixin):
         TAB_NAME = 'Module Streams'
         status_filter = Select(
             locator='.//select[@ng-model="nutupaneParams.status"]')
-        searchbox = Search()
         table = SatTable(
             locator='//table',
             column_widgets={
                 'Name': Text('.//a'),
-                'Actions': UnEvenActionDropDown(".//div[contains(@class, 'dropdown')]")
+                'Actions': ModuleStreamActionDropDown(".//div[contains(@class, 'dropdown')]")
             },
         )
 

--- a/airgun/views/hostcollection.py
+++ b/airgun/views/hostcollection.py
@@ -25,7 +25,9 @@ from airgun.widgets import (
     RadioGroup,
     ReadOnlyEntry,
     SatTable,
+    Search
 )
+from airgun.views.contenthost import UnEvenActionDropDown
 
 
 class HostCollectionsView(BaseLoggedInView, SearchableViewMixin):
@@ -86,6 +88,8 @@ class HostCollectionEditView(BaseLoggedInView):
         manage_packages = Text(".//a[@ng-click='openPackagesModal()']")
         # Errata Installation
         install_errata = Text(".//a[@ng-click='openErrataModal()']")
+        # Module Stream Installation, Removal, and Update
+        manage_module_streams = Text(".//a[@ng-click='openModuleStreamsModal()']")
         # Change assigned Lifecycle Environment or Content View
         change_assigned_content = Text(
             ".//a[@ng-click='openEnvironmentModal()']")
@@ -230,6 +234,29 @@ class HostCollectionInstallErrataView(BaseLoggedInView):
         """The view is displayed when it's title exists"""
         return self.browser.wait_for_element(
             self.title, exception=False) is not None
+
+
+class HostCollectionManageModuleStreamsView(BaseLoggedInView):
+    title = Text("//h4[contains(., 'Content Host Module Stream Management')]")
+    search_box = Search()
+    table = SatTable(
+        locator='//table',
+        column_widgets={
+            'Name': Text('.//a'),
+            'Actions': UnEvenActionDropDown(".//div[contains(@class, 'dropdown')]")
+        },
+    )
+
+    @property
+    def is_displayed(self):
+        """The view is displayed when it's title exists"""
+        return self.browser.wait_for_element(
+            self.title, exception=False) is not None
+
+    def search(self, query):
+        """search module stream based on name and stream version"""
+        self.search_box.search(query)
+        return self.table.read()
 
 
 class HostCollectionChangeAssignedContentView(BaseLoggedInView):

--- a/airgun/views/hostcollection.py
+++ b/airgun/views/hostcollection.py
@@ -251,11 +251,6 @@ class HostCollectionManageModuleStreamsView(BaseLoggedInView, SearchableViewMixi
         return self.browser.wait_for_element(
             self.title, exception=False) is not None
 
-    def search(self, query):
-        """search module stream based on name and stream version"""
-        self.searchbox.search(query)
-        return self.table.read()
-
 
 class HostCollectionChangeAssignedContentView(BaseLoggedInView):
     title = Text("//h4[contains(., 'Content Host Bulk Content')]")

--- a/airgun/views/hostcollection.py
+++ b/airgun/views/hostcollection.py
@@ -25,9 +25,8 @@ from airgun.widgets import (
     RadioGroup,
     ReadOnlyEntry,
     SatTable,
-    Search
 )
-from airgun.views.contenthost import UnEvenActionDropDown
+from airgun.views.contenthost import ModuleStreamActionDropDown
 
 
 class HostCollectionsView(BaseLoggedInView, SearchableViewMixin):
@@ -209,7 +208,7 @@ class HostCollectionManagePackagesView(BaseLoggedInView):
             self.dialog.confirm()
 
 
-class HostCollectionInstallErrataView(BaseLoggedInView):
+class HostCollectionInstallErrataView(BaseLoggedInView, SearchableViewMixin):
     title = Text("//h4[contains(., 'Content Host Errata Management')]")
     search = TextInput(
         locator=".//input[@type='text' and @ng-model='errataFilter']")
@@ -236,14 +235,13 @@ class HostCollectionInstallErrataView(BaseLoggedInView):
             self.title, exception=False) is not None
 
 
-class HostCollectionManageModuleStreamsView(BaseLoggedInView):
+class HostCollectionManageModuleStreamsView(BaseLoggedInView, SearchableViewMixin):
     title = Text("//h4[contains(., 'Content Host Module Stream Management')]")
-    search_box = Search()
     table = SatTable(
         locator='//table',
         column_widgets={
             'Name': Text('.//a'),
-            'Actions': UnEvenActionDropDown(".//div[contains(@class, 'dropdown')]")
+            'Actions': ModuleStreamActionDropDown(".//div[contains(@class, 'dropdown')]")
         },
     )
 
@@ -255,7 +253,7 @@ class HostCollectionManageModuleStreamsView(BaseLoggedInView):
 
     def search(self, query):
         """search module stream based on name and stream version"""
-        self.search_box.search(query)
+        self.searchbox.search(query)
         return self.table.read()
 
 

--- a/airgun/views/hostcollection.py
+++ b/airgun/views/hostcollection.py
@@ -19,13 +19,13 @@ from airgun.views.common import (
 from airgun.views.job_invocation import JobInvocationCreateView
 from airgun.widgets import (
     ActionsDropdown,
+    ActionDropdownWithCheckbox,
     ConfirmationDialog,
     EditableEntry,
     EditableLimitEntry,
     RadioGroup,
     ReadOnlyEntry,
     SatTable,
-    CustomActionDropDown
 )
 
 
@@ -241,7 +241,7 @@ class HostCollectionManageModuleStreamsView(BaseLoggedInView, SearchableViewMixi
         locator='//table',
         column_widgets={
             'Name': Text('.//a'),
-            'Actions': CustomActionDropDown(".//div[contains(@class, 'dropdown')]")
+            'Actions': ActionDropdownWithCheckbox(".//div[contains(@class, 'dropdown')]")
         },
     )
 

--- a/airgun/views/hostcollection.py
+++ b/airgun/views/hostcollection.py
@@ -25,8 +25,8 @@ from airgun.widgets import (
     RadioGroup,
     ReadOnlyEntry,
     SatTable,
+    CustomActionDropDown
 )
-from airgun.views.contenthost import ModuleStreamActionDropDown
 
 
 class HostCollectionsView(BaseLoggedInView, SearchableViewMixin):
@@ -241,7 +241,7 @@ class HostCollectionManageModuleStreamsView(BaseLoggedInView, SearchableViewMixi
         locator='//table',
         column_widgets={
             'Name': Text('.//a'),
-            'Actions': ModuleStreamActionDropDown(".//div[contains(@class, 'dropdown')]")
+            'Actions': CustomActionDropDown(".//div[contains(@class, 'dropdown')]")
         },
     )
 

--- a/airgun/views/job_invocation.py
+++ b/airgun/views/job_invocation.py
@@ -55,6 +55,12 @@ class JobInvocationCreateView(BaseLoggedInView):
     class RunPuppetForm(View):
         puppet_options = TextInput(id='puppet_options')
 
+    @template_content.register('Module Action - SSH Default')
+    class RunModuleForm(View):
+        action = FilteredDropdown(id='s2id_action')
+        module_spec = TextInput(id='module_spec')
+        puppet_options = TextInput(id='options')
+
     @View.nested
     class advanced_options(View):
         expander = Text(".//a[text()='Display advanced fields']")

--- a/airgun/widgets.py
+++ b/airgun/widgets.py
@@ -629,6 +629,19 @@ class ActionsDropdown(GenericLocatorWidget):
         return self.items
 
 
+class CustomActionDropDown(ActionsDropdown):
+    """Custom drop down which contains the checkbox inside in drop down."""
+    customize_check_box = Checkbox(id="customize")
+
+    def fill(self, item):
+        """select action from drop down list, after checking customize checkbox
+        :param item pass dict with values for 'is_customize' and 'action' keys.
+        """
+        self.open()
+        self.customize_check_box.fill(item['is_customize'])
+        self.select(item['action'])
+
+
 class Search(Widget):
     search_field = TextInput(locator=(
         ".//input[@id='search' or contains(@placeholder, 'Filter') or "

--- a/airgun/widgets.py
+++ b/airgun/widgets.py
@@ -629,13 +629,13 @@ class ActionsDropdown(GenericLocatorWidget):
         return self.items
 
 
-class CustomActionDropDown(ActionsDropdown):
+class ActionDropdownWithCheckbox(ActionsDropdown):
     """Custom drop down which contains the checkbox inside in drop down."""
     customize_check_box = Checkbox(id="customize")
 
     def fill(self, item):
         """select action from drop down list, after checking customize checkbox
-        :param item pass dict with values for 'is_customize' and 'action' keys.
+        :param item: dictionary with values for 'is_customize' and 'action' keys.
         """
         self.open()
         self.customize_check_box.fill(item['is_customize'])


### PR DESCRIPTION
UI elements and method added to support search and actions done on module streams from Host UI Page. 


![host](https://user-images.githubusercontent.com/3190629/51549700-e35a9880-1e90-11e9-88d1-87424a55eaa3.png)


### Test Result 

```
(env) [root@okhatavk robottelo]# pytest tests/foreman/ui_airgun/test_contenthost.py -v -k "modu"
=============================================== test session starts ===============================================
platform linux -- Python 3.4.8, pytest-4.0.2, py-1.7.0, pluggy-0.9.0 -- /home/okhatavk/Satellite/robottelo/env/bin/python3.4
cachedir: .pytest_cache
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/okhatavk/Satellite/robottelo, inifile:
plugins: xdist-1.26.1, services-1.3.1, mock-1.10.0, forked-1.0.2, cov-2.6.1
collecting 15 items                                                                                               2019-04-18 18:32:23 - conftest - DEBUG - Collected 15 test cases

collected 15 items / 11 deselected                                                                                

tests/foreman/ui_airgun/test_contenthost.py::test_module_stream_actions_on_content_host PASSED              [ 25%]
tests/foreman/ui_airgun/test_contenthost.py::test_module_streams_customize_action PASSED                    [ 50%]
tests/foreman/ui_airgun/test_contenthost.py::test_install_modular_errata PASSED                             [ 75%]
tests/foreman/ui_airgun/test_contenthost.py::test_module_status_update_from_content_host_to_satellite PASSED [100%]

================================================ warnings summary =================================================

```