### PR TITLE
cockpit test changes

### DIFF
--- a/airgun/entities/host.py
+++ b/airgun/entities/host.py
@@ -228,7 +228,9 @@ class HostEntity(BaseEntity):
             handle_exception=True, timeout=10,
             logger=view.logger
         )
-        return hostname_button_view
+        hostname = hostname_button_view[0].text
+        self.browser.switch_to_main_frame()
+        return hostname
 
 
 @navigator.register(HostEntity, 'All')

--- a/airgun/entities/host.py
+++ b/airgun/entities/host.py
@@ -210,14 +210,25 @@ class HostEntity(BaseEntity):
         view.flash.assert_no_error()
         view.flash.dismiss()
 
-    def open_webconsole(self, entity_name):
-        """Navigate to host's webconsole
+    def has_working_webconsole(self, entity_name):
+        """Navigate to host's webconsole and return the hostname from the cockpit page
 
         :param str entity_name: The host name for which to set the parameter value.
         """
         view = self.navigate_to(self, 'Details', entity_name=entity_name)
         view.webconsole.click()
         view.validations.assert_no_errors()
+        # the remote host content is loaded in an iframe, let's switch to it
+        self.browser.selenium.switch_to.frame(0)
+        webconsole_view = self.browser.selenium.find_elements_by_id(
+            'system_information_hostname_button'
+        )
+        wait_for(
+            lambda: webconsole_view[0].text != '',
+            handle_exception=True, timeout=10,
+            logger=view.logger
+        )
+        return webconsole_view
 
 
 @navigator.register(HostEntity, 'All')

--- a/airgun/entities/host.py
+++ b/airgun/entities/host.py
@@ -210,7 +210,7 @@ class HostEntity(BaseEntity):
         view.flash.assert_no_error()
         view.flash.dismiss()
 
-    def has_working_webconsole(self, entity_name):
+    def get_webconsole_content(self, entity_name):
         """Navigate to host's webconsole and return the hostname from the cockpit page
 
         :param str entity_name: The host name for which to set the parameter value.
@@ -220,15 +220,15 @@ class HostEntity(BaseEntity):
         view.validations.assert_no_errors()
         # the remote host content is loaded in an iframe, let's switch to it
         self.browser.selenium.switch_to.frame(0)
-        webconsole_view = self.browser.selenium.find_elements_by_id(
+        hostname_button_view = self.browser.selenium.find_elements_by_id(
             'system_information_hostname_button'
         )
         wait_for(
-            lambda: webconsole_view[0].text != '',
+            lambda: hostname_button_view[0].text != '',
             handle_exception=True, timeout=10,
             logger=view.logger
         )
-        return webconsole_view
+        return hostname_button_view
 
 
 @navigator.register(HostEntity, 'All')


### PR DESCRIPTION
Moving cockpit test more into airgun. 

I was also thinking to use view
`webconsole_view = WebConsoleView(self.browser)`

```
class WebConsoleView(View):
    ROOT = "//iframe"
    hostname = Text("//a[@id='system_information_hostname_button']")

    @property
    def is_displayed(self):
        return self.browser.wait_for_element(
            self.hostname, exception=False) is not None
```

I was unable to get into the frame for hostname. 

I thought, first view to get me into frame second view to get me inside the frame. I was unable to create that. 

I also find issue on widgetastic not sure if the frame I mean is the same as they mentioned in the [issue](https://github.com/RedHatQE/widgetastic.core/issues/98).

I think this approach, not all logic in the test and not all in the airgun is somewhere in the middle and I think it's just not that important to spend more time with different approaches on this. 

But I would be happy for your feedback here, 
there is still open #7554 PR in robottelo, if you want to see conversation about this before.