### PR TITLE
Fixes host entity with Play Ansible roles action

### DIFF
--- a/airgun/entities/host.py
+++ b/airgun/entities/host.py
@@ -153,6 +153,20 @@ class HostEntity(BaseEntity):
             status_view.wait_for_result(timeout=timeout)
         return status_view.read()
 
+    def play_ansible_roles(self, entities_list, timeout=60, wait_for_results=True):
+        """Play Ansible Roles on hosts names in entities_list
+
+        :param entities_list: The host names to play the ansible roles on.
+        :param timeout: The time to wait for the job to finish.
+        :param wait_for_results: Whether to wait for the job to finish execution.
+
+        :returns: The job invocation status view values
+        """
+        status_view = self._select_action('Play Ansible roles', entities_list)
+        if wait_for_results:
+            status_view.wait_for_result(timeout=timeout)
+        return status_view.read()
+
     def get_puppet_class_parameter_value(self, entity_name, name):
         """Read host Puppet class parameter value.
 
@@ -251,6 +265,7 @@ class HostsSelectAction(NavigateStep):
         'Assign Organization': HostsAssignOrganization,
         'Delete Hosts': HostsDeleteActionDialog,
         'Schedule Remote Job': HostsJobInvocationCreateView,
+        'Play Ansible roles': HostsJobInvocationStatusView,
     }
 
     def prerequisite(self, *args, **kwargs):


### PR DESCRIPTION
given the test bellow
```python
def test_satellite_ansible_install(satellite_ansible_vm, session):
    """Install insights client from satellite by applying the ansible role on host.

    Steps:

        1. Ensure "RedHatInsights.insights-client" role is imported in Configure > Ansible roles
        2. Ensure VM client host registered to satellite, the needed repos for installing insights
            client are enabled and host accessible from satellite via ssh.
        3. Goto All hosts and edit the vm client host, in Ansible roles tab
            add "RedHatInsights.insights-client" and press submit.
        4. in All hosts select the vm client host and select "Play Ansible roles" action

    expected results:

        1. insights client installed on host
        2. host registered
        3. host listed in insights inventory
    """
    session.host.update(satellite_ansible_vm.hostname, {
        "ansible_roles.resources.assigned": [INSIGHTS_ANSIBLE_ROLE]
    })
    # ensure saved
    values = session.host.read(satellite_ansible_vm.hostname, "ansible_roles.resources.assigned")
    assert values["ansible_roles"]["resources"]["assigned"] == [INSIGHTS_ANSIBLE_ROLE]
    # search for the host to reduce the listed hosts and ensure the host is on the page
    values = session.host.search(satellite_ansible_vm.hostname)
    assert values[0]['Name'] == satellite_ansible_vm.hostname
    job_status = session.host.play_ansible_roles([satellite_ansible_vm.hostname], timeout=120)
    assert job_status['overview']['job_status'] == "Success"
    # ensure insights-client installed
    result = satellite_ansible_vm.ssh_run("rpm -qi insights-client")
    assert result.exit_status == 0
    # ensure insights-client registered
    result = satellite_ansible_vm.ssh_run("insights-client --status")
    assert result.exit_status == 0
    # ensure vm client host listed in insights inventory
    table = session.insightsinventory.search(satellite_ansible_vm.hostname)
    session.browser.plugin.ensure_page_safe("60s")
    values = table.read()
    assert values[0]["System Name"] == satellite_ansible_vm.hostname
```
test result output
```
 ◰³ insights  ~/p/i/iqe-satellite-plugin   master *~…  
pytest -v iqe_insights_satellite/tests/test_ansible.py::test_satellite_ansible_install 
⚠️ WARNING: Package iqe-integration-tests  is at version 0.9.3.dev9+g331d6ad, latest 0.9.8
⚠️ WARNING: Package iqe-self-service-portal-plugin  is at version 0.0.3, latest 1.0.0
⚠️ WARNING: Package iqe-insights-satellite-plugin  is at version 0.1.1.dev2+ge9acc37.d20190405, latest 0.1.1
============================================ test session starts =============================================
platform linux -- Python 3.6.6, pytest-4.3.0, py-1.8.0, pluggy-0.9.0 -- /home/dlezz/.pyenv/versions/3.6.6/envs/insights/bin/python
cachedir: .pytest_cache
metadata: {'Python': '3.6.6', 'Platform': 'Linux-4.15.0-47-generic-x86_64-with-debian-stretch-sid', 'Packages': {'pytest': '4.3.0', 'py': '1.8.0', 'pluggy': '0.9.0'}, 'Plugins': {'xdist': '1.27.0', 'report-parameters': '0.2', 'polarion-collect': '0.12', 'metadata': '1.8.0', 'html': '1.20.0', 'forked': '1.0.2', 'cov': '2.6.1', 'iqe-topology-inventory-plugin': '0.0.3', 'iqe-self-service-portal-plugin': '0.0.3', 'iqe-current-ui-plugin': '0.0.6', 'iqe-clientv3-plugin': '0.2', 'iqe-integration-tests': '0.9.3.dev9+g331d6ad', 'iqe-insights-satellite-plugin': '0.1.1.dev2+ge9acc37.d20190405'}}
Default Appliance hostname: access.redhat.com
Default Appliance path: insights/platform
rootdir: /home/dlezz/projects/insights/iqe-satellite-plugin, inifile:
plugins: xdist-1.27.0, report-parameters-0.2, polarion-collect-0.12, metadata-1.8.0, html-1.20.0, forked-1.0.2, cov-2.6.1, iqe-topology-inventory-plugin-0.0.3, iqe-self-service-portal-plugin-0.0.3, iqe-current-ui-plugin-0.0.6, iqe-clientv3-plugin-0.2, iqe-integration-tests-0.9.3.dev9+g331d6ad, iqe-insights-satellite-plugin-0.1.1.dev2+ge9acc37.d20190405
collected 1 item                                                                                             

iqe_insights_satellite/tests/test_ansible.py::test_satellite_ansible_install PASSED                    [100%]

============================================== warnings summary ==============================================
iqe_insights_satellite/tests/test_ansible.py::test_satellite_ansible_install
  /home/dlezz/.pyenv/versions/3.6.6/envs/insights/lib/python3.6/site-packages/openstack/cloud/_utils.py:372: DeprecationWarning: inspect.getargspec() is deprecated, use inspect.signature() or inspect.getfullargspec()
    argspec = inspect.getargspec(func)

-- Docs: https://docs.pytest.org/en/latest/warnings.html
=================================== 1 passed, 1 warnings in 317.42 seconds ===================================
```