### PR TITLE
Fix errata search box locator

### DIFF
--- a/airgun/views/hostcollection.py
+++ b/airgun/views/hostcollection.py
@@ -207,7 +207,7 @@ class HostCollectionManagePackagesView(BaseLoggedInView):
 class HostCollectionInstallErrataView(BaseLoggedInView, SearchableViewMixin):
     title = Text("//h4[contains(., 'Content Host Errata Management')]")
     search = TextInput(
-        locator=".//input[@type='text' and @ng-model='errataFilter']")
+        locator=".//input[@type='text' and @ng-model='table.searchTerm']")
     refresh = Text(locator=".//button[@ng-click='fetchErrata()']")
     install = ActionsDropdown(
             "//span[contains(@class, 'btn-group')]"


### PR DESCRIPTION
Hello
This test was failing:
`tests/foreman/ui/test_hostcollection.py -k test_positive_install_modular_errata`

with:
`>               'Could not find an element {}'.format(repr(locator))) from None
E           selenium.common.exceptions.NoSuchElementException: Message: Could not find an element ".//input[@type='text' and @ng-model='errataFilter']"`

Change came from here:

katello]$ git show 555699b37f9d779af4c1f81c966c8f9ca257a2dc
commit 555699b37f9d779af4c1f81c966c8f9ca257a2dc
Author: Walden Raines <walden@redhat.com>
Date:   Fri Jul 19 14:44:01 2019 -0400

    Fixes #26318: add scoped search to CH errata page.
    
    Add missing scoped search to the content host errata page.
    
    https://projects.theforeman.org/issues/26318

```
     <div ng-show="showTable()" data-extend-template="layouts/partials/table.html">
-      <div data-block="search">
-        <input type="text" class="form-control" stop-event="click"
-               placeholder="{{ 'Filter...' | translate }}"
-               ng-model="errataFilter"/>
-      </div>
-
```

