### PR TITLE
In Sat 6.6 onclick content is different

### DIFF
--- a/airgun/views/host.py
+++ b/airgun/views/host.py
@@ -489,7 +489,7 @@ class HostsActionCommonDialog(BaseLoggedInView):
     title = None
     table = SatTable("//div[@class='modal-body']//table")
     keep_selected = Checkbox(id='keep_selected')
-    submit = Text('//button[@onclick="submit_modal_form()"]')
+    submit = Text('//button[@onclick="tfm.hosts.table.submitModalForm()"]')
 
     @property
     def is_displayed(self):


### PR DESCRIPTION
Without this fix, Robottelo test `tests/foreman/ui/test_host.py::test_positive_inherit_puppet_env_from_host_group_when_action` fails with:

```
session = <airgun.session.Session object at 0x7f0f8d54b198>

    @tier3
    def test_positive_inherit_puppet_env_from_host_group_when_action(session):
        """Host group puppet environment is inherited to already created
        host when corresponding action is applied to that host
    
        :id: 3f5af54e-e259-46ad-a2af-7dc1850891f5
    
        :customerscenario: true
    
        :expectedresults: Expected puppet environment is inherited to the host
    
        :BZ: 1414914
    
        :CaseLevel: System
        """
        org = entities.Organization().create()
        loc = entities.Location().create()
        host = entities.Host(organization=org, location=loc).create()
        env = entities.Environment(
            organization=[org], location=[loc]).create()
        hostgroup = entities.HostGroup(
            environment=env, organization=[org], location=[loc]).create()
        with session:
            session.organization.select(org_name=org.name)
            session.location.select(loc_name=loc.name)
            ###import time; time.sleep(1000)
            session.host.apply_action(
                'Change Environment',
                [host.name],
>               {'environment': '*Clear environment*'})

tests/foreman/ui/test_host.py:530: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
venv/lib/python3.6/site-packages/airgun/entities/host.py:125: in apply_action
    view.submit.click()
venv/lib/python3.6/site-packages/widgetastic/log.py:117: in wrapped
    result = f(self, *args, **kwargs)
venv/lib/python3.6/site-packages/widgetastic/widget/base.py:651: in click
    self.browser.click(self, ignore_ajax=(handle_alert is not None))
venv/lib/python3.6/site-packages/widgetastic/utils.py:682: in wrap
    return method(*args, **kwargs)
venv/lib/python3.6/site-packages/widgetastic/browser.py:365: in click
    el = self.move_to_element(locator, *args, **kwargs)
venv/lib/python3.6/site-packages/airgun/browser.py:651: in move_to_element
    el = self.element(locator, *args, **kwargs)
venv/lib/python3.6/site-packages/widgetastic/browser.py:337: in element
    elements = self.elements(locator, *args, **kwargs)
venv/lib/python3.6/site-packages/widgetastic/browser.py:836: in elements
    force_check_safe=force_check_safe)
venv/lib/python3.6/site-packages/widgetastic/utils.py:682: in wrap
    return method(*args, **kwargs)
venv/lib/python3.6/site-packages/widgetastic/browser.py:249: in elements
    locator = self._process_locator(locator)
venv/lib/python3.6/site-packages/widgetastic/browser.py:198: in _process_locator
    return locator.__element__()
venv/lib/python3.6/site-packages/widgetastic/widget/base.py:67: in wrapped
    return method(self, *new_args, **new_kwargs)
venv/lib/python3.6/site-packages/widgetastic/widget/base.py:342: in __element__
    return self.parent_browser.element(locator)
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

self = <airgun.browser.AirgunBrowser object at 0x7f0f8cf776a0>
locator = Locator(by='xpath', locator='//button[@onclick="submit_modal_form()"]')
args = (), kwargs = {}, vcheck = None, elements = []

    def element(self, locator, *args, **kwargs):
        """Returns one :py:class:`selenium.webdriver.remote.webelement.WebElement`
    
        See: :py:meth:`elements`
    
        Returns:
            :py:class:`selenium.webdriver.remote.webelement.WebElement`
    
        Raises:
            :py:class:`selenium.common.exceptions.NoSuchElementException`
        """
        try:
            vcheck = self._locator_force_visibility_check(locator)
            if vcheck is not None:
                kwargs['check_visibility'] = vcheck
            elements = self.elements(locator, *args, **kwargs)
            if len(elements) > 1:
                visible_elements = [e for e in elements if self.is_displayed(e)]
                if visible_elements:
                    return visible_elements[0]
                else:
                    return elements[0]
            else:
                return elements[0]
        except IndexError:
>           raise NoSuchElementException('Could not find an element {}'.format(repr(locator)))
E           selenium.common.exceptions.NoSuchElementException: Message: Could not find an element Locator(by='xpath', locator='//button[@onclick="submit_modal_form()"]')
```
With this fix, it fails beyond that:
```
session = <airgun.session.Session object at 0x7f8b6462d2b0>

    @tier3
    def test_positive_inherit_puppet_env_from_host_group_when_action(session):
        """Host group puppet environment is inherited to already created
        host when corresponding action is applied to that host
    
        :id: 3f5af54e-e259-46ad-a2af-7dc1850891f5
    
        :customerscenario: true
    
        :expectedresults: Expected puppet environment is inherited to the host
    
        :BZ: 1414914
    
        :CaseLevel: System
        """
        org = entities.Organization().create()
        loc = entities.Location().create()
        host = entities.Host(organization=org, location=loc).create()
        env = entities.Environment(
            organization=[org], location=[loc]).create()
        hostgroup = entities.HostGroup(
            environment=env, organization=[org], location=[loc]).create()
        with session:
            session.organization.select(org_name=org.name)
            session.location.select(loc_name=loc.name)
            ###import time; time.sleep(1000)
            session.host.apply_action(
                'Change Environment',
                [host.name],
                {'environment': '*Clear environment*'})
            host_values = session.host.search(host.name)
            assert host_values[0]['Host group'] == ''
            assert host_values[0]['Puppet Environment'] == ''
            session.host.apply_action(
                'Change Group',
                [host.name],
                {'host_group': hostgroup.name})
            host_values = session.host.search(host.name)
            assert host_values[0]['Host group'] == hostgroup.name
            assert host_values[0]['Puppet Environment'] == ''
            session.host.apply_action(
                'Change Environment',
                [host.name],
                {'environment': '*Inherit from host group*'})
            host_values = session.host.search(host.name)
            assert host_values[0]['Puppet Environment'] == env.name
>           values = session.host.read(host.name)
```
but for this I'll create an issue.