### PR TITLE
Fixes saucelabs remote connection/request timeout

### DIFF
--- a/airgun/browser.py
+++ b/airgun/browser.py
@@ -261,6 +261,9 @@ class SeleniumBrowserFactory(object):
             ),
             desired_capabilities=desired_capabilities
         )
+        idle_timeout = settings.webdriver_desired_capabilities.idleTimeout
+        if idle_timeout:
+            self._webdriver.command_executor.set_timeout(idle_timeout)
         # todo: attempt to rename job here
         return self._webdriver
 


### PR DESCRIPTION
Force the timeout for saucelabs remote connection/request, this has effect only with latest selenium 3.141.0 (as only in this version the timeout is passed to urllib3.PoolManager)
We found this working, as tested with value 10 seconds and 60 seconds with computeresource end_to_end test.
Note: This PR is also working with the selenium version currently used in robottelo (but has  no effect on  connection/request timeout).  
 

