### PR TITLE
syspurpose bulk action 

### DIFF
--- a/airgun/entities/contenthost.py
+++ b/airgun/entities/contenthost.py
@@ -5,6 +5,7 @@ from airgun.views.contenthost import ContentHostDetailsView
 from airgun.views.contenthost import ContentHostsView
 from airgun.views.contenthost import ContentHostTaskDetailsView
 from airgun.views.contenthost import ErrataDetailsView
+from airgun.views.contenthost import SyspurposeBulkActionView
 from airgun.views.job_invocation import JobInvocationCreateView
 from airgun.views.job_invocation import JobInvocationStatusView
 
@@ -59,6 +60,17 @@ class ContentHostEntity(BaseEntity):
         view = ContentHostTaskDetailsView(view.browser)
         view.progressbar.wait_for_result()
         return view.read()
+
+    def bulk_set_syspurpose(self, hosts, values):
+        """Set system purpose for multiple hosts"""
+        view = self.navigate_to(self, 'All')
+        view.search(' or '.join(hosts))
+        view.select_all.fill(True)
+        view.actions.fill('Manage System Purpose')
+        view = SyspurposeBulkActionView(view.browser)
+        view.fill(values)
+        self.browser.click(view.assign)
+        self.browser.click(view.confirm)
 
     def execute_module_stream_action(
         self,

--- a/airgun/views/contenthost.py
+++ b/airgun/views/contenthost.py
@@ -98,6 +98,7 @@ class ContentHostsView(BaseLoggedInView, SearchableViewMixin):
     register = Text(".//button[@ui-sref='content-hosts.register']")
     actions = ActionsDropdown(".//div[contains(@class, 'btn-group')]")
     dialog = ConfirmationDialog()
+    select_all = Checkbox(locator="//input[@ng-model='selection.allSelected']")
     table = SatTable(
         './/table',
         column_widgets={
@@ -328,6 +329,19 @@ class ContentHostTaskDetailsView(TaskDetailsView):
             and self.breadcrumb.locations[0] == 'Content Hosts'
             and len(self.breadcrumb.locations) > 2
         )
+
+
+class SyspurposeBulkActionView(BaseLoggedInView):
+    title = Text("//h4[contains(., 'Content Host System Purpose')]")
+    service_level = Select(locator=".//select[@ng-model='selectedServiceLevels']")
+    role = Select(locator=".//select[@ng-model='selectedRoles']")
+    usage_type = Select(locator=".//select[@ng-model='selectedUsages']")
+    assign = Text(".//span[text()='Assign']")
+    confirm = Text(".//button[text()='Assign']")
+
+    @property
+    def is_displayed(self):
+        return self.browser.wait_for_element(self.title, exception=False) is not None
 
 
 class ErrataDetailsView(BaseLoggedInView):


### PR DESCRIPTION
Airgun prerequisite for testing system purpose bulk actions, new feature in 6.9
Robottelo PR will come soon, successfully tested with:
```
    values = {
            'service_level': 'Standard',
            'usage_type': 'Production',
            'role': 'Red Hat Enterprise Linux Server'
        }
    with session:
        session.contenthost.bulk_set_syspurpose(hosts, values)
```