### PR TITLE
updated xpath for task details check

### DIFF
--- a/airgun/views/task.py
+++ b/airgun/views/task.py
@@ -17,8 +17,8 @@ from airgun.widgets import (
 
 class TaskReadOnlyEntry(ReadOnlyEntry):
     BASE_LOCATOR = (
-        "//span[contains(., '{}') and contains(@class, 'param-name')]"
-        "/following-sibling::span"
+        "//span[contains(., '{}') and contains(@class, 'list-group-item-heading')]//parent::div"
+        "/following-sibling::div/span"
     )
 
 


### PR DESCRIPTION
required by test_positive_bulk_delete_host
```
test tests/foreman/ui/test_host.py -k test_positive_bulk_delete_host
=================================================== test session starts ====================================================
                                                                          

tests/foreman/ui/test_host.py .                                                                                      [100%]


================================== 1 passed, 28 deselected, 3 warnings in 118.70 seconds ===================================
```