### PR TITLE
Fix for a report template test

### DIFF
--- a/airgun/entities/report_template.py
+++ b/airgun/entities/report_template.py
@@ -86,7 +86,7 @@ class ReportTemplateEntity(BaseEntity):
         wait_for(
             lambda: view.generated.is_displayed,
             timeout=300,
-            delay=1
+            delay=1,
         )
         view.flash.assert_no_error()
         return self.browser.save_downloaded_file()

--- a/airgun/entities/report_template.py
+++ b/airgun/entities/report_template.py
@@ -84,9 +84,9 @@ class ReportTemplateEntity(BaseEntity):
         view.submit.click()
         # wait for the report to be generated
         wait_for(
-            lambda: "has been completed." in view.generating.text,
+            lambda: view.generated.is_displayed,
             timeout=300,
-            delay=1,
+            delay=1
         )
         view.flash.assert_no_error()
         return self.browser.save_downloaded_file()

--- a/airgun/views/report_template.py
+++ b/airgun/views/report_template.py
@@ -104,4 +104,3 @@ class ReportTemplateGenerateView(BaseLoggedInView):
             and self.breadcrumb.locations[0] == 'Report Templates'
             and self.breadcrumb.read() == 'Generate a Report'
         )
-        

--- a/airgun/views/report_template.py
+++ b/airgun/views/report_template.py
@@ -94,7 +94,7 @@ class ReportTemplateGenerateView(BaseLoggedInView):
     hosts_filter = TextInput(locator='//input[contains(@class,"search-input")]')
     generate_at = TextInput(id='report_template_report_generate_at')
     submit = Text('//input[@name="commit"]')
-    generating = Text('//div[@data-original-title="Generating a report"]/span[2]')
+    generated = Text('//div[contains(@class, "alert-success")]')
 
     @property
     def is_displayed(self):
@@ -104,3 +104,4 @@ class ReportTemplateGenerateView(BaseLoggedInView):
             and self.breadcrumb.locations[0] == 'Report Templates'
             and self.breadcrumb.read() == 'Generate a Report'
         )
+        


### PR DESCRIPTION
A test that tries to generate a report and download it couldn't pass because of the way `generating` was located. I found a workaround for that and because of the different nature of the element I used, I renamed it to `generated`.

```
pytest tests/foreman/ui/test_reporttemplates.py::test_positive_generate_registered_hosts_report
============================= test session starts ==============================
collected 1 item                                                               

tests/foreman/ui/test_reporttemplates.py .                               [100%]
================== 1 passed, 3 warnings in 307.62s (0:05:07) ===================
```