### PR TITLE
updated locator from key_type to parameter_type

### DIFF
--- a/airgun/views/smart_class_parameter.py
+++ b/airgun/views/smart_class_parameter.py
@@ -33,7 +33,7 @@ class SmartClassParameterContent(View):
         locator=".//input[contains(@name, '[puppetclass_id]')]")
     override = Checkbox(
         locator=".//input[contains(@name, '[override]') and @type!='hidden']")
-    parameter_type = Select(locator=".//select[contains(@class, 'parameter_type')]")
+    parameter_type = Select(locator=".//select[contains(@name, '[parameter_type]')]")
     default_value = TextInputHidden(
         locator=".//textarea[contains(@name, '[default_value]')]")
     omit = Checkbox(

--- a/airgun/views/smart_class_parameter.py
+++ b/airgun/views/smart_class_parameter.py
@@ -33,7 +33,7 @@ class SmartClassParameterContent(View):
         locator=".//input[contains(@name, '[puppetclass_id]')]")
     override = Checkbox(
         locator=".//input[contains(@name, '[override]') and @type!='hidden']")
-    key_type = Select(locator=".//select[contains(@name, '[key_type]')]")
+    parameter_type = Select(locator=".//select[contains(@class, 'parameter_type')]")
     default_value = TextInputHidden(
         locator=".//textarea[contains(@name, '[default_value]')]")
     omit = Checkbox(

--- a/airgun/views/smart_variable.py
+++ b/airgun/views/smart_variable.py
@@ -28,7 +28,7 @@ class SmartVariableContent(View):
     description = TextInput(
         locator=".//textarea[contains(@name, '[description]')]")
     puppet_class = FilteredDropdown(id='variable_lookup_key_puppetclass_id')
-    parameter_type = Select(locator=".//select[contains(@name, 'parameter_type')]")
+    parameter_type = Select(locator=".//select[contains(@name, '[parameter_type]')]")
     default_value = TextInputHidden(
         locator=".//textarea[contains(@name, '[default_value]')]")
     hidden = Checkbox(locator=".//input[contains(@name, '[hidden_value]')]")

--- a/airgun/views/smart_variable.py
+++ b/airgun/views/smart_variable.py
@@ -28,7 +28,7 @@ class SmartVariableContent(View):
     description = TextInput(
         locator=".//textarea[contains(@name, '[description]')]")
     puppet_class = FilteredDropdown(id='variable_lookup_key_puppetclass_id')
-    key_type = Select(locator=".//select[contains(@name, '[key_type]')]")
+    parameter_type = Select(locator=".//select[contains(@name, 'parameter_type')]")
     default_value = TextInputHidden(
         locator=".//textarea[contains(@name, '[default_value]')]")
     hidden = Checkbox(locator=".//input[contains(@name, '[hidden_value]')]")


### PR DESCRIPTION
### PR Objective
Fix the smart class parameter tests. 

### What is failure ?
Currently, the select field name has changed from key_type to parameter_type   

### Solution
changed the locators and updated tests as well here in this PR 

###Upstream PR 
https://github.com/theforeman/foreman/pull/5241/files#diff-6c69b0cc93d393f1605b2749fda757bfR3

### Test Result 
```
Testing started at 6:16 PM ...
/home/okhatavk/Satellite/robottelo/env/bin/python /home/okhatavk/Downloads/pycharm-community-2018.1.4/helpers/pycharm/_jb_pytest_runner.py --target test_smartclassparameter.py::test_positive_end_to_end
Launching py.test with arguments test_smartclassparameter.py::test_positive_end_to_end in /home/okhatavk/Satellite/robottelo/tests/foreman/ui

2019-07-08 18:16:55 - conftest - DEBUG - Registering custom pytest_configure

2019-07-08 18:16:55 - conftest - DEBUG - Fetching BZs to deselect...

2019-07-08 18:17:14 - conftest - DEBUG - Deselected tests reason: BZ resolution ['1414821', '1321543', '1487317', '1214312', '1204686', '1199150', '1278917', '1347658', '1479291', '1311113', '1156555', '1147100', '1310422', '1475443', '1226425', '1230902', '1217635']

2019-07-08 18:17:14 - conftest - DEBUG - Deselected tests reason: missing version flag ['1625783', '1701118', '1610309', '1321543', '1436209', '1487317', '1489322', '1214312', '1488908', '1204686', '1199150', '1581628', '1701132', '1278917', '1194476', '1682940', '1722475', '1347658', '1378442', '1479291', '1602835', '1636067', '1311113', '1711929', '1725686', '1156555', '1147100', '1310422', '1475443', '1716307', '1226425', '1230902', '1217635']

2019-07-08 18:17:14 - conftest - DEBUG - Deselected tests reason: sat-backlog ['1625783', '1701118', '1610309', '1321543', '1436209', '1487317', '1489322', '1214312', '1204686', '1199150', '1581628', '1701132', '1278917', '1194476', '1682940', '1347658', '1378442', '1479291', '1311113', '1156555', '1147100', '1310422', '1475443', '1226425', '1230902', '1217635']

============================= test session starts ==============================
platform linux -- Python 3.4.8, pytest-4.0.2, py-1.7.0, pluggy-0.9.0
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/okhatavk/Satellite/robottelo, inifile:
plugins: xdist-1.26.1, services-1.3.1, mock-1.10.0, forked-1.0.2, cov-2.6.12019-07-08 18:17:14 - conftest - DEBUG - Collected 1 test cases

collected 1 item



-- Docs: https://docs.pytest.org/en/latest/warnings.html
=================== 1 passed, 60 warnings in 367.26 seconds ====================
Process finished with exit code 0
```