### PR TITLE
removing unwanted wait causing issues for naviagation and asseration

### DIFF
--- a/airgun/entities/contentview.py
+++ b/airgun/entities/contentview.py
@@ -239,6 +239,10 @@ class ContentViewEntity(BaseEntity):
         view.confirm_remove.click()
         view.flash.assert_no_error()
         view.flash.dismiss()
+        view = self.navigate_to(self, 'Edit', entity_name=entity_name)
+        result = view.versions.search(version_name)
+        if completely and result[0]['Version'] != version_name:
+            return view.versions.table.row(version=version_name)['Status'].widget.wait_for_result()
 
 
 @navigator.register(ContentViewEntity, 'All')

--- a/airgun/entities/contentview.py
+++ b/airgun/entities/contentview.py
@@ -239,12 +239,6 @@ class ContentViewEntity(BaseEntity):
         view.confirm_remove.click()
         view.flash.assert_no_error()
         view.flash.dismiss()
-        view = self.navigate_to(self, 'Edit', entity_name=entity_name)
-        result = view.versions.search(version_name)
-        if completely and not result:
-            return
-        view.versions.table.row(
-            version=version_name)['Status'].widget.wait_for_result()
 
 
 @navigator.register(ContentViewEntity, 'All')


### PR DESCRIPTION
### PR Objective
Remove this unwanted waiting for the result as in throughout robottelo code uses search entity after removal or deletion. One of the reasons I wanted to remove this was causing a navigation issue.

###
Robottelo PR for test result https://github.com/SatelliteQE/robottelo/pull/7212     