### PR TITLE
removing unwanted wait after delete operation

### DIFF
--- a/airgun/entities/product.py
+++ b/airgun/entities/product.py
@@ -1,4 +1,3 @@
-from wait_for import wait_for
 from navmazing import NavigateToSibling
 
 from airgun.entities.base import BaseEntity
@@ -39,13 +38,6 @@ class ProductEntity(BaseEntity):
         view.dialog.confirm()
         view.flash.assert_no_error()
         view.flash.dismiss()
-        view = self.navigate_to(self, 'All')
-        wait_for(
-            lambda: view.search('name = "{0}"'.format(entity_name)) == [],
-            timeout=30,
-            delay=2,
-            logger=view.logger
-        )
 
     def search(self, value):
         """Search for specific product"""


### PR DESCRIPTION
### PR Objective
Currently, the test is waiting for the searched deleted entity,  and we are getting an empty message instead of an empty list 

### Solution 
Removing wait_for will not cross the for the entity and search step already has been added all tests so removing it. (i thought this best option)

We do have another option to add an empty message, I personally not like that could against airgun code standards.

### Test Result   

```
Testing started at 8:18 PM ...
/home/okhatavk/Satellite/robottelo/env/bin/python /home/okhatavk/Downloads/pycharm-community-2018.1.4/helpers/pycharm/_jb_pytest_runner.py --target test_product.py::test_positive_end_to_end
Launching py.test with arguments test_product.py::test_positive_end_to_end in /home/okhatavk/Satellite/robottelo/tests/foreman/ui

2019-07-15 20:18:51 - conftest - DEBUG - Registering custom pytest_configure

2019-07-15 20:18:51 - conftest - DEBUG - Fetching BZs to deselect...

2019-07-15 20:19:14 - conftest - DEBUG - Deselected tests reason: BZ resolution ['1475443', '1347658', '1156555', '1414821', '1226425', '1199150', '1311113', '1204686', '1278917', '1214312', '1217635', '1310422', '1230902', '1479291', '1147100', '1487317']

2019-07-15 20:19:14 - conftest - DEBUG - Deselected tests reason: missing version flag ['1475443', '1610309', '1347658', '1156555', '1226425', '1489322', '1199150', '1311113', '1436209', '1204686', '1278917', '1378442', '1214312', '1625783', '1217635', '1310422', '1701118', '1230902', '1682940', '1479291', '1147100', '1581628', '1194476', '1701132', '1487317']

2019-07-15 20:19:14 - conftest - DEBUG - Deselected tests reason: sat-backlog ['1475443', '1610309', '1347658', '1156555', '1226425', '1489322', '1199150', '1311113', '1436209', '1204686', '1278917', '1378442', '1214312', '1625783', '1217635', '1310422', '1701118', '1230902', '1682940', '1479291', '1147100', '1581628', '1194476', '1701132', '1487317']

============================= test session starts ==============================
platform linux -- Python 3.4.8, pytest-4.0.2, py-1.7.0, pluggy-0.9.0
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/okhatavk/Satellite/robottelo, inifile:
plugins: xdist-1.26.1, services-1.3.1, mock-1.10.0, forked-1.0.2, cov-2.6.12019-07-15 20:19:14 - conftest - DEBUG - Collected 1 test cases

collected 1 item

test_product.py                                                         [100%]

=============================== warnings summary ===============================

```