### PR TITLE
fixed test_positive_latest_warning_error_tasks

### DIFF
--- a/airgun/views/task.py
+++ b/airgun/views/task.py
@@ -53,4 +53,4 @@ class TaskDetailsView(BaseLoggedInView):
         state = Text("//div[contains(@class, 'progress-description')]")
         progressbar = ProgressBar()
         output = TaskReadOnlyEntry(name='Output')
-        errors = TaskReadOnlyEntry(name='Errors')
+        errors = Text("//pre")


### PR DESCRIPTION
### PR description 
locator has changed, hence test was failing. 

### Test Result 

```
Testing started at 4:09 PM ...
/home/okhatavk/Satellite/robottelo/env/bin/python /home/okhatavk/Downloads/pycharm-community-2018.1.4/helpers/pydev/pydevd.py --multiproc --qt-support=auto --client 127.0.0.1 --port 45674 --file /home/okhatavk/Downloads/pycharm-community-2018.1.4/helpers/pycharm/_jb_pytest_runner.py --target test_dashboard.py::test_positive_latest_warning_error_tasks
pydev debugger: process 14513 is connecting

Connected to pydev debugger (build 181.5087.37)
Launching py.test with arguments test_dashboard.py::test_positive_latest_warning_error_tasks in /home/okhatavk/Satellite/robottelo/tests/foreman/ui

2019-07-03 16:09:22 - conftest - DEBUG - Registering custom pytest_configure

2019-07-03 16:09:22 - conftest - DEBUG - Fetching BZs to deselect...

2019-07-03 16:10:09 - conftest - DEBUG - Deselected tests reason: BZ resolution ['1475443', '1199150', '1375643', '1147100', '1479291', '1214312', '1347658', '1156555', '1321543', '1217635', '1487317', '1311113', '1226425', '1230902', '1204686', '1414821', '1278917', '1310422']

2019-07-03 16:10:09 - conftest - DEBUG - Deselected tests reason: missing version flag ['1475443', '1701118', '1602835', '1199150', '1375643', '1147100', '1479291', '1636067', '1214312', '1378442', '1347658', '1489322', '1194476', '1156555', '1701132', '1610309', '1321543', '1217635', '1487317', '1311113', '1375857', '1226425', '1682940', '1230902', '1722475', '1204686', '1711929', '1581628', '1625783', '1725686', '1278917', '1310422', '1436209', '1488908', '1716307']

2019-07-03 16:10:09 - conftest - DEBUG - Deselected tests reason: sat-backlog ['1475443', '1701118', '1199150', '1375643', '1147100', '1479291', '1214312', '1378442', '1347658', '1489322', '1194476', '1156555', '1701132', '1610309', '1321543', '1217635', '1487317', '1311113', '1375857', '1226425', '1682940', '1230902', '1204686', '1581628', '1625783', '1278917', '1310422', '1436209']

============================= test session starts ==============================


========================== 1 passed in 397.52 seconds ==========================
Process finished with exit code 0

```