### PR TITLE
Pass the chromedriver v76+ undefined method 'left' js error

### DIFF
--- a/airgun/browser.py
+++ b/airgun/browser.py
@@ -670,7 +670,13 @@ class AirgunBrowser(Browser):
         el = self.element(locator, *args, **kwargs)
         self.execute_script(
             "arguments[0].scrollIntoView(false);", el, silent=True)
-        ActionChains(self.selenium).move_to_element(el).perform()
+        try:
+            ActionChains(self.selenium).move_to_element(el).perform()
+        except selenium.common.exceptions.JavascriptException as e:
+            if "javascript error: Cannot read property 'left' of undefined" in e.msg:
+                self.logger.debug("Ignoring 'Cannot read property left of undefined' exception")
+            else:
+                raise(e)
         return el
 
     def get_downloads_list(self):


### PR DESCRIPTION
Some of the actions in our testcases fail with `chromedriver v77` due to the javascript error.

according the background of the issue
https://bugs.chromium.org/p/chromedriver/issues/detail?id=3044#c1

I'm just about to silently catch and pass the exception, which is (according the above comment) pretty much what older versions of the chromedriver did.

- tested on several test cases, this didn't break anything.

Please note, that the error occurs under several circumstances, and in our case it wasn't exactly the dropdown.