### PR TITLE
added custom table to return the empty rows message

### DIFF
--- a/airgun/views/contentcredential.py
+++ b/airgun/views/contentcredential.py
@@ -13,6 +13,16 @@ from airgun.widgets import (
 )
 
 
+class TableWithNoRowsMessage(Table):
+    no_rows_message = Text("//span[contains(@data-block, 'no-rows-message')]")
+
+    def read(self):
+        if self.no_rows_message.is_displayed:
+            return self.no_rows_message.text
+        else:
+            self.parent.read()
+
+
 class ContentCredentialsTableView(BaseLoggedInView, SearchableViewMixin):
     title = Text("//h2[contains(., 'Content Credentials')]")
     new = Text("//button[contains(@href, '/content_credentials/new')]")
@@ -68,7 +78,7 @@ class ContentCredentialEditView(BaseLoggedInView):
 
     @View.nested
     class products(SatTab, SearchableViewMixin):
-        table = Table(
+        table = TableWithNoRowsMessage(
             './/table',
             column_widgets={'Name': Text('./a')}
         )


### PR DESCRIPTION
### PR objective 
Currently when a table has not any qualified rows and it contains empty row message with some useful text was not return correctly, hence added custom table to return that.

### What was the problem? 
The earlier table was read and the empty message was returned a row with column widget which is absolutely wrong and dependent assertions were failed.

### Solution
Created the custom table widget to solve this.     
    
### Possible Upstream Commit 
https://github.com/Katello/katello/commit/48acd2ee14fb54fd79f1b1005dae988555230a84#diff-df08c0b5c1111c905e5e022b202c6415R6105


### Test Result 

```
Testing started at 11:51 AM ...
/home/okhatavk/Satellite/robottelo/env/bin/python /home/okhatavk/Downloads/pycharm-community-2018.1.4/helpers/pycharm/_jb_pytest_runner.py --target test_contentcredential.py::test_positive_delete_key_for_repo_from_product_with_repo
Launching py.test with arguments test_contentcredential.py::test_positive_delete_key_for_repo_from_product_with_repo in /home/okhatavk/Satellite/robottelo/tests/foreman/ui

2019-07-08 11:51:02 - conftest - DEBUG - Registering custom pytest_configure

2019-07-08 11:51:02 - conftest - DEBUG - Fetching BZs to deselect...

2019-07-08 11:52:25 - conftest - DEBUG - Deselected tests reason: BZ resolution ['1147100', '1475443', '1230902', '1487317', '1375643', '1278917', '1347658', '1414821', '1214312', '1204686', '1226425', '1199150', '1321543', '1217635', '1156555', '1479291', '1311113', '1310422']

2019-07-08 11:52:25 - conftest - DEBUG - Deselected tests reason: missing version flag ['1147100', '1475443', '1378442', '1489322', '1230902', '1487317', '1375643', '1636067', '1701132', '1488908', '1610309', '1278917', '1347658', '1725686', '1722475', '1375857', '1581628', '1214312', '1711929', '1436209', '1625783', '1204686', '1226425', '1194476', '1199150', '1716307', '1321543', '1217635', '1156555', '1682940', '1701118', '1479291', '1311113', '1602835', '1310422']

2019-07-08 11:52:25 - conftest - DEBUG - Deselected tests reason: sat-backlog ['1147100', '1475443', '1378442', '1489322', '1230902', '1487317', '1375643', '1701132', '1610309', '1278917', '1347658', '1375857', '1581628', '1214312', '1436209', '1625783', '1204686', '1226425', '1194476', '1199150', '1321543', '1217635', '1156555', '1682940', '1701118', '1479291', '1311113', '1310422']

============================= test session starts ==============================
platform linux -- Python 3.4.8, pytest-4.0.2, py-1.7.0, pluggy-0.9.0
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/okhatavk/Satellite/robottelo, inifile:
plugins: xdist-1.26.1, services-1.3.1, mock-1.10.0, forked-1.0.2, cov-2.6.12019-07-08 11:52:25 - conftest - DEBUG - Collected 1 test cases

collected 1 item

test_contentcredential.py                                               [100%]

========================== 1 passed in 338.77 seconds 
```