### PR TITLE
Fixes session navigator and NavigateStep.

### DIFF
--- a/airgun/navigation.py
+++ b/airgun/navigation.py
@@ -13,11 +13,11 @@ class NavigateStep(navmazing.NavigateStep):
 
     VIEW = None
 
-    def __init__(self, obj, navigate_obj):
+    def __init__(self, obj, navigate_obj, logger=None):
         """Adding shortcut for navigate object to make easier calls to its
         navigate method
         """
-        super(NavigateStep, self).__init__(obj, navigate_obj)
+        super(NavigateStep, self).__init__(obj, navigate_obj, logger=logger)
         self.navigate_to = self.navigate_obj.navigate
 
     @cached_property

--- a/airgun/session.py
+++ b/airgun/session.py
@@ -1,5 +1,4 @@
 """Session controller which manages UI session"""
-import copy
 import logging
 import os
 import sys
@@ -74,7 +73,7 @@ from airgun.entities.sync_status import SyncStatusEntity
 from airgun.entities.user import UserEntity
 from airgun.entities.usergroup import UserGroupEntity
 from airgun.entities.virtwho_configure import VirtwhoConfigureEntity
-from airgun.navigation import navigator
+from airgun.navigation import navigator, Navigate
 
 LOGGER = logging.getLogger(__name__)
 
@@ -258,8 +257,8 @@ class Session(object):
             self._factory.post_init()
 
             # Navigator
-            self.navigator = copy.deepcopy(navigator)
-            self.navigator.browser = self.browser
+            self.navigator = Navigate(self.browser)
+            self.navigator.dest_dict = navigator.dest_dict.copy()
             if self._session_cookie is None:
                 self.login.login({
                     'username': self._user, 'password': self._password})


### PR DESCRIPTION
This should fix the basic session navigator copy exception and NavigateStep with newer version of navmazing as newer versions need logger in __init__ to work as expected that is called from navigator 

in earlier version navigator created navigation step without logger, but in newer version it require NavigationStep with logger. 

This should be tested with robottelo, but with navmazing version >=  1.1.6

in insight project created a work-arround for this , and seems working as expected, but robottelo use all the feature of widgetastic and navmazing and need an intensify testing as maybe other areas may be affected.  


