### PR TITLE
fixed hostgroup locator for global registration

### DIFF
--- a/airgun/views/host.py
+++ b/airgun/views/host.py
@@ -467,7 +467,7 @@ class HostCreateView(BaseLoggedInView):
 
 class HostRegisterView(BaseLoggedInView):
     breadcrumb = BreadCrumb()
-    host_group = FilteredDropdown(id='s2id_host_group_id')
+    hostgroup = FilteredDropdown(id='s2id_hostgroup_id')
     operatingsystem = FilteredDropdown(id='s2id_operatingsystem_id')
     capsule = FilteredDropdown(id='s2id_smart_proxy')
     setup_insights = FilteredDropdown(id='s2id_setup_insights')


### PR DESCRIPTION
Id didn't match the reality, PR brings the fix plus matches the var name to the id