### PR TITLE
Add support for configure_cloud_connector and sync_inventory_status

### DIFF
--- a/airgun/entities/cloud_inventory.py
+++ b/airgun/entities/cloud_inventory.py
@@ -21,58 +21,16 @@ class CloudInventoryEntity(BaseEntity):
         """Configure Cloud Connector"""
         view = self.navigate_to(self, 'All')
         view.cloud_connector.click()
-        wait_for(
-            lambda: view.cloud_connector_status.is_displayed is True,
-            handle_exception=True,
-            timeout=20,
-            delay=1,
-            logger=view.logger,
-        )
-        wait_for(
-            lambda: view.cloud_connector_status.is_displayed is False,
-            handle_exception=True,
-            timeout=180,
-            delay=1,
-            logger=view.logger,
-        )
 
     def sync_inventory_status(self):
         """Sync Inventory status"""
         view = self.navigate_to(self, 'All')
         view.sync_status.click()
-        wait_for(
-            lambda: view.sync_status_disabled.is_displayed is True,
-            handle_exception=True,
-            timeout=20,
-            delay=1,
-            logger=view.logger,
-        )
-        wait_for(
-            lambda: view.sync_status.is_displayed is True,
-            handle_exception=True,
-            timeout=20,
-            delay=1,
-            logger=view.logger,
-        )
 
     def generate_report(self, entity_name):
         view = self.navigate_to(self, 'All')
         view.inventory_list.toggle(entity_name)
         view.browser.click(view.inventory_list.generating.restart, ignore_ajax=True)
-        wait_for(
-            lambda: view.inventory_list.status == 'generating',
-            handle_exception=True,
-            timeout=20,
-            delay=1,
-            logger=view.logger,
-        )
-        wait_for(
-            lambda: view.inventory_list.status == 'idle',
-            handle_exception=True,
-            timeout=180,
-            delay=1,
-            logger=view.logger,
-        )
 
     def download_report(self, entity_name):
         view = self.navigate_to(self, 'All')

--- a/airgun/entities/cloud_inventory.py
+++ b/airgun/entities/cloud_inventory.py
@@ -31,7 +31,7 @@ class CloudInventoryEntity(BaseEntity):
         wait_for(
             lambda: view.cloud_connector_status.is_displayed is False,
             handle_exception=True,
-            timeout=100,
+            timeout=180,
             delay=1,
             logger=view.logger,
         )

--- a/airgun/entities/cloud_inventory.py
+++ b/airgun/entities/cloud_inventory.py
@@ -1,5 +1,3 @@
-from time import sleep
-
 from wait_for import wait_for
 
 from airgun.entities.base import BaseEntity
@@ -19,27 +17,55 @@ class CloudInventoryEntity(BaseEntity):
             result.update(view.inventory_list.read())
         return result
 
+    def configure_cloud_connector(self):
+        """Configure Cloud Connector"""
+        view = self.navigate_to(self, 'All')
+        view.cloud_connector.click()
+        wait_for(
+            lambda: view.cloud_connector_status.is_displayed is True,
+            handle_exception=True,
+            timeout=20,
+            delay=1,
+            logger=view.logger,
+        )
+        wait_for(
+            lambda: view.cloud_connector_status.is_displayed is False,
+            handle_exception=True,
+            timeout=100,
+            delay=1,
+            logger=view.logger,
+        )
+
+    def sync_inventory_status(self):
+        """Sync Inventory status"""
+        view = self.navigate_to(self, 'All')
+        view.sync_status.click()
+        wait_for(
+            lambda: view.sync_status_disabled.is_displayed is True,
+            handle_exception=True,
+            timeout=20,
+            delay=1,
+            logger=view.logger,
+        )
+        wait_for(
+            lambda: view.sync_status.is_displayed is True,
+            handle_exception=True,
+            timeout=20,
+            delay=1,
+            logger=view.logger,
+        )
+
     def generate_report(self, entity_name):
         view = self.navigate_to(self, 'All')
         view.inventory_list.toggle(entity_name)
         view.browser.click(view.inventory_list.generating.restart, ignore_ajax=True)
