### PR TITLE
Fix logger text

### DIFF
--- a/airgun/session.py
+++ b/airgun/session.py
@@ -261,7 +261,7 @@ class Session:
         try:
             selenium_browser = self._factory.get_browser()
             self.browser = AirgunBrowser(selenium_browser, self)
-            LOGGER.info('Setting initial URL to {url}')
+            LOGGER.info(f'Setting initial URL to {url}')
 
             self.browser.url = url
 


### PR DESCRIPTION
This PR makes a small fix to the logging in `session`, where an f-string was not properly defined. Log mesages of the form

`INFO     airgun.session:session.py:264 Setting initial URL to {url}`

are now properly formatted:

`INFO     airgun.session:session.py:264 Setting initial URL to https://satellite.example.com/settings`

