### PR TITLE
submit is too fast, causing bug in automation

### DIFF
--- a/airgun/entities/host.py
+++ b/airgun/entities/host.py
@@ -1,3 +1,5 @@
+from time import sleep
+
 from navmazing import NavigateToSibling
 from wait_for import wait_for
 
@@ -179,6 +181,7 @@ class HostEntity(BaseEntity):
            using the checkbox from table header
         """
         view = self._select_action('Delete Hosts', entities_list)
+        sleep(1)
         view.submit.click()
         view.flash.assert_no_error()
         view.flash.dismiss()


### PR DESCRIPTION
Out automation is too fast. Zalenium record shows, that automation clicks on the right place, and also upgrades automation passes, just normal automation don't. I was unable to reproduce it, but this should solve the problem. 

Please let me try this, I know it is unusual approach, but if it will not work i can remove it after one snap. 

This is maybe a bug in satellite, but no one ever will be that fast, or will not mind to click submit once more.

Note and quetion: 
Not sure if I should use sleep ? 
And if this should go to z-stream ? I think if this patch will work it should