### PR TITLE
added support for read errata details

### DIFF
--- a/airgun/entities/contenthost.py
+++ b/airgun/entities/contenthost.py
@@ -150,10 +150,9 @@ class ContentHostEntity(BaseEntity):
         :param str errata_id: errata id or title, e.g. 'RHEA-2012:0055'
         :param str optional environment: lifecycle environment to filter by.
         """
-        view = self.navigate_to(self, 'Edit', entity_name=entity_name)
-        view.errata.search(errata_id, lce=environment)
-        view.errata.table.row(id=errata_id)['Id'].widget.click()
-        view = ErrataDetailsView(self.browser)
+        view = self.navigate_to(self, 'Errata Details',
+                                entity_name=entity_name,
+                                errata_id=errata_id)
         return view.read()
 
     def export(self):
@@ -209,3 +208,23 @@ class EditContentHost(NavigateStep):
         entity_name = kwargs.get('entity_name')
         self.parent.search(entity_name)
         self.parent.table.row(name=entity_name)['Name'].widget.click()
+
+
+@navigator.register(ContentHostEntity, 'Errata Details')
+class NavigateToErrataDetails(NavigateStep):
+    """Navigate to Errata details screen.
+
+    Args:
+        entity_name: name of content host
+        errata_id: id of errata
+    """
+    VIEW = ErrataDetailsView
+
+    def prerequisite(self, *args, **kwargs):
+        return self.navigate_to(
+            self.obj, 'Edit', entity_name=kwargs.get('entity_name'))
+
+    def step(self, *args, **kwargs):
+        errata_id = kwargs.get('errata_id')
+        self.parent.errata.search(errata_id)
+        self.parent.errata.table.row(id=errata_id)['Id'].widget.click()

--- a/airgun/entities/contenthost.py
+++ b/airgun/entities/contenthost.py
@@ -4,6 +4,7 @@ from airgun.views.contenthost import (
     ContentHostDetailsView,
     ContentHostsView,
     ContentHostTaskDetailsView,
+    ErrataDetailsView,
 )
 from airgun.views.job_invocation import (
     JobInvocationCreateView,
@@ -141,6 +142,19 @@ class ContentHostEntity(BaseEntity):
         view = self.navigate_to(self, 'Edit', entity_name=entity_name)
         view.errata.search(errata_id, lce=environment)
         return view.errata.table.read()
+
+    def read_errata_details(self, entity_name, errata_id, environment=None):
+        """Read Details for specific errata applicable for content host.
+
+        :param str entity_name: the content hosts name.
+        :param str errata_id: errata id or title, e.g. 'RHEA-2012:0055'
+        :param str optional environment: lifecycle environment to filter by.
+        """
+        view = self.navigate_to(self, 'Edit', entity_name=entity_name)
+        view.errata.search(errata_id, lce=environment)
+        view.errata.table.row(id=errata_id)['Id'].widget.click()
+        view = ErrataDetailsView(self.browser)
+        return view.read()
 
     def export(self):
         """Export content hosts list.

