### PR TITLE
Rename "Play Ansible roles" action on hosts page

### DIFF
--- a/airgun/entities/host.py
+++ b/airgun/entities/host.py
@@ -170,7 +170,7 @@ class HostEntity(BaseEntity):
 
         :returns: The job invocation status view values
         """
-        status_view = self._select_action('Play Ansible roles', entities_list)
+        status_view = self._select_action('Run all Ansible roles', entities_list)
         if wait_for_results:
             status_view.wait_for_result(timeout=timeout)
         return status_view.read()
@@ -311,7 +311,7 @@ class HostsSelectAction(NavigateStep):
         'Assign Organization': HostsAssignOrganization,
         'Delete Hosts': HostsDeleteActionDialog,
         'Schedule Remote Job': HostsJobInvocationCreateView,
-        'Play Ansible roles': HostsJobInvocationStatusView,
+        'Run all Ansible roles': HostsJobInvocationStatusView,
     }
 
     def prerequisite(self, *args, **kwargs):


### PR DESCRIPTION
That was renamed during 6.7 cycle, but went unnoticed, as apparently nothing in Robottelo actually uses that. But IQE/Satellite integration does.

I will be cherry-picking that to 6.7.z after merge.

```
$ iqe tests plugin insights_satellite  -k test_satellite_ansible_install --critical
===================================================================================== test session starts =====================================================================================
platform linux -- Python 3.6.3, pytest-5.4.1, py-1.8.1, pluggy-0.13.1
rootdir: /home/mzalewsk/sources/iqe-satellite-plugin, testpaths: /home/mzalewsk/sources/iqe-satellite-plugin/iqe_insights_satellite
plugins: cov-2.8.1, hypothesis-5.8.0, subtests-0.2.1, iqe-red-hat-internal-envs-plugin-0.7.7, polarion-collect-0.23.1, schemathesis-1.0.5, iqe-platform-ui-plugin-0.14.21, report-parameters-0.5.0, iqe-vm-plugin-0.1.23.dev2+g520dd91, iqe-insights-satellite-plugin-0.1.8.dev6+gc3ea5e9, iqe-integration-tests-0.27.2.dev6+g1e7b4b5
collected 18 items / 17 deselected / 1 skipped                                                                                                                                                

iqe_insights_satellite/tests/test_ansible.py::test_satellite_ansible_install PASSED                                                                                                     [100%]
============================================================ 1 passed, 1 skipped, 17 deselected, 295 warnings in 508.75s (0:08:28) ============================================================
```