### PR TITLE
Fixes 349 Added browser logout method

### DIFF
--- a/airgun/entities/login.py
+++ b/airgun/entities/login.py
@@ -1,18 +1,23 @@
 from airgun.entities.base import BaseEntity
 from airgun.navigation import NavigateStep
 from airgun.navigation import navigator
+from airgun.views.common import BaseLoggedInView
 from airgun.views.login import LoginView
 
 
 class LoginEntity(BaseEntity):
-
     def login(self, values):
-        view = self.navigate_to(self, 'NavigateToLogin')
+        view = self.navigate_to(self, "NavigateToLogin")
         view.fill(values)
         view.submit.click()
 
     def logout(self):
-        pass
+        view = BaseLoggedInView(self.browser)
+        view.select_logout()
+        view.flash.assert_no_error()
+        view.flash.dismiss()
+        view = LoginView(self.browser)
+        return view.read()
 
 
 @navigator.register(LoginEntity)

--- a/airgun/session.py
+++ b/airgun/session.py
@@ -216,9 +216,7 @@ class Session(object):
             u'Stopping UI session %r for user %r', self.name, self._user)
         passed = True if exc_type is None else False
         try:
-            if passed:
-                self.login.logout()
-            else:
+            if not passed:
                 self.take_screenshot()
         except Exception as err:
             LOGGER.exception(err)

--- a/airgun/views/login.py
+++ b/airgun/views/login.py
@@ -5,11 +5,12 @@ from widgetastic.widget import View
 
 
 class LoginView(View, ClickableMixin):
-    username = TextInput(id='login_login')
-    password = TextInput(id='login_password')
+    username = TextInput(id="login_login")
+    password = TextInput(id="login_password")
+    login_text = Text('//p[@id="login_text"]')
+    logo = Text('//img[@alt="logo"]')
     submit = Text('//button[@type="submit"]')
 
     @property
     def is_displayed(self):
-        return self.browser.wait_for_element(
-            self.username, exception=False) is not None
+        return self.browser.wait_for_element(self.username, exception=False) is not None


### PR DESCRIPTION
Raised this PR by taking the reference of #397 to fix one of the required login page footer text validation after logout https://github.com/SatelliteQE/robottelo/pull/7710

Test Result
```
$ pytest tests/foreman/ui/test_settings.py::test_positive_update_login_page_footer_text_with_long_string
=============================================================================================== test session starts ===============================================================================================
platform linux -- Python 3.6.6, pytest-4.6.3, py-1.8.1, pluggy-0.13.1
shared_function enabled - OFF - scope:  - storage: file
collecting ... 2020-04-02 12:59:37 - conftest - DEBUG - Collected 1 test cases
2020-04-02 18:29:40 - robottelo.ssh - DEBUG - Instantiated Paramiko client 0x7f3f7b3695c0
2020-04-02 18:29:40 - robottelo.ssh - INFO - >>> rpm -q satellite
2020-04-02 18:29:42 - robottelo.ssh - INFO - <<< stdout
satellite-6.7.0-7.el7sat.noarch

2020-04-02 18:29:42 - robottelo.ssh - DEBUG - Destroyed Paramiko client 0x7f3f7b3695c0
2020-04-02 18:29:42 - robottelo.host_info - DEBUG - Host Satellite version: 6.7
2020-04-02 18:29:42 - robottelo.helpers - DEBUG - Generated file bz_cache.json with BZ collect data
collected 1 item                                                                                                                                                                                                  

tests/foreman/ui/test_settings.py .                                                                                                                                                                         [100%]

============================================================================================ 1 passed in 56.60 seconds ============================================================================================

```