### PR TITLE
Update subscriptions tab on ContentHostDetailsView

### DIFF
--- a/airgun/views/contenthost.py
+++ b/airgun/views/contenthost.py
@@ -187,7 +187,7 @@ class ContentHostDetailsView(BaseLoggedInView):
         host_group = ReadOnlyEntry(name='Host Group')
 
     @View.nested
-    class subscriptions(SatTabWithDropdown):
+    class subscriptions(SatTab):
         SUB_ITEM = 'Subscriptions'
 
         status = ReadOnlyEntry(name='Status')


### PR DESCRIPTION
Update the 'subscriptions' tab on ContentHostDetailsView as missing 'Events ' in Sat6.7 (different with Sat6.6)

Some cases failed due to this.
Error info:
`selenium.common.exceptions.NoSuchElementException: Message: Could not find an element './ul/li[normalize-space(.)="Subscriptions"]'`

Such as :
Satellite:
tests.foreman.ui.test_subscription.test_positive_view_vdc_subscription_products 

Virt-who:
tests.foreman.virtwho.test_ui_virtwho.test_positive_deploy_configure_by_id
tests.foreman.virtwho.test_ui_virtwho.test_positive_deploy_configure_by_script





