### PR TITLE
Add support for widgetastic.patternfly >=1.3.0 (fixes #456)

### DIFF
--- a/airgun/views/common.py
+++ b/airgun/views/common.py
@@ -34,8 +34,7 @@ class BaseLoggedInView(View):
     menu = SatVerticalNavigation(
         './/div[@id="vertical-nav" or contains(@class, "nav-pf-vertical")]/ul')
     taxonomies = ContextSelector()
-    flash = SatFlashMessages(
-        locator='//div[@class="toast-notifications-list-pf"]')
+    flash = SatFlashMessages()
     validations = ValidationErrors()
     current_user = Text("//a[@id='account_menu']")
     account_menu = Text("//a[@id='account_menu']")

--- a/airgun/widgets.py
+++ b/airgun/widgets.py
@@ -683,62 +683,6 @@ class SatVerticalNavigation(VerticalNavigation):
     CURRENTLY_SELECTED = './/li[contains(@class, "active")]/a/span'
 
 
-class SatFlashMessages(FlashMessages):
-    """Satellite version of Patternfly's alerts section. The only difference is
-    overridden ``messages`` property which returns :class:`SatFlashMessage`.
-
-    Example html representation::
-
-        <div class="toast-notifications-list-pf">
-            <div class="alert toast-pf alert-success alert-dismissable">
-                <button ... type="button" class="close close-default">
-                    <span ... class="pficon pficon-close"></span></button>
-                <span aria-hidden="true" class="pficon pficon-ok"></span>
-                <span><span>Sample message</span></span></div>
-            </div>
-        </div>
-
-    Locator example::
-
-        //div[@class="toast-notifications-list-pf"]
-
-    """
-
-    @property
-    def messages(self):
-        result = []
-        try:
-            for flash_div in self.browser.elements(
-                    './div[contains(@class, "alert")]', parent=self,
-                    check_visibility=True):
-                result.append(
-                    SatFlashMessage(self, flash_div, logger=self.logger))
-        except NoSuchElementException:
-            pass
-        return result
-
-    @retry_stale_element
-    def assert_no_error(self, ignore_messages=None):
-        if ignore_messages is None:
-            ignore_messages = []
-        self.logger.info('asserting there are no error messages')
-        for message in self.messages:
-            message_text = message.text
-            if message.type not in {'success', 'info', 'warning'}:
-                if message_text in ignore_messages:
-                    self.logger.info('ERROR MESSAGE IGNORED %s: %r', message.type, message_text)
-                    continue
-                self.logger.error('%s: %r', message.type, message_text)
-                raise AssertionError(
-                    'assert_no_error: {}: {!r}'.format(message.type, message_text))
-            else:
-                self.logger.info('%s: %r', message.type, message_text)
-
-    @retry_stale_element
-    def dismiss(self):
-        return super().dismiss()
-
-
 class SatFlashMessage(FlashMessage):
     """Satellite version of Patternfly alert. It doesn't contain ``<strong>``
     tag and all the text is inside 2 ``<span>``.
@@ -762,6 +706,52 @@ class SatFlashMessage(FlashMessage):
     @property
     def text(self):
         return self.browser.text('./span[text()]', parent=self)
+
+
+class SatFlashMessages(FlashMessages):
+    """Satellite version of Patternfly's alerts section. The only difference is
+    overridden ``messages`` property which returns :class:`SatFlashMessage`.
+
+    Example html representation::
+
+        <div class="toast-notifications-list-pf">
+            <div class="alert toast-pf alert-success alert-dismissable">
+                <button ... type="button" class="close close-default">
+                    <span ... class="pficon pficon-close"></span></button>
+                <span aria-hidden="true" class="pficon pficon-ok"></span>
+                <span><span>Sample message</span></span></div>
+            </div>
+        </div>
+
+    Locator example::
+
+        //div[@class="toast-notifications-list-pf"]
+
+    """
+    ROOT = '//div[@class="toast-notifications-list-pf"]'
+    MSG_LOCATOR = f'{ROOT}/div[contains(@class, "alert")]'
+    msg_class = SatFlashMessage
+
+    @retry_stale_element
+    def assert_no_error(self, ignore_messages=None):
+        if ignore_messages is None:
+            ignore_messages = []
+        self.logger.info('asserting there are no error messages')
+        for message in self.messages():
+            message_text = message.text
+            if message.type not in {'success', 'info', 'warning'}:
+                if message_text in ignore_messages:
+                    self.logger.info('ERROR MESSAGE IGNORED %s: %r', message.type, message_text)
+                    continue
+                self.logger.error('%s: %r', message.type, message_text)
+                raise AssertionError(
+                    'assert_no_error: {}: {!r}'.format(message.type, message_text))
+            else:
+                self.logger.info('%s: %r', message.type, message_text)
+
+    @retry_stale_element
+    def dismiss(self):
+        return super().dismiss()
 
 
 class ValidationErrors(Widget):


### PR DESCRIPTION
widgetastic.patternfly 1.3.0 broke backwards compatibility in flash messages. See #456 and https://github.com/SatelliteQE/robottelo/pull/7646#pullrequestreview-361973923 .

Main changes in widgetastic.patternfly:
* Class to use when instantiating single message is stored as `FlashMessages` class variable, which means we can drop override for `messages`. It also requires us to define `SatFlashMessage` before `SatFlashMessages`.
* `SatFlashMessages.messages` is no longer a property, but a method - must be called
* `SatFlashMessages.messages()` is a generator instead of returning list
* `SatFlashMessages` no longer takes locator as argument during instantiation

We will have to merge https://github.com/SatelliteQE/robottelo/pull/7678 around the same time as this one, as Airgun will no longer work with widgetastic.patternfly pre-1.3.0.

Tests (see https://github.com/SatelliteQE/airgun/issues/456#issuecomment-625869518 for reasoning):
```
$ pytest -v tests/foreman/ui/test_activationkey.py::test_positive_create_with_host_collection tests/foreman/ui/test_contentview.py::test_positive_publish_promote_with_custom_puppet_module tests/foreman/ui/test_settings.py::test_positive_update_email_delivery_method_sendmail tests/foreman/ui/test_subscription.py::test_positive_end_to_end
===================================================================================== test session starts =====================================================================================
platform linux -- Python 3.7.5, pytest-4.6.3, py-1.8.1, pluggy-0.13.1 -- /home/mzalewsk/.virtualenvs/robottelo/bin/python
cachedir: .pytest_cache
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/mzalewsk/sources/robottelo
plugins: xdist-1.31.0, cov-2.8.1, services-1.3.1, forked-1.1.3, mock-1.10.4
collected 4 items                                                                                                                                                                             

tests/foreman/ui/test_activationkey.py::test_positive_create_with_host_collection PASSED                                                                                                [ 25%]
tests/foreman/ui/test_contentview.py::test_positive_publish_promote_with_custom_puppet_module PASSED                                                                                    [ 50%]
tests/foreman/ui/test_settings.py::test_positive_update_email_delivery_method_sendmail PASSED                                                                                           [ 75%]
tests/foreman/ui/test_subscription.py::test_positive_end_to_end PASSED                                                                                                                  [100%]
=========================================================================== 4 passed, 2 warnings in 646.77 seconds ============================================================================
```