-        # Fix for status icons not changing state immediately after restart
-        """
-        here's why we used sleep here:
-        When we click on restart button then the process of generating and uploading
-        a report gets started. There are two icons one for generating tab and other
-        for uploading tab. They indicate users whether process of uploading or
-        generating report is finished or in progress. So we were using those icon
-        to wait till reports are generated and uploaded based on entity_item.status
-        can result in uploading, generating and idle state. But the issue is that
-        those icon don't change their state immediately after we start report
-        generation process(clicking on restart button), which makes automation
-        think that the process is finished(idle), which is not correct. That's
-        why we have added sleep to wait for icons to change their state(generating
-        or uploading). Also the process of generating/uploading reports takes some
-        time either way, so I thought we can wait for few seconds.
-        """
-        sleep(5)
+        wait_for(
+            lambda: view.inventory_list.status == 'generating',
+            handle_exception=True,
+            timeout=20,
+            delay=1,
+            logger=view.logger,
+        )
         wait_for(
             lambda: view.inventory_list.status == 'idle',
             handle_exception=True,
@@ -52,8 +78,6 @@ class CloudInventoryEntity(BaseEntity):
         view = self.navigate_to(self, 'All')
         view.inventory_list.toggle(entity_name)
         view.browser.click(view.inventory_list.uploading.download_report, ignore_ajax=True)
-        # Fix for status icons not changing state immediately after restart
-        sleep(5)
         wait_for(
             lambda: view.inventory_list.status == 'idle',
             handle_exception=True,

--- a/airgun/views/cloud_inventory.py
+++ b/airgun/views/cloud_inventory.py
@@ -115,11 +115,7 @@ class CloudInventoryListView(BaseLoggedInView):
     obfuscate_ips = Switch('.//label[@for="rh-cloud-switcher-obfuscate_inventory_ips"]')
     exclude_packages = Switch('.//label[@for="rh-cloud-switcher-exclude_installed_packages"]')
     cloud_connector = Pf4Button(locator='//button[text()="Configure Cloud Connector"]')
-    cloud_connector_status = Pf4Button(locator='//button[text()="Cloud Connector is in progress"]')
     sync_status = Pf4Button(locator='//button[text()=" Sync inventory status"]')
-    sync_status_disabled = Pf4Button(
-        locator='//button[text()=" Sync inventory status" and @aria-disabled="true"]'
-    )
     inventory_list = View.nested(InventoryItemsView)
 
     @property

--- a/airgun/views/cloud_inventory.py
+++ b/airgun/views/cloud_inventory.py
@@ -116,9 +116,9 @@ class CloudInventoryListView(BaseLoggedInView):
     exclude_packages = Switch('.//label[@for="rh-cloud-switcher-exclude_installed_packages"]')
     cloud_connector = Pf4Button(locator='//button[text()="Configure Cloud Connector"]')
     cloud_connector_status = Pf4Button(locator='//button[text()="Cloud Connector is in progress"]')
-    sync_status = Pf4Button(locator='//button[text()="Sync inventory status"]')
+    sync_status = Pf4Button(locator='//button[text()=" Sync inventory status"]')
     sync_status_disabled = Pf4Button(
-        locator='//button[text()="Sync inventory status" and @aria-disabled="true"]'
+        locator='//button[text()=" Sync inventory status" and @aria-disabled="true"]'
     )
     inventory_list = View.nested(InventoryItemsView)
 

--- a/airgun/views/cloud_inventory.py
+++ b/airgun/views/cloud_inventory.py
@@ -5,6 +5,7 @@ from widgetastic.widget import Text
 from widgetastic.widget import View
 from widgetastic_patternfly import Button
 from widgetastic_patternfly import Tab
+from widgetastic_patternfly4.button import Button as Pf4Button
 from widgetastic_patternfly4.switch import Switch
 
 from airgun.exceptions import ReadOnlyWidgetError
@@ -113,6 +114,12 @@ class CloudInventoryListView(BaseLoggedInView):
     )
     obfuscate_ips = Switch('.//label[@for="rh-cloud-switcher-obfuscate_inventory_ips"]')
     exclude_packages = Switch('.//label[@for="rh-cloud-switcher-exclude_installed_packages"]')
+    cloud_connector = Pf4Button(locator='//button[text()="Configure Cloud Connector"]')
+    cloud_connector_status = Pf4Button(locator='//button[text()="Cloud Connector is in progress"]')
+    sync_status = Pf4Button(locator='//button[text()="Sync inventory status"]')
+    sync_status_disabled = Pf4Button(
+        locator='//button[text()="Sync inventory status" and @aria-disabled="true"]'
+    )
     inventory_list = View.nested(InventoryItemsView)
 
     @property


### PR DESCRIPTION
This PR adds support for `configure_cloud_connector`, `sync_inventory_status` and tries to address sleep issue #578 