### PR TITLE
fixes #349 added logout method

### DIFF
--- a/airgun/entities/login.py
+++ b/airgun/entities/login.py
@@ -1,5 +1,6 @@
 from airgun.entities.base import BaseEntity
 from airgun.navigation import NavigateStep, navigator
+from airgun.views.common import BaseLoggedInView
 from airgun.views.login import LoginView
 
 
@@ -11,7 +12,10 @@ class LoginEntity(BaseEntity):
         view.submit.click()
 
     def logout(self):
-        pass
+        view = BaseLoggedInView(self.browser)
+        view.taxonomies.select_logout()
+        view.flash.assert_no_error()
+        view.flash.dismiss()
 
 
 @navigator.register(LoginEntity)

--- a/airgun/widgets.py
+++ b/airgun/widgets.py
@@ -839,6 +839,8 @@ class ContextSelector(Widget):
     CURRENT_LOC = '//li[@id="location-dropdown"]/a'
     ORG_LOCATOR = '//li[@id="organization-dropdown"]/ul/li/a[contains(.,{})]'
     LOC_LOCATOR = '//li[@id="location-dropdown"]/ul/li/a[contains(.,{})]'
+    ACCOUNT_MENU = Text("//a[@id='account_menu']")
+    LOGOUT = Text("//a[@href='/users/logout']")
 
     def select_org(self, org_name):
         self.logger.info('Selecting Organization %r' % org_name)
@@ -871,6 +873,10 @@ class ContextSelector(Widget):
     @property
     def current_loc(self):
         return self.browser.text(self.CURRENT_LOC)
+
+    def select_logout(self):
+        self.ACCOUNT_MENU.click()
+        self.LOGOUT.click()
 
     def read(self):
         """As reading organization and location is not atomic operation: needs


### PR DESCRIPTION
### PR Objective 
Fixed https://github.com/SatelliteQE/airgun/issues/349

### Test Result
```
(env) [root@okhatavk robottelo]# pytest tests/foreman/ui/test_repository.py -v -k test_positive_discover_repo_via_new_product 
2019-09-17 08:58:34 - conftest - DEBUG - Registering custom pytest_configure

=============================================== test session starts ===============================================
platform linux -- Python 3.4.8, pytest-4.0.2, py-1.7.0, pluggy-0.9.0 -- /home/okhatavk/Satellite/robottelo/env/bin/python3.4
cachedir: .pytest_cache
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/okhatavk/Satellite/robottelo, inifile:
plugins: xdist-1.26.1, services-1.3.1, mock-1.10.0, forked-1.0.2, cov-2.6.1
collecting ... 2019-09-17 08:58:34 - conftest - DEBUG - BZ deselect is disabled in settings

collected 20 items / 19 deselected                                                                                

tests/foreman/ui/test_repository.py::test_positive_discover_repo_via_new_product PASSED                     [100%]

================================================ warnings summary =================================================
tests/foreman/ui/test_repository.py::test_positive_discover_repo_via_new_product
  /home/okhatavk/Satellite/robottelo/env/lib/python3.4/site-packages/widgetastic/widget/select.py:130: DeprecationWarning: The value of convert_charrefs will become True in 3.5. You are encouraged to set the value explicitly.
    parser = html_parser.HTMLParser()
  /home/okhatavk/Satellite/robottelo/env/lib/python3.4/site-packages/widgetastic/widget/select.py:133: DeprecationWarning: The unescape method is deprecated and will be removed in 3.5, use html.unescape() instead.
    for option
  /home/okhatavk/Satellite/robottelo/env/lib/python3.4/site-packages/widgetastic/widget/select.py:130: DeprecationWarning: The value of convert_charrefs will become True in 3.5. You are encouraged to set the value explicitly.
    parser = html_parser.HTMLParser()
  /home/okhatavk/Satellite/robottelo/env/lib/python3.4/site-packages/widgetastic/widget/select.py:133: DeprecationWarning: The unescape method is deprecated and will be removed in 3.5, use html.unescape() instead.
    for option
  /home/okhatavk/Satellite/robottelo/env/lib/python3.4/site-packages/widgetastic/widget/select.py:130: DeprecationWarning: The value of convert_charrefs will become True in 3.5. You are encouraged to set the value explicitly.
    parser = html_parser.HTMLParser()
  /home/okhatavk/Satellite/robottelo/env/lib/python3.4/site-packages/widgetastic/widget/select.py:133: DeprecationWarning: The unescape method is deprecated and will be removed in 3.5, use html.unescape() instead.
    for option

-- Docs: https://docs.pytest.org/en/latest/warnings.html
============================== 1 passed, 19 deselected, 6 warnings in 234.81 seconds ==============================

```
