### PR TITLE
Remove sauceclient

### DIFF
--- a/airgun/session.py
+++ b/airgun/session.py
@@ -219,7 +219,7 @@ class Session(object):
         except Exception as err:
             LOGGER.exception(err)
         finally:
-            self._factory.finalize(passed)
+            self._factory.finalize()
 
     def take_screenshot(self):
         """Take screen shot from the current browser window.


### PR DESCRIPTION
Fixes #418

```
(venv) redacted$  PYTHONPATH="../airgun/:$PYTHONPATH" pytest tests/foreman/ui/test_debug.py 
========================================================================================================================================== test session starts ===========================================================================================================================================
platform darwin -- Python 3.6.5, pytest-4.6.3, py-1.8.0, pluggy-0.12.0
shared_function enabled - OFF - scope:  - storage: file
rootdir: /redacted/robottelo
plugins: services-1.3.1, xdist-1.30.0, forked-1.0.2, mock-1.10.4, cov-2.8.1
collecting ... 2019-11-07 18:42:47 - conftest - DEBUG - Collected 1 test cases

                                                                                                                                                                                                                                                                                        

tests/foreman/ui/test_debug.py .                                                                                                                                                                                                                                                                   [100%]

======================================================================================================================================= 1 passed in 181.25 seconds =======================================================================================================================================
(venv) ovpn-125-135:robottelo pgagne$ 

```