### PR TITLE
Implementing custom clear() method for the AutoCompleteTextInput

### DIFF
--- a/airgun/views/discoveryrule.py
+++ b/airgun/views/discoveryrule.py
@@ -49,7 +49,7 @@ class DiscoveryRuleCreateView(BaseLoggedInView):
     @View.nested
     class primary(SatTab):
         name = TextInput(id='discovery_rule_name')
-        search = AutoCompleteTextInput(id='search')
+        search = AutoCompleteTextInput(name='discovery_rule[search]')
         host_group = FilteredDropdown(id='discovery_rule_hostgroup_id')
         hostname = TextInput(id='discovery_rule_hostname')
         hosts_limit = TextInput(id='discovery_rule_max_count')

--- a/airgun/widgets.py
+++ b/airgun/widgets.py
@@ -2097,14 +2097,30 @@ class GenericRemovableWidgetItem(GenericLocatorWidget):
 
 class AutoCompleteTextInput(TextInput):
     """Autocomplete Search input field, We must remove the focus from this widget after fill to
-    force the auto-completion list to be hidden.
+    force the auto-completion list to be hidden. Since this is a react component, calling browser
+    clear method directly on the field has no effect, thus we need to clear the field using the 
+    clear button attached to the input
     """
 
+    clear_button = Text(
+        locator="//span[contains(@class,'autocomplete-clear-button') or "
+                "contains(@class,'fa-close')]"
+    )
+
+    def clear(self):
+        """Clears search field value and re-trigger search to remove all
+        filters.
+        """
+        if self.clear_button.is_displayed:
+            self.clear_button.click()
+
     def fill(self, value):
-        changes = super().fill(value)
+        old_value = self.value
+        self.clear()
+        super().fill(value)
         self.browser.plugin.ensure_page_safe()
         self.browser.execute_script('arguments[0].blur();', self.__element__())
-        return changes
+        return self.value != old_value
 
 
 class ToggleButton(Button):


### PR DESCRIPTION
Since this is a react element, the browser.clear() doesn't work. We need to access the 'x' button and click it.

```
$ py.test test_discoveryrule.py::test_positive_end_to_end
=== test session starts ===
platform linux -- Python 3.7.8, pytest-4.6.3, py-1.9.0, pluggy-0.13.1
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/rplevka/work/rplevka/robottelo
plugins: xdist-1.33.0, services-1.3.1, forked-1.2.0, repeat-0.8.0, cov-2.10.1, mock-1.10.4
collecting ... 2020-09-18 12:23:25 - conftest - DEBUG - Collected 1 test cases
collected 1 item                                                                                                                                                             

test_discoveryrule.py . 
=== 1 passed, 4 warnings in 166.85 seconds ===
```