### PR TITLE
Remove TODO and FIXME comments (closes #10)

### DIFF
--- a/airgun/browser.py
+++ b/airgun/browser.py
@@ -263,7 +263,6 @@ class SeleniumBrowserFactory(object):
         idle_timeout = settings.webdriver_desired_capabilities.idleTimeout
         if idle_timeout:
             self._webdriver.command_executor.set_timeout(int(idle_timeout))
-        # todo: attempt to rename job here
         return self._webdriver
 
     def _get_docker_browser(self):

--- a/airgun/entities/login.py
+++ b/airgun/entities/login.py
@@ -11,7 +11,6 @@ class LoginEntity(BaseEntity):
         view.submit.click()
 
     def logout(self):
-        # fixme: not implemented
         pass
 
 
@@ -20,7 +19,7 @@ class NavigateToLogin(NavigateStep):
     VIEW = LoginView
 
     def step(self, *args, **kwargs):
-        # fixme: logout() if logged_in
+        # logout() if logged_in?
         pass
 
     def am_i_here(self, *args, **kwargs):

--- a/airgun/settings.py
+++ b/airgun/settings.py
@@ -18,9 +18,6 @@ def get_project_root():
         os.pardir,
     ))
 
-# todo: probably should use properties instead of class attributes
-# and use setters for validation
-
 
 class AirgunSettings(object):
 

--- a/airgun/views/common.py
+++ b/airgun/views/common.py
@@ -38,8 +38,6 @@ class BaseLoggedInView(View):
     flash = SatFlashMessages(
         locator='//div[@class="toast-notifications-list-pf"]')
     validations = ValidationErrors()
-    # TODO Defining current user procedure needs to be improved as it is not
-    # simple field, but a dropdown menu that contains more items/actions
     current_user = Text("//a[@id='account_menu']")
 
     def read(self, widget_names=None):

--- a/airgun/views/job_invocation.py
+++ b/airgun/views/job_invocation.py
@@ -126,7 +126,6 @@ class JobInvocationCreateView(BaseLoggedInView):
 
         @repeats_content.register('weekly')
         class RepeatWeeklyForm(View):
-            # todo implement checkbox group widget here
             at_hours = FilteredDropdown(id='triggering_time_time_4i')
             at_minutes = FilteredDropdown(id='triggering_time_time_5i')
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -53,12 +53,6 @@ nitpick_ignore = [
     ('py:meth', 'Widget.is_displayed'),
     ('py:obj', 'widgetastic.widget.View')
 ]
-# FIXME: No idea why I need these in the ignore list above (looks good to
-# my eyes in the code):
-#    ('py:meth', 'current_org'),
-#    ('py:meth', 'current_loc'),
-#    ('py:meth', 'select'),
-#    ('py:meth', 'fill_with'),
 intersphinx_mapping = {
     'python': ('http://docs.python.org/3.6', None),
     # 'widgetastic':

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,8 +4,6 @@ from airgun import settings
 pytest_plugins = ["airgun.fixtures"]
 
 
-# todo: make sure this hook is needed - for unit tests configuring may be
-# redundant
 def pytest_collection_modifyitems():
     """ called after collection has been performed, may filter or re-order
     the items in-place.


### PR DESCRIPTION
Source code comments are not the best project management tool. Plus we need single source of truth, not ideas scattered across multiple places.

GitHub issues with references to these comments were created instead:

* #348
* #349
* #350
* #351
* #352

This, in some way, implements #10. We could argue proper fixes for these comments should be implemented to really close #10, but let's face it - at this point of project lifecycle, these comments are enhancement ideas, not bugs.