### PR TITLE
Implement "Register Host" page

### DIFF
--- a/airgun/entities/host.py
+++ b/airgun/entities/host.py
@@ -11,6 +11,7 @@ from airgun.navigation import navigator
 from airgun.views.host import HostCreateView
 from airgun.views.host import HostDetailsView
 from airgun.views.host import HostEditView
+from airgun.views.host import HostRegisterView
 from airgun.views.host import HostsAssignCompliancePolicy
 from airgun.views.host import HostsAssignLocation
 from airgun.views.host import HostsAssignOrganization
@@ -42,6 +43,14 @@ class HostEntity(BaseEntity):
         )
         host_view.flash.assert_no_error()
         host_view.flash.dismiss()
+
+    def get_register_command(self, values):
+        """Get curl command generated on Register Host page"""
+        view = self.navigate_to(self, 'Register')
+        view.fill(values)
+        self.browser.click(view.generate_command)
+        self.browser.plugin.ensure_page_safe()
+        return view.registration_command.read()
 
     def search(self, value):
         """Search for existing host entity"""
@@ -257,6 +266,18 @@ class AddNewHost(NavigateStep):
 
     def step(self, *args, **kwargs):
         self.parent.new.click()
+
+
+@navigator.register(HostEntity, 'Register')
+class RegisterHost(NavigateStep):
+    """Navigate to Register Host page"""
+
+    VIEW = HostRegisterView
+
+    prerequisite = NavigateToSibling('All')
+
+    def step(self, *args, **kwargs):
+        self.parent.register.click()
 
 
 @navigator.register(HostEntity, 'Details')

--- a/airgun/views/host.py
+++ b/airgun/views/host.py
@@ -193,6 +193,7 @@ class HostsView(BaseLoggedInView, SearchableViewMixin):
     title = Text("//h1[text()='Hosts']")
     export = Text(".//a[contains(@class, 'btn')][contains(@href, 'hosts.csv')]")
     new = Text("//a[contains(text(),'Create Host')]")
+    register = Button("Register Host")
     select_all = Checkbox(locator="//input[@id='check_all']")
     table = SatTable(
         './/table',
@@ -462,6 +463,29 @@ class HostCreateView(BaseLoggedInView):
         enabled = Checkbox(id='host_enabled')
         hardware_model = FilteredDropdown(id='host_model_id')
         comment = TextInput(id='host_comment')
+
+
+class HostRegisterView(BaseLoggedInView):
+    breadcrumb = BreadCrumb()
+    host_group = FilteredDropdown(id='s2id_host_group_id')
+    operatingsystem = FilteredDropdown(id='s2id_operatingsystem_id')
+    capsule = FilteredDropdown(id='s2id_smart_proxy')
+    setup_insights = FilteredDropdown(id='s2id_setup_insights')
+    remote_execution = FilteredDropdown(id='s2id_setup_remote_execution')
+    token_lifetime = TextInput(id='jwt_expiration')
+    remote_execution_interface = TextInput(id='remote_execution_interface')
+    activation_keys = TextInput(id='activation_key')
+    generate_command = TextInput(name='commit')
+    registration_command = Text('//pre[@id="registration_command"]')
+
+    @property
+    def is_displayed(self):
+        breadcrumb_loaded = self.browser.wait_for_element(self.breadcrumb, exception=False)
+        return (
+            breadcrumb_loaded
+            and self.breadcrumb.locations[0] == 'Registrations'
+            and self.breadcrumb.read() == 'Register Host'
+        )
 
 
 class HostDetailsView(BaseLoggedInView):


### PR DESCRIPTION
Add "Register Host" page, introduced in Satellite 6.9.

So far no test depends on it, but I tested it with following one:
```python
def test_positive_generate_command(session):
    with session:
        cmd = session.host.get_register_command({
            'setup_insights': 'Yes',
            'remote_execution': 'Yes',
            'activation_keys': 'non-existing-key,random-key'
        })
        print(f"\n{cmd}\n")
```
```
$ pytest -sv tests/foreman/ui/test_host.py::test_positive_generate_command
===================================================================================== test session starts =====================================================================================
platform linux -- Python 3.9.0, pytest-5.4.3, py-1.9.0, pluggy-0.13.1 -- /home/mzalewsk/.virtualenvs/robottelo/bin/python3
cachedir: .pytest_cache
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/mzalewsk/sources/robottelo, inifile: pytest.ini
plugins: ibutsu-1.1.1, mock-3.3.1, forked-1.3.0, xdist-1.34.0, services-2.2.1
collecting ... 2020-12-03 09:56:19 - conftest - DEBUG - Collected 1 test cases
collected 1 item                                                                                                                                                                              
2020-12-03 10:56:33 - robottelo - DEBUG - Started Test: test_host.py/test_positive_generate_command

curl -X GET "https://<REDACTED>/register?activation_key=non-existing-key%2Crandom-key&location_id=6&organization_id=5&setup_insights=true" -H 'Authorization: Bearer <REDACTED>' | bash

PASSED2020-12-03 10:57:43 - robottelo - DEBUG - Finished Test: test_host.py/test_positive_generate_command
```