### PR TITLE
Fix locator for save button on Content Host description text field.

### DIFF
--- a/airgun/widgets.py
+++ b/airgun/widgets.py
@@ -1261,7 +1261,7 @@ class EditableEntry(GenericLocatorWidget):
     """
     edit_button = Text(".//span[contains(@ng-hide, 'editMode')]")
     edit_field = TextInput(locator=".//*[self::input or self::textarea]")
-    save_button = Text(".//button[span[text()='Save']]")
+    save_button = Text(".//button[text()='Save']")
     cancel_button = Text(".//button[span[text()='Cancel']]")
     entry_value = Text(".//span[contains(@class, 'editable-value')]")
 


### PR DESCRIPTION
Hello

This change caused test[1] to fail:
In 6.7: `style=""><span class="ng-scope">Save</span></button>`
In 6.8: `style="">Save</button>`


Example of faliure:

    `> 'Could not find an element {}'.format(repr(locator))) from None
    E selenium.common.exceptions.NoSuchElementException: Message: Could not find an element       Locator(by='xpath', locator=".//button[span[text()='Save']]")

    .env/lib64/python3.7/site-packages/widgetastic/browser.py:352: NoSuchElementException`


[1] tests/foreman/ui/test_contenthost.py::test_positive_end_to_end

