### PR TITLE
added support for two-factor rh-sso auth login

### DIFF
--- a/airgun/entities/rhsso_login.py
+++ b/airgun/entities/rhsso_login.py
@@ -4,6 +4,7 @@ from airgun.navigation import navigator
 from airgun.views.common import BaseLoggedInView
 from airgun.views.rhsso_login import RhssoExternalLogoutView
 from airgun.views.rhsso_login import RhssoLoginView
+from airgun.views.rhsso_login import RhssoTwoFactorSuccessView
 
 
 class RHSSOLoginEntity(BaseEntity):
@@ -23,6 +24,12 @@ class RHSSOLoginEntity(BaseEntity):
         view.flash.assert_no_error()
         view.flash.dismiss()
         view = RhssoExternalLogoutView(self.browser)
+        return view.read()
+
+    def get_two_factor_login_code(self, values, url):
+        self.browser.selenium.get(url)
+        self.login(values)
+        view = RhssoTwoFactorSuccessView(self.browser)
         return view.read()
 
 

--- a/airgun/views/rhsso_login.py
+++ b/airgun/views/rhsso_login.py
@@ -23,3 +23,12 @@ class RhssoExternalLogoutView(View, ClickableMixin):
     def is_displayed(self):
         return self.browser.wait_for_element(
             self.login_again, exception=False) is not None
+
+
+class RhssoTwoFactorSuccessView(View, ClickableMixin):
+    code = TextInput(id='code')
+
+    @property
+    def is_displayed(self):
+        return self.browser.wait_for_element(
+            self.code, exception=False) is not None


### PR DESCRIPTION

1. We need to have this url after taking hammer auth login --two- factor  
```

[root@dhcp-2-190 ~]# echo 'df64bf48-453f-4755-8eb1-ba4d5a6a13c7.f89cccec-f022-4ef5-b06b-c2eaa15f799e.77bad924-e252-4daa-a7c9-9697d05339eb' | hammer auth login oauth --oidc-token-endpoint https://rhss.example.com/auth/realms/satqe/protocol/openid-connect/token --oidc-authorization-endpoint https://rhssoexample.com/auth/realms/satqe/protocol/openid-connect/auth --oidc-client-id satelliteexample.com-foreman-openidc --oidc-redirect-uri 'urn:ietf:wg:oauth:2.0:oob' --two-factor 
Enter URL in browser: https://satellite.example.com/auth/realms/satqe/protocol/openid-connect/auth?response_type=code&client_id=satellite.example.com-foreman-openidc&redirect_uri=urn:ietf:wg:oauth:2.0:oob&scope=openid

```
![RHSSO_Login_1](https://user-images.githubusercontent.com/3190629/89398293-8c44ad80-d72e-11ea-82c7-8bcb8488c60e.png)

2. This is the view after the login needs to be collected the token for further automation in hammer cli.  
![Selection_043](https://user-images.githubusercontent.com/3190629/89399505-35d86e80-d730-11ea-88c0-d7aaa391c0ea.png)

