### PR TITLE
fixed audit dynamic locator

### DIFF
--- a/airgun/views/audit.py
+++ b/airgun/views/audit.py
@@ -12,7 +12,7 @@ class AuditEntry(View):
     resource_type = Text(".//div[@class='list-view-pf-additional-info-item'][1]")
     resource_name = Text(".//div[@class='list-view-pf-additional-info-item'][2]")
     created_at = Text(".//div[@class='list-view-pf-actions']/span")
-    expander = Text(".//div[@class='list-view-pf-expand']/span")
+    expander = Text(".//div[contains(@class, 'list-view-pf-expand')]/span")
     affected_organization = Text(
         ".//div[normalize-space(.) = 'Affected Organizations']/following-sibling::div")
     affected_location = Text(


### PR DESCRIPTION
### Description  
Class name changes dynamically from class='list-view-pf-expand' to class='list-view-pf-expand active' when the drop-down is by default is shown. Hence it was not able to get located, I tried to fix this with using contains 

### Test Result 

```
Testing started at 2:38 PM ...
/home/okhatavk/Satellite/robottelo/env/bin/python /home/okhatavk/Downloads/pycharm-community-2018.1.4/helpers/pycharm/_jb_pytest_runner.py --target test_audit.py::test_positive_update_event
Launching py.test with arguments test_audit.py::test_positive_update_event in /home/okhatavk/Satellite/robottelo/tests/foreman/ui

2019-07-16 14:38:11 - conftest - DEBUG - Registering custom pytest_configure

2019-07-16 14:38:11 - conftest - DEBUG - Fetching BZs to deselect...

2019-07-16 14:38:35 - conftest - DEBUG - Deselected tests reason: BZ resolution ['1226425', '1147100', '1310422', '1214312', '1278917', '1230902', '1475443', '1347658', '1204686', '1311113', '1217635', '1487317', '1479291', '1156555', '1414821', '1199150']

2019-07-16 14:38:35 - conftest - DEBUG - Deselected tests reason: missing version flag ['1194476', '1701118', '1226425', '1147100', '1610309', '1701132', '1310422', '1214312', '1625783', '1278917', '1230902', '1475443', '1347658', '1204686', '1311113', '1378442', '1217635', '1487317', '1489322', '1479291', '1682940', '1581628', '1156555', '1199150', '1436209']

2019-07-16 14:38:35 - conftest - DEBUG - Deselected tests reason: sat-backlog ['1194476', '1701118', '1226425', '1147100', '1610309', '1701132', '1310422', '1214312', '1625783', '1278917', '1230902', '1475443', '1347658', '1204686', '1311113', '1378442', '1217635', '1487317', '1489322', '1479291', '1682940', '1581628', '1156555', '1199150', '1436209']

============================= test session starts ==============================
platform linux -- Python 3.4.8, pytest-4.0.2, py-1.7.0, pluggy-0.9.0
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/okhatavk/Satellite/robottelo, inifile:
plugins: xdist-1.26.1, services-1.3.1, mock-1.10.0, forked-1.0.2, cov-2.6.12019-07-16 14:38:35 - conftest - DEBUG - Collected 1 test cases

collected 1 item
 [100%]

========================== 1 passed in 63.34 seconds ==========================
```
  
