### PR TITLE
Add actions to assert if the virtwho config can view/create/edit/delete

### DIFF
--- a/airgun/entities/virtwho_configure.py
+++ b/airgun/entities/virtwho_configure.py
@@ -27,29 +27,24 @@ class VirtwhoConfigureEntity(BaseEntity):
             vals.update({'hypervisor_type': mapping[hypervisor_value]})
         return vals
 
-    def can_view(self):
-        """Assert if can navigate to virtwhopage"""
+    def permissions(self):
+        """Assert if the config can be viewed/created"""
         try:
-            self.navigate_to(self, 'All')
+            view = self.navigate_to(self, 'All')
         except Exception:
-            return False
-        else:
-            return True
+            return {"can_view": False, "can_create": False}
+        return {
+            "can_view": True,
+            "can_create": view.new.is_displayed
+        }
 
-    def can_create(self):
-        """Assert if the config can create"""
-        view = self.navigate_to(self, 'All')
-        return view.new.is_displayed
-
-    def can_delete(self, entity_name):
-        """Assert if the config can delete"""
+    def permissions_on(self, entity_name=None):
+        """Assert if the config can be deleted/edited"""
         view = self.navigate_to(self, 'Details', entity_name=entity_name)
-        return view.delete.is_displayed
-
-    def can_edit(self, entity_name):
-        """Assert if the the config can edit"""
-        view = self.navigate_to(self, 'Details', entity_name=entity_name)
-        return view.edit.is_displayed
+        return {
+            "can_delete": view.delete.is_displayed,
+            "can_edit": view.edit.is_displayed
+        }
 
     def create(self, values):
         """Create new virtwho configure entity"""

--- a/airgun/entities/virtwho_configure.py
+++ b/airgun/entities/virtwho_configure.py
@@ -27,6 +27,30 @@ class VirtwhoConfigureEntity(BaseEntity):
             vals.update({'hypervisor_type': mapping[hypervisor_value]})
         return vals
 
+    def can_view(self):
+        """Assert if can navigate to virtwhopage"""
+        try:
+            self.navigate_to(self, 'All')
+        except Exception:
+            return False
+        else:
+            return True
+
+    def can_create(self):
+        """Assert if the config can create"""
+        view = self.navigate_to(self, 'All')
+        return view.new.is_displayed
+
+    def can_delete(self, entity_name):
+        """Assert if the config can delete"""
+        view = self.navigate_to(self, 'Details', entity_name=entity_name)
+        return view.delete.is_displayed
+
+    def can_edit(self, entity_name):
+        """Assert if the the config can edit"""
+        view = self.navigate_to(self, 'Details', entity_name=entity_name)
+        return view.edit.is_displayed
+
     def create(self, values):
         """Create new virtwho configure entity"""
         view = self.navigate_to(self, 'New')

--- a/airgun/entities/virtwho_configure.py
+++ b/airgun/entities/virtwho_configure.py
@@ -27,8 +27,8 @@ class VirtwhoConfigureEntity(BaseEntity):
             vals.update({'hypervisor_type': mapping[hypervisor_value]})
         return vals
 
-    def permissions(self):
-        """Assert if the config can be viewed/created"""
+    def check_create_permission(self):
+        """Check if the config can be viewed/created"""
         try:
             view = self.navigate_to(self, 'All')
         except Exception:
@@ -38,8 +38,8 @@ class VirtwhoConfigureEntity(BaseEntity):
             "can_create": view.new.is_displayed
         }
 
-    def permissions_on(self, entity_name=None):
-        """Assert if the config can be deleted/edited"""
+    def check_update_permission(self, entity_name=None):
+        """Check if the config can be deleted/edited"""
         view = self.navigate_to(self, 'Details', entity_name=entity_name)
         return {
             "can_delete": view.delete.is_displayed,


### PR DESCRIPTION
As dicsussion :https://github.com/SatelliteQE/robottelo/pull/7405#discussion_r334514188
We need to add actions as below:
1.can_view(self)
2.can_create(self)
3.can_delete(self, entity_name)
4.can_edit(self, entity_name)
to support [the roles testcases for virtwho](https://github.com/SatelliteQE/robottelo/pull/7405)