### PR TITLE
Don't throw exception when "Add subscription" button is not present

### DIFF
--- a/airgun/entities/subscription.py
+++ b/airgun/entities/subscription.py
@@ -1,5 +1,5 @@
 from navmazing import NavigateToSibling
-from wait_for import wait_for
+from wait_for import TimedOutError, wait_for
 
 from airgun.entities.base import BaseEntity
 from airgun.navigation import NavigateStep, navigator
@@ -43,8 +43,14 @@ class SubscriptionEntity(BaseEntity):
     def has_manifest(self):
         """Is there manifest present in current organization?
         :return: boolean value indicating whether manifest is present
+            May be None if user can't verify reliably if manifest is
+            uploaded or not due to missing permissions
         """
         view = self.navigate_to(self, 'All')
+        try:
+            view.add_button.wait_displayed()
+        except TimedOutError:
+            return None
         return not view.add_button.disabled
 
     def add_manifest(self, manifest_file, ignore_error_messages=None):


### PR DESCRIPTION
This will happen when user with insufficient permissions access the page. We rely on "Add subscription" button state as proxy for manifest presence, but with recent changes this button may not be displayed at all. In that case, exception would be thrown.

Also, wait a moment for button to appear. During testing it did happen that page was "loaded", but button was not present yet.

Done as alternative fix for issue described in https://github.com/SatelliteQE/robottelo/pull/7370 . Adding DO NOT MERGE until we reach consensus where fix should be applied.

```
$ pytest -v -k test_positive_access_with_non_admin_user_without_manifest tests/foreman/ui/test_subscription.py
===================================================================================== test session starts =====================================================================================
platform linux -- Python 3.6.3, pytest-4.0.2, py-1.8.0, pluggy-0.12.0 -- /home/mzalewsk/.virtualenvs/robottelo/bin/python3
cachedir: .pytest_cache
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/mzalewsk/sources/robottelo, inifile:
plugins: mock-1.10.0, cov-2.7.1, forked-1.0.2, xdist-1.29.0, services-1.3.1
collecting ... 2019-09-27 11:54:06 - conftest - DEBUG - BZ deselect is disabled in settings

collected 7 items / 6 deselected                                                                                                                                                              

tests/foreman/ui/test_subscription.py::test_positive_access_with_non_admin_user_without_manifest                         PASSED
```