### PR TITLE
fixing the authsource locator issue in satellite 6.9

### DIFF
--- a/airgun/views/ldapauthentication.py
+++ b/airgun/views/ldapauthentication.py
@@ -14,8 +14,7 @@ from airgun.widgets import SatTable
 
 class LDAPAuthenticationsView(BaseLoggedInView):
     title = Text(
-        "//h1[text()='LDAP authentication sources' or "
-        "text()='LDAP Authentication']"
+        "//h1[text()='Authentication Sources' or text()='LDAP authentication sources']"
     )
     internal = AuthSourceAggregateCard(name="Internal")
     external = AuthSourceAggregateCard(name="External")

--- a/airgun/widgets.py
+++ b/airgun/widgets.py
@@ -2098,7 +2098,7 @@ class GenericRemovableWidgetItem(GenericLocatorWidget):
 class AutoCompleteTextInput(TextInput):
     """Autocomplete Search input field, We must remove the focus from this widget after fill to
     force the auto-completion list to be hidden. Since this is a react component, calling browser
-    clear method directly on the field has no effect, thus we need to clear the field using the 
+    clear method directly on the field has no effect, thus we need to clear the field using the
     clear button attached to the input
     """
 


### PR DESCRIPTION
### Test Result 
```
Testing started at 8:00 PM ...
/home/okhatavk/okhatavk/Satellite/robottelo/env/bin/python /home/okhatavk/Downloads/pycharm-community-2018.1.4/helpers/pycharm/_jb_pytest_runner.py --target test_ldap_authentication.py::test_positive_end_to_end_ad
Launching py.test with arguments test_ldap_authentication.py::test_positive_end_to_end_ad in /home/okhatavk/Satellite/robottelo/tests/foreman/ui

============================= test session starts ==============================
platform linux -- Python 3.6.8, pytest-5.4.3, py-1.8.1, pluggy-0.13.1
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/okhatavk/Satellite/robottelo
plugins: forked-1.1.3, cov-2.8.1, cagoule-0.4.0, mock-1.10.4, xdist-1.34.0, lazy-fixture-0.6.3, services-1.3.1, instafail-0.4.2, ibutsu-1.1.12020-10-28 14:30:20 - conftest - DEBUG - Collected 1 test cases
collected 1 item

tests/foreman/ui/test_ldap_authentication.py::test_positive_end_to_end_ad
tests/foreman/ui/test_ldap_authentication.py::test_positive_end_to_end_ad
  /home/okhatavk/okhatavk/Satellite/robottelo/env/lib/python3.6/site-packages/widgetastic/browser.py:743: DeprecationWarning: use driver.switch_to.alert instead
    return self.selenium.switch_to_alert()

-- Docs: https://docs.pytest.org/en/latest/warnings.html
================== 1 passed, 4 warnings in 109.57s (0:01:49) ===================
```