### PR TITLE
Convert <a> to <input> on Job page

### DIFF
--- a/airgun/views/job_invocation.py
+++ b/airgun/views/job_invocation.py
@@ -5,6 +5,7 @@ from widgetastic.widget import Text
 from widgetastic.widget import TextInput
 from widgetastic.widget import View
 from widgetastic_patternfly import BreadCrumb
+from widgetastic_patternfly import Button
 
 from airgun.views.common import BaseLoggedInView
 from airgun.views.common import SatTab
@@ -183,8 +184,8 @@ class JobInvocationStatusView(BaseLoggedInView):
     rerun = Text("//a[text()='Rerun']")
     rerun_failed = Text("//a[text()='Rerun failed']")
     job_task = Text("//a[text()='Job Task']")
-    cancel_job = Text("//a[text()='Cancel Job']")
-    abort_job = Text("//a[text()='Abort Job']")
+    cancel_job = Button(value='Cancel Job')
+    abort_job = Button(value='Abort Job')
 
     @View.nested
     class overview(SatTab):


### PR DESCRIPTION
On Job page, Cancel and Abort were converted from `<a>` to `<input>` back in 6.6. This change is needed to fix non-critical error in tests calling `.read()` on `JobInvocationStatusView` or any of derived classes.

I will be backporting that to 6.7.z and 6.6.z after merge.

