### PR TITLE
Add --ignore-certificate-errors flag for Chrome 80+

### DIFF
--- a/airgun/browser.py
+++ b/airgun/browser.py
@@ -194,6 +194,7 @@ class SeleniumBrowserFactory(object):
             prefs = {'download.prompt_for_download': False}
             options.add_experimental_option("prefs", prefs)
             options.add_argument('disable-web-security')
+            options.add_argument('ignore-certificate-errors')
             if browseroptions:
                 for opt in browseroptions.split(';'):
                     options.add_argument(opt)
@@ -310,7 +311,7 @@ class SeleniumBrowserFactory(object):
             desired_capabilities = webdriver.DesiredCapabilities.CHROME.copy()
             enable_downloading = {
                 'chromeOptions': {
-                    'args': ['disable-web-security'],
+                    'args': ['disable-web-security', 'ignore-certificate-errors'],
                     'prefs': {'download.prompt_for_download': False}
                 }
             }


### PR DESCRIPTION
On Chrome 80 and above, opening Satellite results in `NET::ERR_CERT_AUTHORITY_INVALID` error page displayed ("Your connection is not private"). Starting Chrome with `--ignore-certificate-errors` makes this error go away and allows UI test to work.

`--ignore-certificate-errors` has been available in Chrome for at least 10 years, and Chrome team has been trying to get rid of it since at least 2014. It's not publicly advertised and is probable to stop working sometime soon, but it does get the job done now.

[This StackOverflow question](https://stackoverflow.com/q/7580508/3552063) deals with similar issue and provides multiple solutions applied at various levels. I'm open to discussion about better approach than one in this PR.

Verified on Chrome 80 and Chrome 81 (beta, to be released tomorrow).