### PR TITLE
[6.7.z] Pin older flake8 to avoid travis failures

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,6 +5,10 @@ repos:
   rev: v1.9.0
   hooks:
   - id: reorder-python-imports
+- repo: https://gitlab.com/pycqa/flake8
+  rev: 3.7.9
+  hooks:
+  - id: flake8
 - repo: https://github.com/pre-commit/pre-commit-hooks
   rev: v2.5.0
   hooks:
@@ -12,4 +16,3 @@ repos:
   - id: end-of-file-fixer
   - id: check-yaml
   - id: debug-statements
-  - id: flake8


### PR DESCRIPTION
Our pre-commit config used unpinned flake8 dependency. flake8 recently introduced new version with updated style guide that reports syntax that used to pass without problems.

We could fix that error, but our strategy is to freeze older branches in time, so it makes more sense for me to pin flake8 dependency to known version.

Test results - see travis