### PR TITLE
host bulk delete change in path

### DIFF
--- a/airgun/views/task.py
+++ b/airgun/views/task.py
@@ -94,7 +94,7 @@ class TaskDetailsView(BaseLoggedInView):
         ended_at = TaskReadOnlyEntry(name='Ended at')
         start_before = TaskReadOnlyEntry(name='Start before')
         state = Text("//div[contains(@class, 'progress-description')]")
-        progressbar = ProgressBar()
+        progressbar = ProgressBar(locator='//div[contains(@class,"progress-bar")]')
         output = TaskReadOnlyEntry(name='Output')
         errors = TaskReadOnlyEntry(name='Errors')
 


### PR DESCRIPTION
I already talk to @mirekdlugosz and I appreciate Mireks help a lot. I would be happy to if he can take a look once again:

4 types of progressbar are used: 

1. views.common.py  - TaskDetailsView  - entities. (contenthost, errata, hostcollection, product, repository)
2. views.task - TaskDetailsView - entities. (host, task)
3. views.contentview - PublishPromoteProgressBar - inherits from Progressbar - entities.contentview
4. views.subscription - SubscriptionListView - entities.subscription

Mirek has a point that everything it is going to change to react. 
So my idea now is, maybe we can change default locator inside `ProgressBar` 
But as most of the locators are still using views.common which do not change. **So I think, for now just change the locator in TaskDetailsView.** 

a) Should I use by default the `ProgressBar(locator=Xpath)` or should I pass it without parameter name `ProgressBar(Xpath)` as [here in subscription](https://github.com/SatelliteQE/airgun/blob/4781b054bc4116beab0faf175e2d8c41ddf55a4c/airgun/views/subscription.py#L145)

b) And last comment on this number 2 and number 4 can use the same Xpath. But as views.task is not dependent on views.subscription I think it really doesn't matter. But I would like to know what you think about it.

**Test result:**
```
================== 1 passed, 28 deselected in 123.76 seconds ===================
```