### PR TITLE
Extend Insights plan entity to support more actions

### DIFF
--- a/airgun/views/rhai.py
+++ b/airgun/views/rhai.py
@@ -121,7 +121,8 @@ class AllPlansView(BaseLoggedInView):
         title = Text(".")
         delete = Text(".//i[@tooltip='Delete this plan']")
         edit = Text(".//i[@tooltip='Click to edit this plan']")
-        run_playbook = Button("Run Playbook")
+        ansible_actions = ActionsDropdown(
+            "//div[contains(@class, 'btn-group')][@ng-if='ansibleRunner']")
         export_csv = Button("Export CSV")
         add_actions = Button("Add actions")
 


### PR DESCRIPTION
New actions supported:
* run Ansible playbook
* run Ansible playbook with REX customizations
* download Ansible playbook
* download plan CSV

Needed for https://github.com/SatelliteQE/robottelo/pull/8102 ; see it for test results.