--- a/airgun/entities/contenthost.py
+++ b/airgun/entities/contenthost.py
@@ -152,7 +152,8 @@ class ContentHostEntity(BaseEntity):
         """
         view = self.navigate_to(self, 'Errata Details',
                                 entity_name=entity_name,
-                                errata_id=errata_id)
+                                errata_id=errata_id,
+                                environment=environment)
         return view.read()
 
     def export(self):
@@ -226,5 +227,6 @@ class NavigateToErrataDetails(NavigateStep):
 
     def step(self, *args, **kwargs):
         errata_id = kwargs.get('errata_id')
-        self.parent.errata.search(errata_id)
+        environment = kwargs.get('environment')
+        self.parent.errata.search(errata_id, lce=environment)
         self.parent.errata.table.row(id=errata_id)['Id'].widget.click()

--- a/airgun/views/contenthost.py
+++ b/airgun/views/contenthost.py
@@ -346,6 +346,7 @@ class ContentHostTaskDetailsView(TaskDetailsView):
 
 class ErrataDetailsView(BaseLoggedInView):
 
+    breadcrumb = BreadCrumb()
     advisory = Text("//h3")
     type = ReadOnlyEntry(name='Type')
     title = ReadOnlyEntry(name='Title')
@@ -356,3 +357,13 @@ class ErrataDetailsView(BaseLoggedInView):
     reboot_suggested = ReadOnlyEntry(name='Reboot Suggested')
     packages = ReadOnlyEntry(name='Packages')
     module_streams = ReadOnlyEntry(name='Module Streams')
+
+    @property
+    def is_displayed(self):
+        breadcrumb_loaded = self.browser.wait_for_element(
+            self.breadcrumb, exception=False)
+        return (
+                breadcrumb_loaded
+                and self.breadcrumb.locations[1] == 'Errata'
+                and len(self.breadcrumb.locations) > 3
+        )

--- a/airgun/views/contenthost.py
+++ b/airgun/views/contenthost.py
@@ -342,3 +342,17 @@ class ContentHostTaskDetailsView(TaskDetailsView):
                 and self.breadcrumb.locations[0] == 'Content Hosts'
                 and len(self.breadcrumb.locations) > 2
         )
+
+
+class ErrataDetailsView(BaseLoggedInView):
+
+    advisory = Text("//h3")
+    type = ReadOnlyEntry(name='Type')
+    title = ReadOnlyEntry(name='Title')
+    issued = ReadOnlyEntry(name='Issued')
+    updated = ReadOnlyEntry(name='Updated')
+    description = ReadOnlyEntry(name='Description')
+    last_updated_on = ReadOnlyEntry(name='Last Updated On')
+    reboot_suggested = ReadOnlyEntry(name='Reboot Suggested')
+    packages = ReadOnlyEntry(name='Packages')
+    module_streams = ReadOnlyEntry(name='Module Streams')


### PR DESCRIPTION
### PR Description 
This is PR is to support errata details page from content host

### Robottelo PR 
https://github.com/SatelliteQE/robottelo/pull/7471

### Test Result 
```
Testing started at 11:47 AM ...
/home/okhatavk/okhatavk/Satellite/robottelo/env/bin/python /home/okhatavk/Downloads/pycharm-community-2018.1.4/helpers/pycharm/_jb_pytest_runner.py --target test_errata.py::test_positive_content_host_errata_details
Launching py.test with arguments test_errata.py::test_positive_content_host_errata_details in /home/okhatavk/Satellite/robottelo/tests/foreman/ui

============================= test session starts ==============================
platform linux -- Python 3.7.2, pytest-4.6.3, py-1.8.0, pluggy-0.13.0
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/okhatavk/Satellite/robottelo
plugins: cov-2.8.1, xdist-1.30.0, mock-1.10.4, services-1.3.1, forked-1.1.12019-11-15 06:17:44 - conftest - DEBUG - Collected 1 test cases

2019-11-15 11:47:47 - robottelo.ssh - DEBUG - Instantiated Paramiko client 0x7f9390aa4cf8
2019-11-15 11:47:47 - robottelo.ssh - INFO - Connected to [fedora-build02.lab4.eng.bos.redhat.com]
2019-11-15 11:47:47 - robottelo.ssh - INFO - >>> rpm -q satellite
2019-11-15 11:47:50 - robottelo.ssh - INFO - <<< stdout
satellite-6.7.0-1.beta.el7sat.noarch

2019-11-15 11:47:50 - robottelo.ssh - DEBUG - Destroyed Paramiko client 0x7f9390aa4cf8
2019-11-15 11:47:50 - robottelo.host_info - DEBUG - Host Satellite version: 6.7
2019-11-15 11:47:50 - robottelo.helpers - DEBUG - Generated file bz_cache.json with BZ collect data
collected 1 item
>           assert erratum_details['advisory'] == CUSTOM_REPO_ERRATA_ID
E           AssertionError: assert '' == 'RHEA-2012:0055'
E             + RHEA-2012:0055

test_errata.py:569: AssertionError
```

The above is failing because there is an issue in the application as mentioned here https://bugzilla.redhat.com/show_bug.cgi?id=1655130 which means the test is working as expected 