### PR TITLE
Fix default http proxy name value

### DIFF
--- a/airgun/entities/repository.py
+++ b/airgun/entities/repository.py
@@ -1,3 +1,5 @@
+import re
+
 from wait_for import wait_for
 
 from airgun.entities.base import BaseEntity
@@ -19,13 +21,17 @@ class RepositoryEntity(BaseEntity):
         """Look up the default http proxy and return the string that a user would select for
         HTTP Proxy Policy when creating or updating a repository.
         """
-        proxy_name = SettingsEntity(self.browser).read(
+        proxy_setting = SettingsEntity(self.browser).read(
             property_name='name = content_default_http_proxy'
         )['table'][0]['Value']
 
         # The default text for no default http proxy varies between versions of Satellite
-        if proxy_name in ('Empty', 'no global default'):
+        if proxy_setting in ('Empty', 'no global default'):
             proxy_name = 'None'
+        else:
+            regex = re.compile(r'^(.*) \((.*)\)$')
+            match = regex.match(proxy_setting)
+            proxy_name = match.group(1) if match else 'None'
 
         return f'Global Default ({proxy_name})'
 


### PR DESCRIPTION
This PR fixes the behavior of `RepositoryEntity.global_default_http_proxy`. When a global default http proxy has been configured under `Administer > Settings > Content`, the setting is displayed as:

`proxy_name (proxy_url)`

and `RepositoryEntity.global_default_http_proxy` should return a string matching what the corresponding value will be in the `HTTP Proxy Policy` dropdown when creating a new custom repository:

`Global Default (proxy_name)`

Previously, the method was using the full setting value, like this:

`Global Default (proxy_name (proxy_url))`

Now it uses a regular expression to extract `proxy_name` from the setting and return the correct string. 

