### PR TITLE
fixes #368 - add support for scap_deployment_option_tab

### DIFF
--- a/airgun/entities/oscappolicy.py
+++ b/airgun/entities/oscappolicy.py
@@ -48,7 +48,7 @@ class OSCAPPolicyEntity(BaseEntity):
 
     def details(self, entity_name, widget_names=None):
         """Read the content from corresponding SCAP Policy dashboard,
-            clicking on the Name of SCAP Policy shows the dashboard
+            clicking on the Dashboard button of SCAP Policy shows the dashboard
 
         :param entity_name:
         :return: dictionary with values from SCAP Policy Details View
@@ -114,7 +114,7 @@ class EditSCAPPolicy(NavigateStep):
     def step(self, *args, **kwargs):
         entity_name = kwargs.get('entity_name')
         self.parent.search(entity_name)
-        self.parent.table.row(name=entity_name)['Actions'].widget.fill('Edit')
+        self.parent.table.row(name=entity_name)['Name'].widget.click()
 
 
 @navigator.register(OSCAPPolicyEntity, 'Details')
@@ -132,4 +132,4 @@ class DetailsSCAPPolicy(NavigateStep):
     def step(self, *args, **kwargs):
         entity_name = kwargs.get('entity_name')
         self.parent.search(entity_name)
-        self.parent.table.row(name=entity_name)['Name'].widget.click()
+        self.parent.table.row(name=entity_name)['Actions'].widget.fill('Dashboard')

--- a/airgun/views/oscappolicy.py
+++ b/airgun/views/oscappolicy.py
@@ -17,6 +17,7 @@ from airgun.widgets import (
     ActionsDropdown,
     FilteredDropdown,
     MultiSelect,
+    RadioGroup,
     SatTable,
 )
 
@@ -64,8 +65,18 @@ class SCAPPolicyCreateView(BaseLoggedInView):
         )
 
     @View.nested
-    class create_policy(BaseLoggedInView):
-        TAB_NAME = 'Create policy'
+    class deployment_options(BaseLoggedInView):
+        TAB_NAME = 'Deployment Options'
+        next_step = Text("//input[contains(@value, 'Next')]")
+        deploy_by_ = RadioGroup(
+            locator="//div[contains(@id, 'deploy_by')]")
+
+        def after_fill(self, was_change):
+            self.next_step.click()
+
+    @View.nested
+    class policy_attributes(BaseLoggedInView):
+        TAB_NAME = 'Policy Attributes'
         next_step = Text("//input[contains(@value, 'Next')]")
         name = TextInput(id='policy_name')
         description = TextInput(id='policy_description')


### PR DESCRIPTION
Temporary fix for issue #368
This PR contains temporary fix for failing UI test foreman.ui.test_oscappolicy.test_positive_check_dashboard and some tier1 tests failing due to new changes in policy creation page.
Bugzilla [1731987](https://bugzilla.redhat.com/show_bug.cgi?id=1731987) has been filed to see whether it is possible to make compliance policy creation page consistent with rest of Satellite UI.