### PR TITLE
 Fix LoginView submit button selector

### DIFF
--- a/airgun/views/login.py
+++ b/airgun/views/login.py
@@ -4,7 +4,7 @@ from widgetastic.widget import ClickableMixin, Text, TextInput, View
 class LoginView(View, ClickableMixin):
     username = TextInput(id='login_login')
     password = TextInput(id='login_password')
-    submit = Text('//input[@name="commit"]')
+    submit = Text('//button[@type="submit"]')
 
     @property
     def is_displayed(self):


### PR DESCRIPTION
After the new Login page was introduced to Foreman,
the button is no longer an 'input' and currently doesn't have the name attribute,

old implementation:
```
<input type="submit" name="commit" value="Log In" class="btn btn-primary" data-disable-with="Log In">
```

new:
```
<button type="submit" disabled="" class="login-pf-submit-button btn btn-lg btn-primary btn-block">Log In</button>
```

I didn't test this change, but if you would like this to work I guess a small modification like this PR could be made.

also, if you would like to add something more specific, I have added this PR in foreman: https://github.com/theforeman/foreman/pull/6971

so we could wait and than change it into something with an ID or name,
this is how the Login Page button will look like after that PR will get merged:
```
<button type="submit" disabled="" id="login_submit_btn" name="commit" class="login-pf-submit-button btn btn-lg btn-primary btn-block">Log In</button>
```

cc @jhutar - fixes https://projects.theforeman.org/issues/27559