### PR TITLE
Fix Table widget on ModuleStreamsDetailsView.repositories

### DIFF
--- a/airgun/views/modulestream.py
+++ b/airgun/views/modulestream.py
@@ -1,3 +1,4 @@
+from widgetastic.widget import Table
 from widgetastic.widget import Text
 from widgetastic.widget import TextInput
 from widgetastic.widget import View
@@ -60,7 +61,7 @@ class ModuleStreamsDetailsView(BaseLoggedInView):
 
     @View.nested
     class repositories(SatTab):
-        table = SatTable(
+        table = Table(
             locator=".//table",
             column_widgets={
                 'Name': Text("./a"),


### PR DESCRIPTION
This PR fixes an issue with viewing the table on a module stream's Repositories tab. The table was implemented using `SatTable`, but as mentioned in the class definition, `SatTable` is deprecated in favor of widgetastic's `Table` class. Using this class instead fixes the issue.

Before:

```
# pytest -k test_positive_module_stream_details_search_in_repo tests/foreman/ui/test_modulestreams.py
[...]
collected 1 item

tests/foreman/ui/test_modulestreams.py F [100%]

=== FAILURES ===
[...]
        with session:
            session.organization.select(org_name=module_org.name)
            assert session.modulestream.search('name = duck')[0]['Name'].startswith('duck')
>           walrus_details = session.modulestream.read('walrus', '5.21')

tests/foreman/ui/test_modulestreams.py:66: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
venv/lib64/python3.9/site-packages/airgun/entities/modulestream.py:31: in read
    return view.read(widget_names=widget_names)
[...]
venv/lib64/python3.9/site-packages/widgetastic/browser.py:489: in is_displayed
    return self.move_to_element(locator, *args, **kwargs).is_displayed()
venv/lib64/python3.9/site-packages/widgetastic/utils.py:695: in wrap
    return method(*args, **kwargs)
venv/lib64/python3.9/site-packages/widgetastic/browser.py:522: in move_to_element
    move_to.perform()
[...]
>       raise exception_class(message, screen, stacktrace)
E       selenium.common.exceptions.ElementNotInteractableException: Message: element not interactable: [object HTMLTableRowElement] has no size and location
E         (Session info: chrome=89.0.4389.128)

venv/lib64/python3.9/site-packages/selenium/webdriver/remote/errorhandler.py:242: ElementNotInteractableException
[...]
``` 


After:

```
$ pytest -k test_positive_module_stream_details_search_in_repo tests/foreman/ui/test_modulestreams.py
[...]
collected 1 item

tests/foreman/ui/test_modulestreams.py . [100%]

=== 1 passed in 91.24s (0:01:31) ===
```