### PR TITLE
add test_name to the capabilities for `remote` browser

### DIFF
--- a/airgun/browser.py
+++ b/airgun/browser.py
@@ -309,6 +309,9 @@ class SeleniumBrowserFactory(object):
         if settings.webdriver_desired_capabilities:
             desired_capabilities.update(
                 vars(settings.webdriver_desired_capabilities))
+
+        desired_capabilities.update({'name': self.test_name})
+
         return desired_capabilities
 
     def _finalize_saucelabs_browser(self, passed):


### PR DESCRIPTION
The `remote_browser` did not forward the `self.test_name` as one of the desired_capabilities, leaving the session without a name (causing random uuid to be generated for them and causing chaos in the Dashboard). This fixes it.