Before:
```
2020-05-22 13:06:48 ERROR [HostsJobInvocationStatusView/cancel_job]: An exception happened during read call (elapsed 498 ms)
2020-05-22 13:06:48 ERROR [HostsJobInvocationStatusView/cancel_job]: Message: Could not find an element Locator(by='xpath', locator="//a[text()='Cancel Job']")
Traceback (most recent call last):
  File "/home/mzalewsk/.virtualenvs/iqe-tests/lib64/python3.6/site-packages/widgetastic/log.py", line 115, in wrapped
    result = f(self, *args, **kwargs)
  File "/home/mzalewsk/.virtualenvs/iqe-tests/lib64/python3.6/site-packages/widgetastic/widget/text.py", line 20, in read
    return self.text
  File "/home/mzalewsk/.virtualenvs/iqe-tests/lib64/python3.6/site-packages/widgetastic/widget/text.py", line 17, in text
    return self.browser.text(self, parent=self.parent)
  File "/home/mzalewsk/.virtualenvs/iqe-tests/lib64/python3.6/site-packages/widgetastic/utils.py", line 679, in wrap
    return method(*args, **kwargs)
  File "/home/mzalewsk/.virtualenvs/iqe-tests/lib64/python3.6/site-packages/widgetastic/browser.py", line 633, in text
    text = self.element(locator, *args, **kwargs).text
  File "/home/mzalewsk/.virtualenvs/iqe-tests/lib64/python3.6/site-packages/widgetastic/browser.py", line 341, in element
    elements = self.elements(locator, *args, **kwargs)
  File "/home/mzalewsk/.virtualenvs/iqe-tests/lib64/python3.6/site-packages/widgetastic/browser.py", line 928, in elements
    force_check_safe=force_check_safe)
  File "/home/mzalewsk/.virtualenvs/iqe-tests/lib64/python3.6/site-packages/widgetastic/utils.py", line 679, in wrap
    return method(*args, **kwargs)
  File "/home/mzalewsk/.virtualenvs/iqe-tests/lib64/python3.6/site-packages/widgetastic/browser.py", line 253, in elements
    locator = self._process_locator(locator)
  File "/home/mzalewsk/.virtualenvs/iqe-tests/lib64/python3.6/site-packages/widgetastic/browser.py", line 202, in _process_locator
    return locator.__element__()
  File "/home/mzalewsk/.virtualenvs/iqe-tests/lib64/python3.6/site-packages/widgetastic/widget/base.py", line 67, in wrapped
    return method(self, *new_args, **new_kwargs)
  File "/home/mzalewsk/.virtualenvs/iqe-tests/lib64/python3.6/site-packages/widgetastic/widget/base.py", line 344, in __element__
    return self.parent_browser.element(locator)
  File "/home/mzalewsk/.virtualenvs/iqe-tests/lib64/python3.6/site-packages/widgetastic/browser.py", line 352, in element
    'Could not find an element {}'.format(repr(locator))) from None
selenium.common.exceptions.NoSuchElementException: Message: Could not find an element Locator(by='xpath', locator="//a[text()='Cancel Job']")

2020-05-22 13:06:48 ERROR [HostsJobInvocationStatusView/abort_job]: An exception happened during read call (elapsed 21 ms)
2020-05-22 13:06:48 ERROR [HostsJobInvocationStatusView/abort_job]: Message: Could not find an element Locator(by='xpath', locator="//a[text()='Abort Job']")
Traceback (most recent call last):
  File "/home/mzalewsk/.virtualenvs/iqe-tests/lib64/python3.6/site-packages/widgetastic/log.py", line 115, in wrapped
    result = f(self, *args, **kwargs)
  File "/home/mzalewsk/.virtualenvs/iqe-tests/lib64/python3.6/site-packages/widgetastic/widget/text.py", line 20, in read
    return self.text
  File "/home/mzalewsk/.virtualenvs/iqe-tests/lib64/python3.6/site-packages/widgetastic/widget/text.py", line 17, in text
    return self.browser.text(self, parent=self.parent)
  File "/home/mzalewsk/.virtualenvs/iqe-tests/lib64/python3.6/site-packages/widgetastic/utils.py", line 679, in wrap
    return method(*args, **kwargs)
  File "/home/mzalewsk/.virtualenvs/iqe-tests/lib64/python3.6/site-packages/widgetastic/browser.py", line 633, in text
    text = self.element(locator, *args, **kwargs).text
  File "/home/mzalewsk/.virtualenvs/iqe-tests/lib64/python3.6/site-packages/widgetastic/browser.py", line 341, in element
    elements = self.elements(locator, *args, **kwargs)
  File "/home/mzalewsk/.virtualenvs/iqe-tests/lib64/python3.6/site-packages/widgetastic/browser.py", line 928, in elements
    force_check_safe=force_check_safe)
  File "/home/mzalewsk/.virtualenvs/iqe-tests/lib64/python3.6/site-packages/widgetastic/utils.py", line 679, in wrap
    return method(*args, **kwargs)
  File "/home/mzalewsk/.virtualenvs/iqe-tests/lib64/python3.6/site-packages/widgetastic/browser.py", line 253, in elements
    locator = self._process_locator(locator)
  File "/home/mzalewsk/.virtualenvs/iqe-tests/lib64/python3.6/site-packages/widgetastic/browser.py", line 202, in _process_locator
    return locator.__element__()
  File "/home/mzalewsk/.virtualenvs/iqe-tests/lib64/python3.6/site-packages/widgetastic/widget/base.py", line 67, in wrapped
    return method(self, *new_args, **new_kwargs)
  File "/home/mzalewsk/.virtualenvs/iqe-tests/lib64/python3.6/site-packages/widgetastic/widget/base.py", line 344, in __element__
    return self.parent_browser.element(locator)
  File "/home/mzalewsk/.virtualenvs/iqe-tests/lib64/python3.6/site-packages/widgetastic/browser.py", line 352, in element
    'Could not find an element {}'.format(repr(locator))) from None
selenium.common.exceptions.NoSuchElementException: Message: Could not find an element Locator(by='xpath', locator="//a[text()='Abort Job']")

```

After:
```
2020-05-22 14:53:03 INFO [HostsJobInvocationStatusView/cancel_job]: read -> '' (elapsed 858 ms)
2020-05-22 14:53:04 INFO [HostsJobInvocationStatusView/abort_job]: read -> '' (elapsed 706 ms)
```