### PR TITLE
Fix CustomSearch widget used in ModuleStreamsDetailsView

### DIFF
--- a/airgun/views/modulestream.py
+++ b/airgun/views/modulestream.py
@@ -12,8 +12,7 @@ from airgun.widgets import Search
 
 
 class CustomSearch(Search):
-    search_field = TextInput(locator=".//input[@role='combobox']")
-    clear_button = Text(".//span[contains(@class,'fa-times')]")
+    search_field = TextInput(id='downshift-0-input')
     search_button = Button('Search')
 
 
@@ -51,9 +50,8 @@ class ModuleStreamsDetailsView(BaseLoggedInView):
 
     @property
     def is_displayed(self):
-        """The view is displayed when it's details ta exists"""
+        """Assume the view is displayed when its breadcrumb is visible"""
         breadcrumb_loaded = self.browser.wait_for_element(self.breadcrumb, exception=False)
-
         return breadcrumb_loaded and self.breadcrumb.locations[0] == 'Module Streams'
 
     @View.nested


### PR DESCRIPTION
The `CustomSearch` widget used in `ModuleStreamsDetailsView` was failing because the locator for the `search_field` sub-widget doesn't exist (anymore?). This PR fixes the issue by updating the locator to match on `id`. I've also removed the `clear_button` sub-widget, which doesn't exist on this particular page's search bar. Any calls to the `clear()` method should still work, because it falls back on clearing the text in `search_field` input field if `clear_button` isn't available. In `airgun/widgets.py`:
```
class Search(Widget):
[...]
    def clear(self):
        """Clears search field value and re-trigger search to remove all
        filters.
        """
        if self.clear_button.is_displayed:
            self.clear_button.click()
        else:
            self.browser.clear(self.search_field)
        if self.search_button.is_displayed:
            self.search_button.click()
```
