### PR TITLE
updating to more accurate table locator

### DIFF
--- a/airgun/views/task.py
+++ b/airgun/views/task.py
@@ -2,7 +2,7 @@ from widgetastic.widget import Text, View
 from widgetastic_patternfly import BreadCrumb
 
 from airgun.views.common import BaseLoggedInView, SearchableViewMixin, SatTab
-from airgun.widgets import ProgressBar, ReadOnlyEntry, SatTable
+from airgun.widgets import ProgressBar, ReadOnlyEntry, Table
 
 
 class TaskReadOnlyEntry(ReadOnlyEntry):
@@ -14,8 +14,8 @@ class TaskReadOnlyEntry(ReadOnlyEntry):
 
 class TasksView(BaseLoggedInView, SearchableViewMixin):
     title = Text("//h1[text()='Tasks']")
-    table = SatTable(
-        './/table',
+    table = Table(
+        ".//div[@id='content']/table",
         column_widgets={
             'Action': Text('./a'),
         }


### PR DESCRIPTION
There is one new more table was added in view. hence updated table locator.

### Test Resut 

Testing started at 4:39 PM ...
/home/okhatavk/Satellite/robottelo/env/bin/python /home/okhatavk/Downloads/pycharm-community-2018.1.4/helpers/pycharm/_jb_pytest_runner.py --target test_dashboard.py::test_positive_task_status
Launching py.test with arguments test_dashboard.py::test_positive_task_status in /home/okhatavk/Satellite/robottelo/tests/foreman/ui

2019-07-29 16:39:26 - conftest - DEBUG - Registering custom pytest_configure

2019-07-29 16:39:26 - conftest - DEBUG - Fetching BZs to deselect...

2019-07-29 16:40:20 - conftest - DEBUG - Deselected tests reason: BZ resolution ['1347658', '1475443', '1214312', '1414821', '1226425', '1217635', '1147100', '1230902', '1311113', '1199150', '1278917', '1310422', '1204686', '1156555', '1487317', '1479291']

2019-07-29 16:40:20 - conftest - DEBUG - Deselected tests reason: missing version flag ['1610309', '1347658', '1701118', '1475443', '1682940', '1194476', '1214312', '1226425', '1217635', '1147100', '1230902', '1311113', '1199150', '1278917', '1310422', '1436209', '1701132', '1716429', '1204686', '1156555', '1378442', '1489322', '1625783', '1581628', '1487317', '1479291']

2019-07-29 16:40:20 - conftest - DEBUG - Deselected tests reason: sat-backlog ['1610309', '1347658', '1701118', '1475443', '1682940', '1194476', '1214312', '1226425', '1217635', '1147100', '1230902', '1311113', '1199150', '1278917', '1310422', '1436209', '1701132', '1716429', '1204686', '1156555', '1378442', '1489322', '1625783', '1581628', '1487317', '1479291']

============================= test session starts ==============================
platform linux -- Python 3.4.8, pytest-4.0.2, py-1.7.0, pluggy-0.9.0
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/okhatavk/Satellite/robottelo, inifile:
plugins: xdist-1.26.1, services-1.3.1, mock-1.10.0, forked-1.0.2, cov-2.6.12019-07-29 16:40:21 - conftest - DEBUG - Collected 1 test cases

collected 1 item

test_dashboard.py                                                       [100%]

========================== 1 passed in 178.47 seconds  