### PR TITLE
Fixes for some UI CR VMware tests

### DIFF
--- a/airgun/entities/computeresource.py
+++ b/airgun/entities/computeresource.py
@@ -132,7 +132,8 @@ class ComputeResourceEntity(BaseEntity):
         :return: The Compute resource images table rows values.
         """
         view = self.navigate_to(self, 'Detail', entity_name=entity_name)
-        return view.images.search(value)
+        view.images.filterbox.fill(value)
+        return view.images.table.read()
 
     def read_image(self, entity_name, image_name, widget_names=None):
         """Read from compute resource image edit view.
@@ -164,7 +165,7 @@ class ComputeResourceEntity(BaseEntity):
         :param str image_name: The existing compute resource image name to delete.
         """
         view = self.navigate_to(self, 'Detail', entity_name=entity_name)
-        view.images.search(image_name)
+        view.images.filterbox.fill(image_name)
         view.images.table.row(name=image_name)['Actions'].widget.fill('Destroy')
         self.browser.handle_alert()
         self.browser.plugin.ensure_page_safe()
@@ -309,5 +310,5 @@ class ComputeResourceImageEdit(ComputeResourceImageProvider):
 
     def step(self, *args, **kwargs):
         image_name = kwargs.get('image_name')
-        self.parent.images.search(image_name)
+        self.parent.images.filterbox.fill(image_name)
         self.parent.images.table.row(name=image_name)['Actions'].widget.fill('Edit')

--- a/airgun/views/computeresource.py
+++ b/airgun/views/computeresource.py
@@ -187,11 +187,14 @@ class ResourceProviderDetailView(BaseLoggedInView):
     @View.nested
     class compute_resource(SatTab):
         TAB_NAME = 'Compute Resource'
+        ROOT = ".//div[@id='primary']"
+
         table = SatTable('.//table')
 
     @View.nested
     class virtual_machines(SatTab, SearchableViewMixin):
         TAB_NAME = 'Virtual Machines'
+        ROOT = ".//div[@id='vms']"
 
         actions = ActionsDropdown("//div[contains(@class, 'btn-group')]")
         table = Table(
@@ -206,6 +209,8 @@ class ResourceProviderDetailView(BaseLoggedInView):
     @View.nested
     class compute_profiles(SatTab):
         TAB_NAME = 'Compute profiles'
+        ROOT = ".//div[@id='compute_profiles']"
+
         table = SatTable(
             './/table',
             column_widgets={
@@ -215,6 +220,9 @@ class ResourceProviderDetailView(BaseLoggedInView):
 
     @View.nested
     class images(SatTab, SearchableViewMixin):
+        TAB_NAME = 'Images'
+        ROOT = ".//div[@id='images']"
+
         table = Table(
             './/table',
             column_widgets={

--- a/airgun/views/computeresource.py
+++ b/airgun/views/computeresource.py
@@ -219,10 +219,13 @@ class ResourceProviderDetailView(BaseLoggedInView):
         )
 
     @View.nested
-    class images(SatTab, SearchableViewMixin):
+    class images(SatTab):
         TAB_NAME = 'Images'
         ROOT = ".//div[@id='images']"
 
+        filterbox = TextInput(
+            locator=(".//input[contains(@placeholder, 'Filter')]")
+        )
         table = Table(
             './/table',
             column_widgets={

--- a/airgun/widgets.py
+++ b/airgun/widgets.py
@@ -629,7 +629,7 @@ class ActionDropdownWithCheckbox(ActionsDropdown):
 class Search(Widget):
     """Searchbar for table filtering"""
 
-    ROOT = '//div[@id="search-bar" or contains(@class, "toolbar-pf-filter")]'
+    ROOT = '//div[@id="search-bar" or contains(@class, "toolbar-pf-filter") or contains(@class, "dataTables_filter")]'
     search_field = TextInput(
         locator=(
             ".//input[@id='search' or contains(@placeholder, 'Filter') or "


### PR DESCRIPTION
This PR is a result of my investigation into the failed tests of `test_computeresource_vmware.py`. I managed to fix most of it (but not all). The test results:
```
pytest tests/foreman/ui/test_computeresource_vmware.py 
============================= test session starts ==============================
platform linux -- Python 3.9.5, pytest-6.2.3, py-1.10.0, pluggy-0.13.1
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/petrpochop/Work/robottelo, configfile: pyproject.toml
plugins: forked-1.3.0, xdist-2.2.1, services-2.2.1, reportportal-5.0.8, ibutsu-1.14.1, cov-2.11.1, mock-3.6.0
collected 6 items / 6 deselected                                               

tests/foreman/ui/test_computeresource_vmware.py .....F                   [100%]
=========================== short test summary info ============================
FAILED tests/foreman/ui/test_computeresource_vmware.py::test_positive_access_vmware_with_custom_profile
====== 1 failed, 5 passed, 6 deselected, 5 warnings in 727.32s (0:12:07) =======
```
Before only 1 test passed.
