### PR TITLE
Revert "In the vertical menu, "Host Groups" has been changed to "Host Group" (#244)"

### DIFF
--- a/airgun/entities/hostgroup.py
+++ b/airgun/entities/hostgroup.py
@@ -58,7 +58,7 @@ class ShowAllHostGroups(NavigateStep):
     VIEW = HostGroupsView
 
     def step(self, *args, **kwargs):
-        self.view.menu.select('Configure', 'Host Group')
+        self.view.menu.select('Configure', 'Host Groups')
 
 
 @navigator.register(HostGroupEntity, 'New')


### PR DESCRIPTION
This reverts commit a0a95fc8b5c0b13b06925a507818e376b8063b09.

The commit has been a workaround for bz1652677 which has now been fixed.