### PR TITLE
Add ROOT for Search widget

### DIFF
--- a/airgun/widgets.py
+++ b/airgun/widgets.py
@@ -628,6 +628,7 @@ class ActionDropdownWithCheckbox(ActionsDropdown):
 class Search(Widget):
     """Searchbar for table filtering"""
 
+    ROOT = '//div[@id="search-bar" or contains(@class, "toolbar-pf-filter")]'
     search_field = TextInput(
         locator=(
             ".//input[@id='search' or contains(@placeholder, 'Filter') or "


### PR DESCRIPTION
Some robottelo tests are failing because the `search_field` subwidget cannot be found. This is happening because there are two hidden search fields higher up in the page, associated with the Organization and Location context dropdowns. The `search_field` locator matches those, and because they are not visible, any attempts to interact with `search_field` fail.

This PR fixes the issue by adding a `ROOT` locator to `Search`:

`ROOT = '//div[@id="search-bar" or contains(@class, "toolbar-pf-filter")]'`

The two locators are necessary because there are two distinct search bar implementations. Some pages (e.g., `Administer > Locations`) use the `search-bar` version, whereas others (e.g., `Content > Products`), use `toolbar-pf-filter`.