### PR TITLE
 command_executor can be configured for selenium/remote 

### DIFF
--- a/airgun/browser.py
+++ b/airgun/browser.py
@@ -202,7 +202,8 @@ class SeleniumBrowserFactory(object):
             elif browserName == 'firefox':
                 capabilities = webdriver.DesiredCapabilities.FIREFOX.copy()
             elif browserName == 'ie':
-                capabilities = webdriver.DesiredCapabilities.INTERNETEXPLORER.copy()
+                capabilities = (
+                        webdriver.DesiredCapabilities.INTERNETEXPLORER.copy())
             elif browserName == 'edge':
                 capabilities = webdriver.DesiredCapabilities.EDGE.copy()
             else:
@@ -214,8 +215,8 @@ class SeleniumBrowserFactory(object):
                 capabilities.update(
                     vars(settings.webdriver_desired_capabilities))
             self._webdriver = webdriver.Remote(
-                command_executor = settings.selenium.command_executor,
-                desired_capabilities = capabilities
+                command_executor=settings.selenium.command_executor,
+                desired_capabilities=capabilities
             )
             idle_timeout = settings.webdriver_desired_capabilities.idleTimeout
             if idle_timeout:

--- a/airgun/browser.py
+++ b/airgun/browser.py
@@ -196,10 +196,31 @@ class SeleniumBrowserFactory(object):
             self._webdriver = webdriver.PhantomJS(
                 service_args=['--ignore-ssl-errors=true'])
         elif self.browser == 'remote':
-            capabilities = vars(settings.webdriver_desired_capabilities)
+            browserName = settings.webdriver_desired_capabilities.browserName
+            if browserName == 'chrome':
+                capabilities = webdriver.DesiredCapabilities.CHROME.copy()
+            elif browserName == 'firefox':
+                capabilities = webdriver.DesiredCapabilities.FIREFOX.copy()
+            elif browserName == 'ie':
+                capabilities = webdriver.DesiredCapabilities.INTERNETEXPLORER.copy()
+            elif browserName == 'edge':
+                capabilities = webdriver.DesiredCapabilities.EDGE.copy()
+            else:
+                raise ValueError(
+                    '"{}" browserName is not supported. Please use one of {}'
+                    .format(browserName, ('chrome', 'firefox', 'ie', 'edge'))
+                )
+            if settings.webdriver_desired_capabilities:
+                capabilities.update(
+                    vars(settings.webdriver_desired_capabilities))
             self._webdriver = webdriver.Remote(
-                desired_capabilities=capabilities
+                command_executor = settings.selenium.command_executor,
+                desired_capabilities = capabilities
             )
+            idle_timeout = settings.webdriver_desired_capabilities.idleTimeout
+            if idle_timeout:
+                self._webdriver.command_executor.set_timeout(int(idle_timeout))
+
         if self._webdriver is None:
             raise ValueError(
                 '"{}" webdriver is not supported. Please use one of {}'

--- a/airgun/settings.py
+++ b/airgun/settings.py
@@ -46,6 +46,7 @@ class SeleniumSettings(object):
         self.screenshots_path = None
         self.webdriver = None
         self.webdriver_binary = None
+        self.command_executor = None
 
 
 class WebdriverCapabilitiesSettings(object):
@@ -53,6 +54,7 @@ class WebdriverCapabilitiesSettings(object):
     def __init__(self):
         self.platform = None
         self.version = None
+        self.browserName = None
         self.maxDuration = None
         self.idleTimeout = None
         self.seleniumVersion = None

--- a/settings.ini.example
+++ b/settings.ini.example
@@ -12,11 +12,13 @@ browser=selenium
 webdriver=chrome
 webdriver_binary=/home/user/path/to/chromedriver
 screenshots_path=/home/user/path/to/screenshots
+command_executor=http://127.0.0.1:4444/wd/hub
 # saucelabs_user=user
 # saucelabs_key=key
 
 # [webdriver_desired_capabilities]
 # platform=macOS 10.12
+# browserName=chrome
 # version=64.0
 # maxDuration=5400
 # idleTimeout=1000


### PR DESCRIPTION
This is an enhancement for the selenium/remote, the scenario is:
if I have a remote selenium webdriver, such as http://10.66.xxx.xxx:4444/wd/hub, and the browserName is firefox, I want to use it for robottelo UI testing, I can configure it in robottelo.properties: 
[robottelo]
browser=selenium
webdriver=remote
webdriver_desired_capabilities=platform=Linux,browserName=firefox
command_executor=http://10.66.xxx.xxx:4444/wd/hub

The key point is I don't need to care about how to deploy my remote webdriver and where is the webdriver,  you only need to provide an available command_executor to access the remote webdriver.