### PR TITLE
Added read title method in Settings

### DIFF
--- a/airgun/entities/settings.py
+++ b/airgun/entities/settings.py
@@ -26,6 +26,10 @@ class SettingsEntity(BaseEntity):
         view.validations.assert_no_errors()
         view.wait_for_update()
 
+    def read_title(self):
+        """Read settings title"""
+        return self.browser.title
+
 
 @navigator.register(SettingsEntity, 'All')
 class ShowAllSettings(NavigateStep):


### PR DESCRIPTION
The intent of this method to get the title name of the settings page, It the user has admin right then settings page title would be "Settings" and If it has no admin right then the title would be "Permission denied".