### PR TITLE
[POC] Fix search clear on Module Streams page

### DIFF
--- a/airgun/views/modulestream.py
+++ b/airgun/views/modulestream.py
@@ -13,6 +13,7 @@ from airgun.widgets import Search
 
 class CustomSearch(Search):
     search_field = TextInput(locator=".//input[@role='combobox']")
+    clear_button = Text(".//span[contains(@class,'fa-times')]")
     search_button = Button('Search')
 
 


### PR DESCRIPTION
See https://github.com/SatelliteQE/robottelo/pull/7927
```bash
pytest tests/foreman/ui/test_modulestreams.py::test_positive_module_stream_details_search_in_repo
===================================================================================== test session starts =====================================================================================
platform linux -- Python 3.8.5, pytest-4.6.3, py-1.8.1, pluggy-0.13.1
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/mzalewsk/sources/robottelo
plugins: cov-2.10.0, mock-1.10.4, forked-1.2.0, services-1.3.1, xdist-1.32.0
collecting ... 2020-08-11 09:58:52 - conftest - DEBUG - Collected 1 test cases
collected 1 item                                                                                                                                                                              

tests/foreman/ui/test_modulestreams.py .                                                                                                                                                [100%]
=========================================================================== 1 passed, 2 warnings in 132.98 seconds ============================================================================
```