### PR TITLE
6.4.z Fixes Hosts Play Ansible roles

### DIFF
--- a/airgun/entities/host.py
+++ b/airgun/entities/host.py
@@ -12,6 +12,7 @@ from airgun.views.host import (
     HostsAssignOrganization,
     HostsChangeGroup,
     HostsChangeEnvironment,
+    HostsJobInvocationStatusView,
     HostsView,
 )
 
@@ -45,15 +46,23 @@ class HostEntity(BaseEntity):
         view = self.navigate_to(self, 'Details', entity_name=entity_name)
         return view.read(widget_names=widget_names)
 
-    def read(self, entity_name):
+    def read(self, entity_name, widget_names=None):
         """Read host values from Host Edit page"""
         view = self.navigate_to(self, 'Edit', entity_name=entity_name)
-        return view.read()
+        return view.read(widget_names=widget_names)
 
     def read_all(self):
         """Read all values from hosts title page"""
         view = self.navigate_to(self, 'All')
         return view.read()
+
+    def update(self, entity_name, values):
+        """Update an existing host with values"""
+        view = self.navigate_to(self, 'Edit', entity_name=entity_name)
+        view.fill(values)
+        view.submit.click()
+        view.flash.assert_no_error()
+        view.flash.dismiss()
 
     def delete(self, entity_name):
         """Delete host from the system"""

--- a/airgun/entities/host.py
+++ b/airgun/entities/host.py
@@ -102,6 +102,20 @@ class HostEntity(BaseEntity):
         view.export.click()
         return self.browser.save_downloaded_file()
 
+    def play_ansible_roles(self, entities_list, timeout=60, wait_for_results=True):
+        """Play Ansible Roles on hosts names in entities_list
+
+        :param entities_list: The host names to play the ansible roles on.
+        :param timeout: The time to wait for the job to finish.
+        :param wait_for_results: Whether to wait for the job to finish execution.
+
+        :returns: The job invocation status view values
+        """
+        status_view = self._select_action('Play Ansible roles', entities_list)
+        if wait_for_results:
+            status_view.wait_for_result(timeout=timeout)
+        return status_view.read()
+
 
 @navigator.register(HostEntity, 'All')
 class ShowAllHosts(NavigateStep):
@@ -176,6 +190,7 @@ class HostsSelectAction(NavigateStep):
         'Assign Compliance Policy': HostsAssignCompliancePolicy,
         'Assign Location': HostsAssignLocation,
         'Assign Organization': HostsAssignOrganization,
+        'Play Ansible roles': HostsJobInvocationStatusView,
     }
 
     def prerequisite(self, *args, **kwargs):

