### PR TITLE
Fix Infrastructure component locators for 6.10

### DIFF
--- a/airgun/views/computeprofile.py
+++ b/airgun/views/computeprofile.py
@@ -9,8 +9,8 @@ from airgun.widgets import ActionsDropdown
 
 
 class ComputeProfilesView(BaseLoggedInView, SearchableViewMixin):
-    title = Text("//h1[text()='Compute Profiles']")
-    new = Text("//a[contains(@href, '/compute_profiles/new')]")
+    title = Text('//*[(self::h1 or self::h5) and text()="Compute Profiles"]')
+    new = Text('//a[text()="Create Compute Profile"]')
     table = Table(
         './/table',
         column_widgets={

--- a/airgun/views/computeresource.py
+++ b/airgun/views/computeresource.py
@@ -24,8 +24,8 @@ from airgun.widgets import SatTable
 
 class ComputeResourcesView(BaseLoggedInView, SearchableViewMixin):
 
-    title = Text("//h1[text()='Compute Resources']")
-    new = Text("//a[contains(@href, '/compute_resources/new')]")
+    title = Text('//*[(self::h1 or self::h5) and text()="Compute Resources"]')
+    new = Text('//a[text()="Create Compute Resource"]')
     table = SatTable(
         './/table',
         column_widgets={

--- a/airgun/views/domain.py
+++ b/airgun/views/domain.py
@@ -15,8 +15,8 @@ from airgun.widgets import MultiSelect
 class DomainListView(BaseLoggedInView, SearchableViewMixin):
     """List of all domains."""
 
-    title = Text("//h1[text()='Domains']")
-    new = Text("//a[contains(@href, '/domains/new')]")
+    title = Text('//*[(self::h1 or self::h5) and text()="Domains"]')
+    new = Text('//a[text()="Create Domain"]')
     table = Table(
         './/table',
         column_widgets={

--- a/airgun/views/http_proxy.py
+++ b/airgun/views/http_proxy.py
@@ -11,7 +11,7 @@ from airgun.widgets import MultiSelect
 
 
 class HTTPProxyView(BaseLoggedInView, SearchableViewMixin):
-    title = Text('//h5[text()="HTTP Proxies"]')
+    title = Text('//*[(self::h1 or self::h5) and text()="HTTP Proxies"]')
     new = Text('//a[text()="New HTTP Proxy"]')
     table = Table(
         './/table',

--- a/airgun/views/http_proxy.py
+++ b/airgun/views/http_proxy.py
@@ -11,8 +11,8 @@ from airgun.widgets import MultiSelect
 
 
 class HTTPProxyView(BaseLoggedInView, SearchableViewMixin):
-    title = Text("//h1[text()='HTTP Proxies']")
-    new = Text("//a[contains(@href, 'http_proxies/new')]")
+    title = Text('//h5[text()="HTTP Proxies"]')
+    new = Text('//a[text()="New HTTP Proxy"]')
     table = Table(
         './/table',
         column_widgets={

--- a/airgun/views/subnet.py
+++ b/airgun/views/subnet.py
@@ -14,8 +14,8 @@ from airgun.widgets import RadioGroup
 
 
 class SubnetsView(BaseLoggedInView, SearchableViewMixin):
-    title = Text("//h1[text()='Subnets']")
-    new = Text("//a[contains(@href, '/subnets/new')]")
+    title = Text('//*[(self::h1 or self::h5) and text()="Subnets"]')
+    new = Text('//a[text()="Create Subnet"]')
     table = Table(
         './/table',
         column_widgets={


### PR DESCRIPTION
Some of locators for landing page of Satellite 6.10 components have changed because of PF4 change. This PR fixes the landing page locators for those pages.