### PR TITLE
Discovered Host and Discovery Rule Menu locator Fixed

### DIFF
--- a/airgun/entities/discoveredhosts.py
+++ b/airgun/entities/discoveredhosts.py
@@ -126,7 +126,7 @@ class ShowAllDiscoveredHosts(NavigateStep):
     VIEW = DiscoveredHostsView
 
     def step(self, *args, **kwargs):
-        self.view.menu.select('Hosts', 'Discovered hosts')
+        self.view.menu.select('Hosts', 'Discovered Hosts')
 
 
 @navigator.register(DiscoveredHostsEntity, 'Details')

--- a/airgun/entities/discoveryrule.py
+++ b/airgun/entities/discoveryrule.py
@@ -129,7 +129,7 @@ class ShowAllDiscoveryRules(NavigateStep):
     VIEW = DiscoveryRulesView
 
     def step(self, *args, **kwargs):
-        self.view.menu.select('Configure', 'Discovery rules')
+        self.view.menu.select('Configure', 'Discovery Rules')
 
 
 @navigator.register(DiscoveryRuleEntity, 'New')


### PR DESCRIPTION
Fixes UI Discovered Hosts and Discovery Rule Failed Tests:

Discovered Host:
-------------------------------------
```
# py.test tests/foreman/ui/test_discoveredhost.py -k test_positive_delete
2019-07-04 19:25:02 - conftest - DEBUG - Registering custom pytest_configure

2019-07-04 19:25:02 - conftest - DEBUG - Fetching BZs to deselect...

========================================== test session starts ==========================================
platform linux -- Python 3.6.8, pytest-4.6.3, py-1.7.0, pluggy-0.12.0
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/jitendrayejare/Desktop/RedHat/RoboTelloNew/robottelo
plugins: forked-1.0.2, services-1.3.1, xdist-1.26.1, mock-1.10.4, cov-2.6.1
collecting ... 2019-07-04 19:25:24 - conftest - DEBUG - Collected 8 test cases

collected 8 items / 7 deselected / 1 selected                                                           

tests/foreman/ui/test_discoveredhost.py .                                                         [100%]

================================ 1 passed, 7 deselected in 72.17 seconds ================================
```

This fixes all the UI Discovered Hosts tests failing due to incorrect locator.


Discovery Rule:
-----------------------------------
```
py.test tests/foreman/ui/test_discoveryrule.py -k test_positive_create_rule_with_non_admin_user
2019-07-04 20:34:52 - conftest - DEBUG - Registering custom pytest_configure

2019-07-04 20:34:52 - conftest - DEBUG - Fetching BZs to deselect...

========================================== test session starts ==========================================
platform linux -- Python 3.6.8, pytest-4.6.3, py-1.7.0, pluggy-0.12.0
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/jitendrayejare/Desktop/RedHat/RoboTelloNew/robottelo
plugins: forked-1.0.2, services-1.3.1, xdist-1.26.1, mock-1.10.4, cov-2.6.1
collecting ... 2019-07-04 20:35:15 - conftest - DEBUG - Collected 6 test cases

collected 6 items / 5 deselected / 1 selected                                                           

tests/foreman/ui/test_discoveryrule.py .                                                         [100%]

================================ 1 passed, 5 deselected in 82.26 seconds ================================
```

This fixes all the UI Discovery Rules tests failing due to incorrect locator.