### PR TITLE
overriding read to handle cv_filter option

### DIFF
--- a/airgun/entities/lifecycleenvironment.py
+++ b/airgun/entities/lifecycleenvironment.py
@@ -67,6 +67,12 @@ class LCEEntity(BaseEntity):
         view.packages.search(package_name, cv=cv_name, repo=repo_name)
         return view.packages.table.read()
 
+    def search_puppet_module(self, entity_name, pupet_module_name, cv_name=None):
+        """Search for specific puppet module inside lifecycle environment"""
+        view = self.navigate_to(self, 'Edit', entity_name=entity_name)
+        view.puppet_modules.search(pupet_module_name, cv=cv_name)
+        return view.puppet_modules.table.read()
+
     def search_module_stream(self, entity_name, module_name, cv_name=None, repo_name=None):
         """Search for specific module stream inside lifecycle environment"""
         view = self.navigate_to(self, 'Edit', entity_name=entity_name)

--- a/airgun/views/lifecycleenvironment.py
+++ b/airgun/views/lifecycleenvironment.py
@@ -177,6 +177,23 @@ class LCEEditView(BaseLoggedInView):
             self.searchbox.search(query)
             return self.table.read()
 
+        def read(self):
+            """Returns puppet modules are available for each content view.
+
+               We get dictionary in next format:
+
+                   {
+                       'CV1': [{'Name': 'httpd', 'Version': '0.2' },]
+                       'CV2': [{'Name': 'Nginx', 'Version': '1.2' },]
+                   }
+
+               """
+            result = {}
+            for option in self.cv_filter.all_options:
+                self.cv_filter.fill(option.text)
+                result[option.text] = self.table.read()
+            return result
+
     @View.nested
     class module_streams(SatTab):
         TAB_NAME = 'Module Streams'

--- a/airgun/views/lifecycleenvironment.py
+++ b/airgun/views/lifecycleenvironment.py
@@ -177,23 +177,6 @@ class LCEEditView(BaseLoggedInView):
             self.searchbox.search(query)
             return self.table.read()
 
-        def read(self):
-            """Returns puppet modules are available for each content view.
-
-               We get dictionary in next format:
-
-                   {
-                       'CV1': [{'Name': 'httpd', 'Version': '0.2' },]
-                       'CV2': [{'Name': 'Nginx', 'Version': '1.2' },]
-                   }
-
-               """
-            result = {}
-            for option in self.cv_filter.all_options:
-                self.cv_filter.fill(option.text)
-                result[option.text] = self.table.read()
-            return result
-
     @View.nested
     class module_streams(SatTab):
         TAB_NAME = 'Module Streams'


### PR DESCRIPTION
### PR Objective
CV filter by default is empty making table having empty rows and while reading puppet modules tab it is not been selected. This will read puppet modules based on CV_filter will help to fix the issue for https://github.com/SatelliteQE/robottelo/issues/7217

### Test Result 
```
Testing started at 12:05 PM ...
/home/okhatavk/Satellite/robottelo/env/bin/python /home/okhatavk/Downloads/pycharm-community-2018.1.4/helpers/pycharm/_jb_pytest_runner.py --target test_lifecycleenvironment.py::test_positive_add_puppet_module
Launching py.test with arguments test_lifecycleenvironment.py::test_positive_add_puppet_module in /home/okhatavk/Satellite/robottelo/tests/foreman/ui

2019-07-23 12:05:45 - conftest - DEBUG - Registering custom pytest_configure

2019-07-23 12:05:45 - conftest - DEBUG - Fetching BZs to deselect...

2019-07-23 12:06:03 - conftest - DEBUG - Deselected tests reason: BZ resolution ['1487317', '1156555', '1147100', '1214312', '1278917', '1226425', '1230902', '1414821', '1217635', '1479291', '1310422', '1311113', '1347658', '1204686', '1475443', '1199150']

2019-07-23 12:06:03 - conftest - DEBUG - Deselected tests reason: missing version flag ['1487317', '1156555', '1682940', '1147100', '1214312', '1278917', '1581628', '1625783', '1194476', '1226425', '1230902', '1436209', '1217635', '1489322', '1479291', '1310422', '1311113', '1347658', '1204686', '1716429', '1701132', '1701118', '1378442', '1610309', '1475443', '1199150']

2019-07-23 12:06:03 - conftest - DEBUG - Deselected tests reason: sat-backlog ['1487317', '1156555', '1682940', '1147100', '1214312', '1278917', '1581628', '1625783', '1194476', '1226425', '1230902', '1436209', '1217635', '1489322', '1479291', '1310422', '1311113', '1347658', '1204686', '1716429', '1701132', '1701118', '1378442', '1610309', '1475443', '1199150']

============================= test session starts ==============================
platform linux -- Python 3.4.8, pytest-4.0.2, py-1.7.0, pluggy-0.9.0
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/okhatavk/Satellite/robottelo, inifile:
plugins: xdist-1.26.1, services-1.3.1, mock-1.10.0, forked-1.0.2, cov-2.6.12019-07-23 12:06:03 - conftest - DEBUG - Collected 1 test cases

collected 1 item
=================== 1 passed, 15 warnings in 201.01 seconds ====================

```  