### PR TITLE
Fix item selections on os table

### DIFF
--- a/airgun/entities/os.py
+++ b/airgun/entities/os.py
@@ -24,8 +24,7 @@ class OperatingSystemEntity(BaseEntity):
         """Remove existing operating system entity"""
         view = self.navigate_to(self, 'All')
         view.search(entity_name)
-        view.table.row(
-            title=entity_name)['Actions'].widget.click(handle_alert=True)
+        view.table.row(title__endswith=entity_name)['Actions'].widget.click(handle_alert=True)
         view.flash.assert_no_error()
         view.flash.dismiss()
 
@@ -83,4 +82,4 @@ class EditOperatingSystem(NavigateStep):
     def step(self, *args, **kwargs):
         entity_name = kwargs.get('entity_name')
         self.parent.search(entity_name)
-        self.parent.table.row(title=entity_name)['Title'].widget.click()
+        self.parent.table.row(title__endswith=entity_name)['Title'].widget.click()


### PR DESCRIPTION
The table has a filter mechanism that is causing problems with selecting an element in the row and drilling into the link or selecting the deletion action in the table.  This is causing failures to several test cases in ```test_operatingsystem.py```. I'm not sure of the correct syntax so that I can pass in the value for ```view.table.row()``` and ```self.parent.table.row()``` so it can navigate correctly.  This current implementation seems to work, but is not ideal.