### PR TITLE
In 6.6 there is one more div in td->div->a, so lets be smarter here

### DIFF
--- a/airgun/views/hardware_model.py
+++ b/airgun/views/hardware_model.py
@@ -11,7 +11,7 @@ class HardwareModelsView(BaseLoggedInView, SearchableViewMixin):
     table = SatTable(
         './/table',
         column_widgets={
-            'Name': Text('./a'),
+            'Name': Text('.//a'),
             'Actions': Text('.//a[@data-method="delete"]'),
         }
     )


### PR DESCRIPTION
Without the fix:
```
    def test_positive_end_to_end(session, module_org, module_loc):
        """Perform end to end testing for hardware model component
    
        :id: 93663cc9-7c8f-4f43-8050-444be1313bed
    
        :expectedresults: All expected CRUD actions finished successfully
    
        :CaseLevel: Integration
    
        :CaseImportance: High
        """
        name = gen_string('alpha')
        model = gen_string('alphanumeric')
        vendor_class = gen_string('alpha')
        info = gen_string('alpha')
        new_name = gen_string('alpha')
        host_template = entities.Host(organization=module_org, location=module_loc)
        host_template.create_missing()
        with session:
            # Create new hardware model
            session.hardwaremodel.create({
                'name': name,
                'hardware_model': model,
                'vendor_class': vendor_class,
                'info': info,
            })
            assert session.hardwaremodel.search(name)[0]['Name'] == name
> hm_values = session.hardwaremodel.read(name)

tests/foreman/ui/test_hardwaremodel.py:54:
[...]
    def pre_navigate(self, _tries, *args, **kwargs):
        """Describes steps that takes place before any prerequisite or navigation takes place.
    
        This is a default and is generally overridden.
        """
        if _tries > self._default_tries:
> raise NavigationTriesExceeded(self._name)
E navmazing.NavigationTriesExceeded: Navigation failed to reach [Edit] in the specificed tries
```

with the fix, we are failing far later in the test because of bug https://bugzilla.redhat.com/show_bug.cgi?id=1729386 (I think):

```
    @tier2
    @upgrade
    def test_positive_end_to_end(session, module_org, module_loc):
        """Perform end to end testing for hardware model component
    
        :id: 93663cc9-7c8f-4f43-8050-444be1313bed
    
        :expectedresults: All expected CRUD actions finished successfully
    
        :CaseLevel: Integration
    
        :CaseImportance: High
        """
        name = gen_string('alpha')
        model = gen_string('alphanumeric')
        vendor_class = gen_string('alpha')
        info = gen_string('alpha')
        new_name = gen_string('alpha')
        host_template = entities.Host(organization=module_org, location=module_loc)
        host_template.create_missing()
        with session:
            # Create new hardware model
            session.hardwaremodel.create({
                'name': name,
                'hardware_model': model,
                'vendor_class': vendor_class,
                'info': info,
            })
            assert session.hardwaremodel.search(name)[0]['Name'] == name
            hm_values = session.hardwaremodel.read(name)
            assert hm_values['name'] == name
            assert hm_values['hardware_model'] == model
            assert hm_values['vendor_class'] == vendor_class
            assert hm_values['info'] == info
            # Create host with associated hardware model
            host_name = create_fake_host(
                session,
                host_template,
                extra_values={'additional_information.hardware_model': name}
            )
            host_values = session.host.read(host_name, 'additional_information')
            assert host_values['additional_information']['hardware_model'] == name
            # Update hardware model with new name
            session.hardwaremodel.update(name, {'name': new_name})
            assert session.hardwaremodel.search(new_name)[0]['Name'] == new_name
            host_values = session.host.read(host_name, 'additional_information')
            assert host_values['additional_information']['hardware_model'] == new_name
            # Make an attempt to delete hardware model that associated with host
            with raises(AssertionError) as context:
                session.hardwaremodel.delete(new_name)
            assert "error: '{} is used by {}'".format(
                new_name, host_name) in str(context.value)
            session.host.update(host_name, {'additional_information.hardware_model': ''})
            # Delete hardware model
            session.hardwaremodel.delete(new_name)
>           assert not session.hardwaremodel.search(new_name)
[...]
self = <airgun.browser.AirgunBrowserPlugin object at 0x7fd570349ef0>
timeout = '30s'

    def ensure_page_safe(self, timeout='10s'):
        # THIS ONE SHOULD ALWAYS USE JAVASCRIPT ONLY, NO OTHER SELENIUM INTERACTION
    
        def _check():
            result = self.browser.execute_script(self.ENSURE_PAGE_SAFE, silent=True)
            # TODO: Logging
            try:
                return all(result.values())
            except AttributeError:
                return True
    
>       wait_for(_check, timeout=timeout, delay=0.2, very_quiet=True)
E       wait_for.TimedOutError: Could not do function _check() at /home/pok/Checkouts/robottelo/venv/lib/python3.7/site-packages/widgetastic/browser.py:51 in time
```