### PR TITLE
Get virtwho configure status by icon color

### DIFF
--- a/airgun/views/virtwho_configure.py
+++ b/airgun/views/virtwho_configure.py
@@ -8,7 +8,6 @@ from widgetastic.widget import (
     Text,
     TextInput,
     View,
-    Widget,
 )
 from airgun.views.common import (
     BaseLoggedInView,

--- a/airgun/views/virtwho_configure.py
+++ b/airgun/views/virtwho_configure.py
@@ -49,7 +49,6 @@ class StatusIcon(GenericLocatorWidget):
             'rgb(63, 156, 53)': 'green',
             'rgb(54, 54, 54)': 'gray',
         }
-        print(self.browser.element(self, parent=self.parent).value_of_css_property('color'))
         return colors.get(
             self.browser.element(self, parent=self.parent).value_of_css_property('color'),
             'unknown'

--- a/airgun/views/virtwho_configure.py
+++ b/airgun/views/virtwho_configure.py
@@ -8,6 +8,7 @@ from widgetastic.widget import (
     Text,
     TextInput,
     View,
+    Widget,
 )
 from airgun.views.common import (
     BaseLoggedInView,
@@ -57,7 +58,7 @@ class VirtwhoConfigureStatus(GenericLocatorWidget):
         raise ReadOnlyWidgetError('Status widget is read only')
 
 
-class VirtwhoConfigureScript(GenericLocatorWidget):
+class VirtwhoConfigureScript(Widget):
     """Return the virtwho configure script by innerHTML.
     It will preserve the line break and whitespace.
     """
@@ -206,5 +207,5 @@ class VirtwhoConfigureDetailsView(BaseLoggedInView):
     @View.nested
     class deploy(SatTab):
         command = Text("//pre[@id='config_command']")
-        script = VirtwhoConfigureScript('.')
+        script = VirtwhoConfigureScript()
         download = Text("//a[text()='Download the script']")

--- a/airgun/views/virtwho_configure.py
+++ b/airgun/views/virtwho_configure.py
@@ -2,11 +2,13 @@ from widgetastic_patternfly import BreadCrumb
 
 from widgetastic.widget import (
     Checkbox,
+    GenericLocatorWidget,
     ConditionalSwitchableView,
     Table,
     Text,
     TextInput,
     View,
+    Widget,
 )
 from airgun.views.common import (
     BaseLoggedInView,
@@ -19,6 +21,45 @@ from airgun.widgets import (
 )
 
 
+class StatusIcon(GenericLocatorWidget):
+    """The status for virtwho configure can be: green, gray.
+
+    green: The virt-who report has not arrived within the interval,
+         which indicates there was no change on hypervisor
+    gray: The configuration was not deployed yet or the virt-who was
+        unable to report the status
+    """
+
+    def __init__(self, parent, locator=None, logger=None):
+        """Provide default locator value if it wasn't passed"""
+        if not locator:
+            locator = ".//span[contains(@class, 'virt-who-config-report-status')]"
+        Widget.__init__(self, parent, logger=logger)
+        self.locator = locator
+
+    @property
+    def color(self):
+        """Returns string representing icon color: 'gray', 'green' or'unknown'.
+        rgba is created for chrome.
+        rbg is created for firefox.
+        """
+        colors = {
+            'rgba(54, 54, 54, 1)': 'gray',
+            'rgba(63, 156, 53, 1)': 'green',
+            'rgb(63, 156, 53)': 'green',
+            'rgb(54, 54, 54)': 'gray',
+        }
+        print(self.browser.element(self, parent=self.parent).value_of_css_property('color'))
+        return colors.get(
+            self.browser.element(self, parent=self.parent).value_of_css_property('color'),
+            'unknown'
+        )
+
+    def read(self):
+        """Returns current icon color"""
+        return self.color
+
+
 class VirtwhoConfiguresView(BaseLoggedInView, SearchableViewMixin):
     title = Text("//h1[text()='Virt-who Configurations']")
     new = Text("//a[contains(@href, '/foreman_virt_who_configure/configs/new')]")
@@ -26,6 +67,7 @@ class VirtwhoConfiguresView(BaseLoggedInView, SearchableViewMixin):
         './/table',
         column_widgets={
             'Name': Text('./a'),
+            'Status': StatusIcon(),
             'Actions': ActionsDropdown("./div[contains(@class, 'btn-group')]"),
         }
     )
@@ -134,7 +176,7 @@ class VirtwhoConfigureDetailsView(BaseLoggedInView):
 
     @View.nested
     class overview(SatTab):
-        status = Text('.//span[contains(@class,"virt-who-config-report-status")]')
+        status = StatusIcon()
         hypervisor_type = Text('.//span[contains(@class,"config-hypervisor_type")]')
         hypervisor_server = Text('.//span[contains(@class,"config-hypervisor_server")]')
         hypervisor_username = Text('.//span[contains(@class,"config-hypervisor_username")]')

--- a/airgun/views/virtwho_configure.py
+++ b/airgun/views/virtwho_configure.py
@@ -18,6 +18,7 @@ from airgun.widgets import (
     ActionsDropdown,
     FilteredDropdown,
 )
+from airgun.exceptions import ReadOnlyWidgetError
 
 
 class VirtwhoConfigureStatus(GenericLocatorWidget):
@@ -51,6 +52,29 @@ class VirtwhoConfigureStatus(GenericLocatorWidget):
     def read(self):
         """Returns current status"""
         return self.status
+
+    def fill(self, value):
+        raise ReadOnlyWidgetError('Status widget is read only')
+
+
+class VirtwhoConfigureScript(GenericLocatorWidget):
+    """Return the virtwho configure script by innerHTML.
+    It will preserve the line break and whitespace.
+    """
+
+    SCRIPT_PRE = ".//pre[@id='config_script']"
+
+    @property
+    def content(self):
+        element = self.browser.element(self.SCRIPT_PRE)
+        return element.get_attribute('innerHTML')
+
+    def read(self):
+        """Returns the script content"""
+        return self.content
+
+    def fill(self, value):
+        raise ReadOnlyWidgetError('Script widget is read only')
 
 
 class VirtwhoConfiguresView(BaseLoggedInView, SearchableViewMixin):
@@ -182,4 +206,5 @@ class VirtwhoConfigureDetailsView(BaseLoggedInView):
     @View.nested
     class deploy(SatTab):
         command = Text("//pre[@id='config_command']")
-        script = Text("//pre[@id='config_script']")
+        script = VirtwhoConfigureScript('.')
+        download = Text("//a[text()='Download the script']")


### PR DESCRIPTION
After deployed the virtwho configure, we need to validate the configure status, but it's difficult to get the status by Text:
<span class="virt-who-config-report-status pficon-ok status-ok" title="" data-original-title="The virt-who report arrived within the interval"></span>

This commit will support to get the status from icon color:
`rgba(63, 156, 53, 1)': 'green'` => configure is deployed successfully.
`rgba(54, 54, 54, 1)': 'gray'`  => configure is not reported yet.