--- a/airgun/views/host.py
+++ b/airgun/views/host.py
@@ -13,6 +13,7 @@ from widgetastic.widget import (
 from widgetastic_patternfly import BreadCrumb
 
 from airgun.views.common import BaseLoggedInView, SearchableViewMixin, SatTab
+from airgun.views.job_invocation import JobInvocationStatusView
 from airgun.widgets import (
     ActionsDropdown,
     CheckboxWithAlert,
@@ -485,3 +486,7 @@ class HostsAssignCompliancePolicy(HostsActionCommonDialog):
         "//h4[text()='Assign Compliance Policy"
         " - The following hosts are about to be changed']")
     policy = Select(id='policy_id')
+
+
+class HostsJobInvocationStatusView(JobInvocationStatusView):
+    """Hosts Job Invocation Status View"""

--- a/airgun/views/job_invocation.py
+++ b/airgun/views/job_invocation.py
@@ -1,3 +1,5 @@
+from wait_for import wait_for
+
 from widgetastic.widget import (
     Checkbox,
     ConditionalSwitchableView,
@@ -170,7 +172,7 @@ class JobInvocationStatusView(BaseLoggedInView):
             self.breadcrumb, exception=False)
         return (
             breadcrumb_loaded
-            and self.breadcrumb.locations[0] == 'Job invocations'
+            and self.breadcrumb.locations[0] == 'Jobs'
             and len(self.breadcrumb.locations) == 2
         )
 
@@ -201,4 +203,21 @@ class JobInvocationStatusView(BaseLoggedInView):
         total_hosts = Text(
             "//h2[contains(., 'Total hosts')]"
             "/span[@class='card-pf-aggregate-status-count']"
+        )
+
+    def wait_for_result(self, timeout=600, delay=1):
+        """Wait for invocation job to finish"""
+        wait_for(
+            lambda: (self.is_displayed and self.overview.job_status.is_displayed
+                     and self.overview.job_status_progress.is_displayed),
+            timeout=timeout,
+            delay=delay,
+            logger=self.logger,
+        )
+        wait_for(
+            lambda: (self.overview.job_status.read() != 'Pending'
+                     and self.overview.job_status_progress.read() == '100%'),
+            timeout=timeout,
+            delay=1,
+            logger=self.logger
         )


### PR DESCRIPTION
Back port of https://github.com/SatelliteQE/airgun/pull/318 to 6.4.z
```
pytest -v iqe_insights_satellite/tests/test_ansible.py::test_satellite_ansible_install 
⚠️ WARNING: Package iqe-integration-tests  is at version 0.9.3.dev9+g331d6ad, latest 0.9.8
⚠️ WARNING: Package iqe-self-service-portal-plugin  is at version 0.0.3, latest 1.0.0
⚠️ WARNING: Package iqe-insights-satellite-plugin  is at version 0.1.1.dev2+ge9acc37.d20190405, latest 0.1.2
============================================ test session starts =============================================
platform linux -- Python 3.6.6, pytest-4.3.0, py-1.8.0, pluggy-0.9.0 -- /home/dlezz/.pyenv/versions/3.6.6/envs/insights/bin/python
cachedir: .pytest_cache
metadata: {'Python': '3.6.6', 'Platform': 'Linux-4.15.0-47-generic-x86_64-with-debian-stretch-sid', 'Packages': {'pytest': '4.3.0', 'py': '1.8.0', 'pluggy': '0.9.0'}, 'Plugins': {'xdist': '1.27.0', 'report-parameters': '0.2', 'polarion-collect': '0.12', 'metadata': '1.8.0', 'html': '1.20.0', 'forked': '1.0.2', 'cov': '2.6.1', 'iqe-topology-inventory-plugin': '0.0.3', 'iqe-self-service-portal-plugin': '0.0.3', 'iqe-current-ui-plugin': '0.0.6', 'iqe-clientv3-plugin': '0.2', 'iqe-integration-tests': '0.9.3.dev9+g331d6ad', 'iqe-insights-satellite-plugin': '0.1.1.dev2+ge9acc37.d20190405'}}
Default Appliance hostname: access.redhat.com
Default Appliance path: insights/platform
rootdir: /home/dlezz/projects/insights/iqe-satellite-plugin, inifile:
plugins: xdist-1.27.0, report-parameters-0.2, polarion-collect-0.12, metadata-1.8.0, html-1.20.0, forked-1.0.2, cov-2.6.1, iqe-topology-inventory-plugin-0.0.3, iqe-self-service-portal-plugin-0.0.3, iqe-current-ui-plugin-0.0.6, iqe-clientv3-plugin-0.2, iqe-integration-tests-0.9.3.dev9+g331d6ad, iqe-insights-satellite-plugin-0.1.1.dev2+ge9acc37.d20190405
collected 1 item                                                                                             

iqe_insights_satellite/tests/test_ansible.py::test_satellite_ansible_install PASSED                    [100%]

============================================== warnings summary ==============================================
iqe_insights_satellite/tests/test_ansible.py::test_satellite_ansible_install
  /home/dlezz/.pyenv/versions/3.6.6/envs/insights/lib/python3.6/site-packages/openstack/cloud/_utils.py:372: DeprecationWarning: inspect.getargspec() is deprecated, use inspect.signature() or inspect.getfullargspec()
    argspec = inspect.getargspec(func)

-- Docs: https://docs.pytest.org/en/latest/warnings.html
=================================== 1 passed, 1 warnings in 269.46 seconds ===================================
```