### PR TITLE
Update the virt-who view as the http proxy option has been updated

### DIFF
--- a/airgun/views/virtwho_configure.py
+++ b/airgun/views/virtwho_configure.py
@@ -124,7 +124,7 @@ class VirtwhoConfigureCreateView(BaseLoggedInView):
     satellite_url = TextInput(id='foreman_virt_who_configure_config_satellite_url')
     hypervisor_id = FilteredDropdown(id='foreman_virt_who_configure_config_hypervisor_id')
     debug = Checkbox(id='foreman_virt_who_configure_config_debug')
-    proxy = TextInput(id='foreman_virt_who_configure_config_proxy')
+    proxy = FilteredDropdown(id='foreman_virt_who_configure_config_http_proxy_id')
     no_proxy = TextInput(id='foreman_virt_who_configure_config_no_proxy')
     filtering = FilteredDropdown(id='foreman_virt_who_configure_config_listing_mode')
     filtering_content = ConditionalSwitchableView(reference='filtering')
@@ -216,7 +216,7 @@ class VirtwhoConfigureDetailsView(BaseLoggedInView):
         filter_host_parents = Text('.//span[contains(@class,"config-filter_host_parents")]')
         exclude_hosts = Text('.//span[contains(@class,"config-blacklist")]')
         exclude_host_parents = Text('.//span[contains(@class,"config-exclude_host_parents")]')
-        proxy = Text('.//span[contains(@class,"config-proxy")]')
+        proxy = Text('.//span[contains(@class,"config-http_proxy_id")]')
         no_proxy = Text('.//span[contains(@class,"config-no_proxy")]')
         kubeconfig_path = Text('.//span[contains(@class,"config-kubeconfig_path")]')
 
@@ -244,7 +244,7 @@ class VirtwhoConfigureDetailsView(BaseLoggedInView):
         exclude_host_parents_label = Text(
             _label_locator.format(class_name="config-exclude_host_parents")
         )
-        proxy_label = Text(_label_locator.format(class_name="config-proxy"))
+        proxy_label = Text(_label_locator.format(class_name="config-http_proxy_id"))
         no_proxy_label = Text(_label_locator.format(class_name="config-no_proxy"))
         kubeconfig_path_label = Text(_label_locator.format(class_name="config-kubeconfig_path"))
 


### PR DESCRIPTION
**Description**
Fix #539 


**Test Result**
```
(venv) [hkx303@kuhuang ui]$ pytest test_esx.py -k test_positive_overview_label_name -s
==================================== test session starts =====================================
platform linux -- Python 3.7.3, pytest-5.4.3, py-1.9.0, pluggy-0.13.1
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/hkx303/Documents/CI/robottelo/robottelo, inifile: pytest.ini
plugins: metadata-1.10.0, html-2.1.1, cov-2.10.1, services-1.3.1, xdist-1.34.0, mock-1.10.4, forked-1.3.0, ibutsu-1.1.1
collecting ... 2020-11-27 11:47:35 - conftest - DEBUG - Collected 15 test cases
collected 15 items / 14 deselected / 1 selected       

================== 1 passed, 14 deselected, 5 warnings in 117.31s (0:01:57) ==================
```

