### PR TITLE
Fix Sync Status page partial loading (#507)

### DIFF
--- a/airgun/entities/sync_status.py
+++ b/airgun/entities/sync_status.py
@@ -37,6 +37,7 @@ class SyncStatusEntity(BaseEntity):
         :return: the results text in RESULT columns
         """
         view = self.navigate_to(self, 'All')
+        view.browser.refresh()
         repo_nodes = [view.table.get_node_from_path(repo_path)
                       for repo_path in repository_paths]
         for repo_node in repo_nodes:


### PR DESCRIPTION
Hello
For 6.7 branch

this fixes issue :
Sync Status page does not display correctly unless refreshed #507