### PR TITLE
Change Remove Hosts to Delete Hosts

### DIFF
--- a/airgun/entities/contenthost.py
+++ b/airgun/entities/contenthost.py
@@ -20,7 +20,7 @@ class ContentHostEntity(BaseEntity):
         view = self.navigate_to(self, 'All')
         view.search(entity_name)
         view.table.row(name=entity_name)[0].widget.fill(True)
-        view.actions.fill('Remove Hosts')
+        view.actions.fill('Delete Hosts')
         view.dialog.confirm()
         view.flash.assert_no_error()
         view.flash.dismiss()


### PR DESCRIPTION
Hello

While using test automation server to run this:

    tests/foreman/ui/test_contenthost.py::test_positive_end_to_end_bulk_update

I saw this error:

		    # Delete content host
	>           session.contenthost.delete(vm.hostname)

	tests/foreman/ui/test_contenthost.py:280: 
	_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
	../../shiningpanda/jobs/ad0ef6b5/virtualenvs/d41d8cd9/lib/python3.6/site-packages/airgun/entities/contenthost.py:23: in delete
	    view.actions.fill('Remove Hosts')
	../../shiningpanda/jobs/ad0ef6b5/virtualenvs/d41d8cd9/lib/python3.6/site-packages/widgetastic/log.py:115: in wrapped
	    result = f(self, *args, **kwargs)
	../../shiningpanda/jobs/ad0ef6b5/virtualenvs/d41d8cd9/lib/python3.6/site-packages/widgetastic/widget/base.py:30: in wrapped
	    return method(self, Fillable.coerce(value), *args, **kwargs)
	../../shiningpanda/jobs/ad0ef6b5/virtualenvs/d41d8cd9/lib/python3.6/site-packages/airgun/widgets.py:625: in fill
	    self.select(item)
	../../shiningpanda/jobs/ad0ef6b5/virtualenvs/d41d8cd9/lib/python3.6/site-packages/widgetastic/widget/base.py:67: in wrapped
	    return method(self, *new_args, **new_kwargs)
	_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

	self = ActionsDropdown(".//div[contains(@class, 'btn-group')]")
	item = 'Remove Hosts'

	    def select(self, item):
		"""Selects item from dropdown."""
		if item in self.items:
		    self.open()
		    self.browser.element(
			self.ITEM_LOCATOR.format(item), parent=self).click()
		else:
		    raise ValueError(
			'Specified action "{}" not found in actions list. Available'
			' actions are {}'
	>               .format(item, self.items)
		    )
	E           ValueError: Specified action "Remove Hosts" not found in actions list. Available actions are ['Change Host Collections', 'Manage Packages', 'Manage Errata', 'Change Lifecycle Environment', 'Set Release Version', 'Manage Subscriptions', 'Manage Repository Sets', 'Manage Module Streams', 'Delete Hosts']

The entry has changed in the actions menu some time ago.

Traced the value to the airgun/entities/contenthost.py file.