### PR TITLE
Add pagination support for chost

### DIFF
--- a/airgun/entities/contenthost.py
+++ b/airgun/entities/contenthost.py
@@ -27,10 +27,12 @@ class ContentHostEntity(BaseEntity):
         view = self.navigate_to(self, 'All')
         return view.search(value)
 
-    def read_all(self):
-        """Read all values from content host title page"""
+    def read_all(self, widget_names=None):
+        """Read all values from content host title page.
+        Optionally, read only the widgets in widget_names.
+        """
         view = self.navigate_to(self, 'All')
-        return view.read()
+        return view.read(widget_names=widget_names)
 
     def read(self, entity_name, widget_names=None):
         """Read content host details, optionally read only the widgets in widget_names."""

--- a/airgun/views/contenthost.py
+++ b/airgun/views/contenthost.py
@@ -27,6 +27,7 @@ from airgun.widgets import EditableEntry
 from airgun.widgets import EditableEntryCheckbox
 from airgun.widgets import EditableEntryMultiCheckbox
 from airgun.widgets import EditableEntrySelect
+from airgun.widgets import Pagination
 from airgun.widgets import ReadOnlyEntry
 from airgun.widgets import Search
 
@@ -106,6 +107,7 @@ class ContentHostsView(BaseLoggedInView, SearchableViewMixin):
             'Installable Updates': InstallableUpdatesCellView(),
         }
     )
+    pagination = Pagination()
 
     @property
     def is_displayed(self):

--- a/airgun/widgets.py
+++ b/airgun/widgets.py
@@ -1504,7 +1504,7 @@ class Pagination(Widget):
     last_page_button = Text(".//li[a[span[contains(@class, 'angle-double-right')]]]")
     page = TextInput(locator=".//input[contains(@class, 'pagination-pf-page')]")
     pages = Text(".//span[contains(@class, 'pagination-pf-pages')]")
-    total_items = Text(".//span[@class='pagination-pf-items-total']")
+    total_items = Text(".//span[contains(@class, 'pagination-pf-items-total')]")
 
     @cached_property
     def per_page(self):


### PR DESCRIPTION
Thanks to @mirekdlugosz for help with this. In particular, for pointing out that `total_items` line in widgets.py had to change:

"now has two classes:
   \<span class="pagination-pf-items-total ng-binding">1\</span>

As fix, change `total_items` line in airgun/widgets.py to:
   total_items = Text(".//span[contains(@class, 'pagination-pf-items-total')]")"