### PR TITLE
Use "All" page of requested entity as starting url for session

### DIFF
--- a/airgun/entities/activationkey.py
+++ b/airgun/entities/activationkey.py
@@ -11,6 +11,7 @@ from airgun.views.activationkey import (
 
 
 class ActivationKeyEntity(BaseEntity):
+    endpoint_path = '/activation_keys'
 
     def create(self, values):
         """Create new activation key entity"""

--- a/airgun/entities/architecture.py
+++ b/airgun/entities/architecture.py
@@ -10,6 +10,7 @@ from airgun.views.architecture import (
 
 
 class ArchitectureEntity(BaseEntity):
+    endpoint_path = '/architectures'
 
     def create(self, values):
         """Create new architecture entity"""

--- a/airgun/entities/audit.py
+++ b/airgun/entities/audit.py
@@ -4,6 +4,7 @@ from airgun.views.audit import AuditsView
 
 
 class AuditEntity(BaseEntity):
+    endpoint_path = '/audits'
 
     def search(self, value):
         """Search for audit entry in logs and return first one from the list"""

--- a/airgun/entities/bookmark.py
+++ b/airgun/entities/bookmark.py
@@ -17,6 +17,7 @@ def _gen_queries(entity_name, controller=None):
 
 
 class BookmarkEntity(BaseEntity):
+    endpoint_path = '/bookmarks'
 
     # Note: creation procedure takes place on specific entity page, generic
     # helper is implemented inside :class:`BaseEntity`.

--- a/airgun/entities/computeprofile.py
+++ b/airgun/entities/computeprofile.py
@@ -11,6 +11,7 @@ from airgun.views.computeprofile import (
 
 
 class ComputeProfileEntity(BaseEntity):
+    endpoint_path = '/compute_profiles'
 
     def create(self, values):
         """Create new compute profile entity"""

--- a/airgun/entities/computeresource.py
+++ b/airgun/entities/computeresource.py
@@ -17,6 +17,7 @@ from airgun.views.computeresource import (
 
 
 class ComputeResourceEntity(BaseEntity):
+    endpoint_path = '/compute_resources'
 
     def create(self, values):
         """Create new compute resource entity"""

--- a/airgun/entities/configgroup.py
+++ b/airgun/entities/configgroup.py
@@ -10,6 +10,7 @@ from airgun.views.configgroup import (
 
 
 class ConfigGroupEntity(BaseEntity):
+    endpoint_path = '/config_groups'
 
     def create(self, values):
         """Create new config group"""

--- a/airgun/entities/containerimagetag.py
+++ b/airgun/entities/containerimagetag.py
@@ -7,6 +7,7 @@ from airgun.views.containerimagetag import (
 
 
 class ContainerImageTagEntity(BaseEntity):
+    endpoint_path = '/docker_tags'
 
     def search(self, value):
         """Search for specific Container Image Tag

--- a/airgun/entities/contentcredential.py
+++ b/airgun/entities/contentcredential.py
@@ -11,6 +11,7 @@ from airgun.views.product import ProductEditView
 
 
 class ContentCredentialEntity(BaseEntity):
+    endpoint_path = '/content_credentials'
 
     def create(self, values):
         """Create new content credentials entity"""

--- a/airgun/entities/contenthost.py
+++ b/airgun/entities/contenthost.py
@@ -12,6 +12,7 @@ from airgun.views.job_invocation import (
 
 
 class ContentHostEntity(BaseEntity):
+    endpoint_path = '/content_hosts'
 
     def delete(self, entity_name):
         """Delete existing content host"""

--- a/airgun/entities/contentview.py
+++ b/airgun/entities/contentview.py
@@ -19,6 +19,7 @@ from airgun.views.contentview import (
 
 
 class ContentViewEntity(BaseEntity):
+    endpoint_path = '/content_views'
 
     def create(self, values):
         """Create a new content view"""

--- a/airgun/entities/discoveredhosts.py
+++ b/airgun/entities/discoveredhosts.py
@@ -16,6 +16,7 @@ from airgun.views.discoveredhosts import (
 
 
 class DiscoveredHostsEntity(BaseEntity):
+    endpoint_path = '/discovered_hosts'
 
     def wait_for_entity(self, entity_name):
         """Wait for a host to be discovered providing the expected entity_name

--- a/airgun/entities/discoveryrule.py
+++ b/airgun/entities/discoveryrule.py
@@ -12,6 +12,7 @@ from airgun.views.host import HostsView
 
 
 class DiscoveryRuleEntity(BaseEntity):
+    endpoint_path = '/discovery_rules'
 
     def create(self, values):
         """Create new Discovery rule

--- a/airgun/entities/domain.py
+++ b/airgun/entities/domain.py
@@ -10,6 +10,8 @@ from airgun.views.domain import (
 
 
 class DomainEntity(BaseEntity):
+    endpoint_path = '/domains'
+
     def create(self, values):
         """Create a new domain."""
         view = self.navigate_to(self, 'New')

--- a/airgun/entities/errata.py
+++ b/airgun/entities/errata.py
@@ -11,6 +11,7 @@ from airgun.views.errata import (
 
 
 class ErrataEntity(BaseEntity):
+    endpoint_path = '/errata'
 
     def search(self, value, applicable=True, installable=False, repo=None):
         """Search for specific errata.

--- a/airgun/entities/hardware_model.py
+++ b/airgun/entities/hardware_model.py
@@ -10,6 +10,7 @@ from airgun.views.hardware_model import (
 
 
 class HardwareModelEntity(BaseEntity):
+    endpoint_path = '/hardware_models'
 
     def create(self, values):
         """Create new hardware model"""

--- a/airgun/entities/host.py
+++ b/airgun/entities/host.py
@@ -23,6 +23,7 @@ from airgun.views.host import (
 
 
 class HostEntity(BaseEntity):
+    endpoint_path = '/hosts'
 
     HELPER_CLASS = HostHelper
 

--- a/airgun/entities/hostcollection.py
+++ b/airgun/entities/hostcollection.py
@@ -21,6 +21,7 @@ from airgun.views.job_invocation import (
 
 
 class HostCollectionEntity(BaseEntity):
+    endpoint_path = '/host_collections'
 
     def create(self, values):
         """Create a host collection"""

--- a/airgun/entities/hostgroup.py
+++ b/airgun/entities/hostgroup.py
@@ -10,6 +10,7 @@ from airgun.views.hostgroup import (
 
 
 class HostGroupEntity(BaseEntity):
+    endpoint_path = '/hostgroups'
 
     def create(self, values):
         """Create new host group entity"""

--- a/airgun/entities/job_invocation.py
+++ b/airgun/entities/job_invocation.py
@@ -11,6 +11,7 @@ from airgun.views.job_invocation import (
 
 
 class JobInvocationEntity(BaseEntity):
+    endpoint_path = '/job_invocations'
 
     def run(self, values):
         """Run specific job"""

--- a/airgun/entities/job_template.py
+++ b/airgun/entities/job_template.py
@@ -10,6 +10,7 @@ from airgun.views.job_template import (
 
 
 class JobTemplateEntity(BaseEntity):
+    endpoint_path = '/job_templates'
 
     def create(self, values):
         """Create new job template"""

--- a/airgun/entities/ldap_authentication.py
+++ b/airgun/entities/ldap_authentication.py
@@ -11,6 +11,7 @@ from airgun.views.ldapauthentication import (
 
 
 class LDAPAuthenticationEntity(BaseEntity):
+    endpoint_path = '/auth_source_ldaps'
 
     def create(self, values):
         """Create new LDAP Authentication source"""

--- a/airgun/entities/lifecycleenvironment.py
+++ b/airgun/entities/lifecycleenvironment.py
@@ -10,6 +10,7 @@ from airgun.views.lifecycleenvironment import (
 
 
 class LCEEntity(BaseEntity):
+    endpoint_path = '/lifecycle_environments'
 
     def create_environment_path(self, values):
         view = self.navigate_to(self, 'New Path')

--- a/airgun/entities/location.py
+++ b/airgun/entities/location.py
@@ -12,6 +12,7 @@ from airgun.views.location import (
 
 
 class LocationEntity(BaseEntity):
+    endpoint_path = '/locations'
 
     def create(self, values):
         """Create new location entity"""

--- a/airgun/entities/media.py
+++ b/airgun/entities/media.py
@@ -10,6 +10,7 @@ from airgun.views.media import (
 
 
 class MediaEntity(BaseEntity):
+    endpoint_path = '/media'
 
     def create(self, values):
         """Create new media"""

--- a/airgun/entities/modulestream.py
+++ b/airgun/entities/modulestream.py
@@ -7,7 +7,7 @@ from wait_for import wait_for
 
 
 class ModuleStreamEntity(BaseEntity):
-    """Module Stream entity"""
+    endpoint_path = '/module_streams'
 
     def search(self, query):
         """Search for module stream

--- a/airgun/entities/organization.py
+++ b/airgun/entities/organization.py
@@ -13,6 +13,7 @@ from airgun.views.organization import (
 
 
 class OrganizationEntity(BaseEntity):
+    endpoint_path = '/organizations'
 
     def create(self, values):
         """Create new organization entity"""

--- a/airgun/entities/os.py
+++ b/airgun/entities/os.py
@@ -10,6 +10,7 @@ from airgun.views.os import (
 
 
 class OperatingSystemEntity(BaseEntity):
+    endpoint_path = '/operatingsystems'
 
     def create(self, values):
         """Create new operating system entity"""

--- a/airgun/entities/oscapcontent.py
+++ b/airgun/entities/oscapcontent.py
@@ -10,6 +10,7 @@ from airgun.views.oscapcontent import (
 
 
 class OSCAPContentEntity(BaseEntity):
+    endpoint_path = '/compliance/scap_contents'
 
     def create(self, values):
         """Create new SCAP Conent

--- a/airgun/entities/oscappolicy.py
+++ b/airgun/entities/oscappolicy.py
@@ -11,6 +11,7 @@ from airgun.views.oscappolicy import (
 
 
 class OSCAPPolicyEntity(BaseEntity):
+    endpoint_path = '/compliance/policies'
 
     def create(self, values):
         """Creates new OSCAP Policy

--- a/airgun/entities/oscaptailoringfile.py
+++ b/airgun/entities/oscaptailoringfile.py
@@ -10,6 +10,7 @@ from airgun.views.oscaptailoringfile import (
 
 
 class OSCAPTailoringFileEntity(BaseEntity):
+    endpoint_path = '/compliance/tailoring_files'
 
     def create(self, values):
         """Creates new SCAP Tailoring File

--- a/airgun/entities/package.py
+++ b/airgun/entities/package.py
@@ -6,7 +6,7 @@ from airgun.views.package import PackagesView, PackageDetailsView
 
 
 class PackageEntity(BaseEntity):
-    """Package entity"""
+    endpoint_path = '/packages'
 
     def search(self, query, repository='All Repositories', applicable=False,
                upgradable=False):

--- a/airgun/entities/partitiontable.py
+++ b/airgun/entities/partitiontable.py
@@ -10,6 +10,7 @@ from airgun.views.partitiontable import (
 
 
 class PartitionTableEntity(BaseEntity):
+    endpoint_path = '/templates/ptables'
 
     def create(self, values,):
         """Create new partition table entity"""

--- a/airgun/entities/product.py
+++ b/airgun/entities/product.py
@@ -13,6 +13,7 @@ from airgun.views.product import (
 
 
 class ProductEntity(BaseEntity):
+    endpoint_path = '/products'
 
     def create(self, values, sync_plan_values=None):
         """Creates new product from UI.

--- a/airgun/entities/provisioning_template.py
+++ b/airgun/entities/provisioning_template.py
@@ -11,6 +11,7 @@ from airgun.views.provisioning_template import (
 
 
 class ProvisioningTemplateEntity(BaseEntity):
+    endpoint_path = '/provisioning_templates'
 
     def create(self, values):
         """Create new provisioning template"""

--- a/airgun/entities/puppet_class.py
+++ b/airgun/entities/puppet_class.py
@@ -4,6 +4,7 @@ from airgun.views.puppet_class import PuppetClassDetailsView, PuppetClassesView
 
 
 class PuppetClassEntity(BaseEntity):
+    endpoint_path = '/puppetclasses'
 
     def search(self, value):
         """Search for puppet class entity"""

--- a/airgun/entities/puppet_environment.py
+++ b/airgun/entities/puppet_environment.py
@@ -10,6 +10,7 @@ from airgun.views.puppet_environment import (
 
 
 class PuppetEnvironmentEntity(BaseEntity):
+    endpoint_path = '/environments'
 
     def create(self, values):
         """Create puppet environment entity"""

--- a/airgun/entities/redhat_repository.py
+++ b/airgun/entities/redhat_repository.py
@@ -5,6 +5,7 @@ from airgun.views.redhat_repository import RedHatRepositoriesView
 
 
 class RedHatRepositoryEntity(BaseEntity):
+    endpoint_path = '/redhat_repositories'
 
     def search(self, value, category='Available', types=None):
         """Search RH repositories.

--- a/airgun/entities/report_template.py
+++ b/airgun/entities/report_template.py
@@ -13,6 +13,7 @@ from airgun.views.report_template import (
 
 
 class ReportTemplateEntity(BaseEntity):
+    endpoint_path = '/templates/report_templates'
 
     def create(self, values):
         """Create new report template"""

--- a/airgun/entities/rhai/action.py
+++ b/airgun/entities/rhai/action.py
@@ -5,6 +5,7 @@ from airgun.views.rhai import ActionsDetailsView
 
 
 class ActionEntity(BaseEntity):
+    endpoint_path = '/redhat_access/insights/actions'
 
     def read(self, widget_names=None):
         """Read the content of the view."""

--- a/airgun/entities/rhai/inventory.py
+++ b/airgun/entities/rhai/inventory.py
@@ -7,6 +7,7 @@ from airgun.views.rhai import InventoryAllHosts, InventoryHostDetails
 
 
 class InventoryHostEntity(BaseEntity):
+    endpoint_path = '/redhat_access/insights/inventory'
 
     @property
     def total_systems(self):

--- a/airgun/entities/rhai/manage.py
+++ b/airgun/entities/rhai/manage.py
@@ -5,6 +5,7 @@ from airgun.views.rhai import ManageDetailsView
 
 
 class ManageEntity(BaseEntity):
+    endpoint_path = '/redhat_access/insights/manage'
 
     def _toggle_service(self, state):
         view = self.navigate_to(self, "Details")

--- a/airgun/entities/rhai/overview.py
+++ b/airgun/entities/rhai/overview.py
@@ -5,6 +5,7 @@ from airgun.views.rhai import OverviewDetailsView
 
 
 class OverviewEntity(BaseEntity):
+    endpoint_path = '/redhat_access/insights'
 
     def read(self, widget_names=None):
         view = self.navigate_to(self, "Details")

--- a/airgun/entities/rhai/plan.py
+++ b/airgun/entities/rhai/plan.py
@@ -13,6 +13,7 @@ from airgun.views.rhai import (
 
 
 class PlanEntity(BaseEntity):
+    endpoint_path = '/redhat_access/insights/planner'
 
     def create(self, name, rules):
         """Create a new RHAI Plan entity."""

--- a/airgun/entities/rhai/rule.py
+++ b/airgun/entities/rhai/rule.py
@@ -5,6 +5,7 @@ from airgun.views.rhai import AllRulesView
 
 
 class RuleEntity(BaseEntity):
+    endpoint_path = '/redhat_access/insights/rules'
 
     def search(self, rule_name):
         """Perform the search of a rule."""

--- a/airgun/entities/role.py
+++ b/airgun/entities/role.py
@@ -6,6 +6,7 @@ from airgun.views.role import RoleCloneView, RoleCreateView, RoleEditView, Roles
 
 
 class RoleEntity(BaseEntity):
+    endpoint_path = '/roles'
 
     def create(self, values):
         """Create new role"""

--- a/airgun/entities/settings.py
+++ b/airgun/entities/settings.py
@@ -4,6 +4,8 @@ from airgun.views.settings import SettingsView
 
 
 class SettingsEntity(BaseEntity):
+    endpoint_path = '/settings'
+
     def search(self, value):
         """Search for necessary settings entry"""
         view = self.navigate_to(self, 'All')

--- a/airgun/entities/smart_class_parameter.py
+++ b/airgun/entities/smart_class_parameter.py
@@ -7,6 +7,7 @@ from airgun.views.smart_class_parameter import (
 
 
 class SmartClassParameterEntity(BaseEntity):
+    endpoint_path = '/puppetclass_lookup_keys'
 
     def search(self, value):
         """Search for smart class parameter entity and return table row that

--- a/airgun/entities/smart_variable.py
+++ b/airgun/entities/smart_variable.py
@@ -10,6 +10,7 @@ from airgun.views.smart_variable import (
 
 
 class SmartVariableEntity(BaseEntity):
+    endpoint_path = '/variable_lookup_keys'
 
     def create(self, values):
         """Create new smart variable entity"""

--- a/airgun/entities/subnet.py
+++ b/airgun/entities/subnet.py
@@ -10,6 +10,7 @@ from airgun.views.subnet import (
 
 
 class SubnetEntity(BaseEntity):
+    endpoint_path = '/subnets'
 
     def create(self, values):
         """Create new subnet"""

--- a/airgun/entities/subscription.py
+++ b/airgun/entities/subscription.py
@@ -13,6 +13,8 @@ from airgun.views.subscription import (
 
 
 class SubscriptionEntity(BaseEntity):
+    endpoint_path = '/subscriptions'
+
     def _wait_for_process_to_finish(self, name, has_manifest=False, timeout=600,
                                     ignore_error_messages=None):
         """Helper ensuring that task (upload / delete manifest / subscription)

--- a/airgun/entities/sync_status.py
+++ b/airgun/entities/sync_status.py
@@ -5,6 +5,7 @@ from airgun.views.sync_status import SyncStatusView
 
 
 class SyncStatusEntity(BaseEntity):
+    endpoint_path = '/katello/sync_management'
 
     def read(self, widget_names=None):
         """Read all widgets at Sync status entity"""

--- a/airgun/entities/syncplan.py
+++ b/airgun/entities/syncplan.py
@@ -10,6 +10,7 @@ from airgun.views.syncplan import (
 
 
 class SyncPlanEntity(BaseEntity):
+    endpoint_path = '/sync_plans'
 
     def create(self, values):
         """Create new sync plan"""

--- a/airgun/entities/task.py
+++ b/airgun/entities/task.py
@@ -4,6 +4,7 @@ from airgun.views.task import TaskDetailsView, TasksView
 
 
 class TaskEntity(BaseEntity):
+    endpoint_path = '/foreman_tasks/tasks'
 
     def search(self, value):
         """Search for specific task"""

--- a/airgun/entities/trend.py
+++ b/airgun/entities/trend.py
@@ -11,6 +11,7 @@ from airgun.views.trend import (
 
 
 class TrendEntity(BaseEntity):
+    endpoint_path = '/trends'
 
     def create(self, values):
         """Create new trend in the system

--- a/airgun/entities/user.py
+++ b/airgun/entities/user.py
@@ -6,6 +6,7 @@ from airgun.views.user import UserCreateView, UserDetailsView, UsersView
 
 
 class UserEntity(BaseEntity):
+    endpoint_path = '/users'
 
     def create(self, values):
         """Create new user entity"""

--- a/airgun/entities/usergroup.py
+++ b/airgun/entities/usergroup.py
@@ -10,6 +10,7 @@ from airgun.views.usergroup import (
 
 
 class UserGroupEntity(BaseEntity):
+    endpoint_path = '/usergroups'
 
     def create(self, values):
         """Create new user group entity"""

--- a/airgun/entities/virtwho_configure.py
+++ b/airgun/entities/virtwho_configure.py
@@ -11,6 +11,7 @@ from airgun.views.virtwho_configure import (
 
 
 class VirtwhoConfigureEntity(BaseEntity):
+    endpoint_path = '/foreman_virt_who_configure/configs'
 
     def _reset_values(self, values):
         mapping = {

--- a/airgun/session.py
+++ b/airgun/session.py
@@ -251,6 +251,7 @@ class Session(object):
         try:
             selenium_browser = self._factory.get_browser()
             self.browser = AirgunBrowser(selenium_browser, self)
+            LOGGER.info('Setting initial URL to {url}')
 
             self.browser.url = url
 

--- a/airgun/session.py
+++ b/airgun/session.py
@@ -170,7 +170,7 @@ class Session(object):
         self._password = password or settings.satellite.password
         self._session_cookie = session_cookie
         self._factory = None
-        self._url = None
+        self._url = url
         self.navigator = None
         self.browser = None
 


### PR DESCRIPTION
This is Airgun-only re-implementation of idea presented by @omkarkhatavkar in https://github.com/SatelliteQE/robottelo/pull/7442

The main goal here is to use entity "All items" URL as starting point for session. This way list of all entities will be visible right after logging in (instead of displaying dashboard, which we hardly ever need).

This is implemented by deferring execution of browser initialization code until entity is requested. It has two effects:
1. We can let each entity define URL fragment on their own. Web-specific data is kept within Airgun, which is in line of our design principles. As a result, this change is completely transparent to Robottelo - no test must be changed to benefit from this PR.
2. If you happen to use `Session` context manager, but never actually interact with it, browser will not be initialized. This will save time during test development and allows us to put more code inside session context (as there is no performance penalty for that).

Test case:
```bash
$ pytest -s --durations=0 --count 3 -k end_to_end tests/foreman/ui/test_lifecycleenvironment.py
```

Before change:
```
=================================================================================== slowest test durations ====================================================================================
73.52s call     tests/foreman/ui/test_lifecycleenvironment.py::test_positive_end_to_end[1-3]
71.91s call     tests/foreman/ui/test_lifecycleenvironment.py::test_positive_end_to_end[2-3]
70.26s call     tests/foreman/ui/test_lifecycleenvironment.py::test_positive_end_to_end[3-3]
6.75s setup    tests/foreman/ui/test_lifecycleenvironment.py::test_positive_end_to_end[1-3]
0.24s teardown tests/foreman/ui/test_lifecycleenvironment.py::test_positive_end_to_end[3-3]
```

After change:
```
=================================================================================== slowest test durations ====================================================================================
61.88s call     tests/foreman/ui/test_lifecycleenvironment.py::test_positive_end_to_end[3-3]
61.47s call     tests/foreman/ui/test_lifecycleenvironment.py::test_positive_end_to_end[1-3]
60.53s call     tests/foreman/ui/test_lifecycleenvironment.py::test_positive_end_to_end[2-3]
4.36s setup    tests/foreman/ui/test_lifecycleenvironment.py::test_positive_end_to_end[1-3]
0.26s teardown tests/foreman/ui/test_lifecycleenvironment.py::test_positive_end_to_end[3-3]
```

So, with that PR, we can expect individual test execution time to be reduced by **8 to 13 seconds**.

I am also running entire UI Robottelo suite, but this takes forever.