### PR TITLE
Fix logging if screenshot save failed

### DIFF
--- a/airgun/session.py
+++ b/airgun/session.py
@@ -306,7 +306,8 @@ class Session:
             f'{self.name}-screenshot-{now.strftime("%Y-%m-%d_%H_%M_%S")}.png',
         )
         LOGGER.debug('Saving screenshot %s', path)
-        self.browser.selenium.save_screenshot(path)
+        if not self.browser.selenium.save_screenshot(path):
+            LOGGER.error('Failed to save screenshot %s', path)
 
     @cached_property
     def activationkey(self):


### PR DESCRIPTION
Airgun's session context manager tries to capture a screenshot of the browser if an exception has been raised, and then log any exception that `take_screenshot()` itself might raise. But there are also cases in which `take_screenshot()` fails, returning `False` without raising an exception. In particular, the underlying selenium webdriver method `get_screenshot_as_file()` that ends up getting called will catch any exceptions from the OS while trying to save the screenshot to file: 

```
        try:
            with open(filename, 'wb') as f:
                f.write(png)
        except IOError:
            return False
```

I've added a check on the return value of `take_screenshot()`, and some error logging in case of failure.