### PR TITLE
Added is_displayed for confirm_dialog click

### DIFF
--- a/airgun/widgets.py
+++ b/airgun/widgets.py
@@ -1085,12 +1085,23 @@ class ConfirmationDialog(Widget):
     discard_dialog = Text(
         ".//button[contains(@ng-click, 'cancel') and @class='close']")
 
+    def _check_is_displayed(self, elem):
+        """ This is to check if dialog is displayed """
+        wait_for(
+            lambda: elem.is_displayed,
+            timeout=10,
+            delay=1,
+            logger=self.logger
+        )
+
     def confirm(self):
         """Clicks on the positive outcome button like 'Remove', 'Ok', 'Yes'"""
+        self._check_is_displayed(self.confirm_dialog)
         self.confirm_dialog.click()
 
     def cancel(self):
         """Clicks on the negative outcome button like 'Cancel' or 'No'"""
+        self._check_is_displayed(self.cancel_dialog)
         self.cancel_dialog.click()
 
     def read(self):


### PR DESCRIPTION
- Multiple tests are false failed due to a slight delay to load dialog window/related element and `self.confirm_dialog.click()` action failed.
- Added a `wait_for` to avoid false fail and check `is_displayed`.
- Tests results:
```
PASSED2020-01-22 13:15:31 - robottelo - DEBUG - Finished Test: test_repository.py/test_positive_resynchronize_rpm_repo
tests/foreman/ui/test_repository.py::test_positive_resynchronize_puppet_repo PASSED                                                                                   [100%]
tests/foreman/ui/test_repository.py::test_positive_end_to_end_custom_module_streams_crud PASSED                                                                       [100%]
```