### PR TITLE
javascript fix on listing downloaded files via selenium

### DIFF
--- a/airgun/browser.py
+++ b/airgun/browser.py
@@ -687,7 +687,7 @@ class AirgunBrowser(Browser):
         return self.execute_script("""
             return downloads.Manager.get().items_
               .filter(e => e.state === "COMPLETE")
-              .map(e => e.file_url);
+              .map(e => e.file_url || e.fileUrl);
         """)
 
     def get_file_content(self, uri):


### PR DESCRIPTION
Automation failure correction of test_positive_export 
https://github.com/SatelliteQE/robottelo/blob/master/tests/foreman/ui/test_host.py#L814

export automatically goes to browser where `files[0]` were empty and this cause an error later on. 
https://github.com/SatelliteQE/airgun/blob/master/airgun/browser.py#L756

I looked into the JavaScript and it seems there can be also another option fileUrl. 

```
============================= test session starts ==============================
collected 28 items / 27 deselected / 1 selected
============ 1 passed, 27 deselected, 2 warnings in 165.83 seconds =============
```




