### PR TITLE
updated the global registration form w.r.t PF4

### DIFF
--- a/airgun/entities/host.py
+++ b/airgun/entities/host.py
@@ -47,7 +47,6 @@ class HostEntity(BaseEntity):
     def get_register_command(self, values):
         """Get curl command generated on Register Host page"""
         view = self.navigate_to(self, 'Register')
-        view.breadcrumb.wait_displayed()
         view.fill(values)
         self.browser.click(view.generate_command)
         self.browser.plugin.ensure_page_safe()

--- a/airgun/views/common.py
+++ b/airgun/views/common.py
@@ -11,6 +11,7 @@ from widgetastic_patternfly import BreadCrumb
 from widgetastic_patternfly import Button
 from widgetastic_patternfly import Tab
 from widgetastic_patternfly import TabWithDropdown
+from widgetastic_patternfly4.ouia import Dropdown
 
 from airgun.utils import get_widget_by_name
 from airgun.utils import normalize_dict_values
@@ -28,7 +29,6 @@ from airgun.widgets import SatTable
 from airgun.widgets import SatVerticalNavigation
 from airgun.widgets import Search
 from airgun.widgets import ValidationErrors
-from widgetastic_patternfly4.ouia import Dropdown
 
 
 class BaseLoggedInView(View):

--- a/airgun/views/host.py
+++ b/airgun/views/host.py
@@ -14,7 +14,7 @@ from widgetastic.widget import View
 from widgetastic.widget import Widget
 from widgetastic_patternfly import BreadCrumb
 from widgetastic_patternfly import Button
-from widgetastic_patternfly4.ouia import Button as pf4Button
+from widgetastic_patternfly4.ouia import Button as PF4Button
 from widgetastic_patternfly4.ouia import FormSelect
 from widgetastic_patternfly4.tabs import Tab
 
@@ -198,7 +198,7 @@ class HostsView(BaseLoggedInView, SearchableViewMixin):
     title = Text("//h1[text()='Hosts']")
     export = Text(".//a[contains(@class, 'btn')][contains(@href, 'hosts.csv')]")
     new = Text("//a[contains(text(),'Create Host')]")
-    register = pf4Button('OUIA-Generated-Button-secondary-2')
+    register = PF4Button('OUIA-Generated-Button-secondary-2')
     select_all = Checkbox(locator="//input[@id='check_all']")
     table = SatTable(
         './/table',
@@ -471,8 +471,8 @@ class HostCreateView(BaseLoggedInView):
 
 
 class HostRegisterView(BaseLoggedInView):
-    generate_command = pf4Button('OUIA-Generated-Button-primary-1')
-    cancel = pf4Button('OUIA-Generated-Button-link-1')
+    generate_command = PF4Button('OUIA-Generated-Button-primary-1')
+    cancel = PF4Button('OUIA-Generated-Button-link-1')
     registration_command = TextInput(id='text-input-3')
 
     @View.nested
@@ -518,10 +518,10 @@ class HostRegisterView(BaseLoggedInView):
         return self.browser.wait_for_element(self.general.operating_system, exception=False)
 
     def before_fill(self, values):
-        """Fill some of the parameters tab widgets with values.
+        """Fill some of the parameters in the widgets with values.
 
         Args:
-            values: A dictionary of ``widget_name: value_to_fill``.
+            values: A dictionary of `widget_name: value_to_fill`.
 
         Note:
             Some of the fields are disabled for few seconds and get enabled based

--- a/airgun/widgets.py
+++ b/airgun/widgets.py
@@ -2248,8 +2248,7 @@ class BaseMultiSelect(BaseSelect, Dropdown):
     https://www.patternfly.org/v4/documentation/react/components/select#multiple
     """
 
-    BUTTON_LOCATOR = './/button'
-    MENU_BUTTON_LOCATOR = './/button[@aria-label="Options menu"]'
+    BUTTON_LOCATOR = './/button[@aria-label="Options menu"]'
     OUIA_COMPONENT_TYPE = "PF4/Select"
 
     def item_select(self, items, close=True):
@@ -2261,14 +2260,15 @@ class BaseMultiSelect(BaseSelect, Dropdown):
         """
         if not isinstance(items, (list, tuple, set)):
             items = [items]
-
+        if isinstance(items, str):
+            items = items.split(',')
         try:
             for item in items:
                 element = self.item_element(item, close=False)
                 if not element.find_element_by_xpath("./..").get_attribute('aria-selected'):
                     element.click()
         finally:
-            self.browser.click(self.MENU_BUTTON_LOCATOR)
+            self.browser.click(self.BUTTON_LOCATOR)
 
     def fill(self, items):
         """Fills all the items.

--- a/airgun/widgets.py
+++ b/airgun/widgets.py
@@ -21,7 +21,9 @@ from widgetastic_patternfly import FlashMessage
 from widgetastic_patternfly import FlashMessages
 from widgetastic_patternfly import Kebab
 from widgetastic_patternfly import VerticalNavigation
+from widgetastic_patternfly4.ouia import BaseSelect
 from widgetastic_patternfly4.ouia import ContextSelector as OUIAContextSelector
+from widgetastic_patternfly4.ouia import Dropdown
 
 from airgun.exceptions import DisabledWidgetError
 from airgun.exceptions import ReadOnlyWidgetError
@@ -2238,3 +2240,43 @@ class Accordion(View, ClickableMixin):
 
     def toggle(self, value):
         self.browser.click(self.ITEM.format(value))
+
+
+class BaseMultiSelect(BaseSelect, Dropdown):
+    """Represents the Patternfly Multi Select.
+
+    https://www.patternfly.org/v4/documentation/react/components/select#multiple
+    """
+
+    BUTTON_LOCATOR = './/button'
+    MENU_BUTTON_LOCATOR = './/button[@aria-label="Options menu"]'
+    OUIA_COMPONENT_TYPE = "PF4/Select"
+
+    def item_select(self, items, close=True):
+        """Opens the Dropdown and selects the desired items.
+
+        Args:
+            items: Items to be selected
+            close: Close the dropdown when finished
+        """
+        if not isinstance(items, (list, tuple, set)):
+            items = [items]
+
+        try:
+            for item in items:
+                element = self.item_element(item, close=False)
+                if not element.find_element_by_xpath("./..").get_attribute('aria-selected'):
+                    element.click()
+        finally:
+            self.browser.click(self.MENU_BUTTON_LOCATOR)
+
+    def fill(self, items):
+        """Fills all the items.
+
+        Args:
+            items: list containing what items to be selected
+        """
+        try:
+            self.item_select(items, close=False)
+        finally:
+            self.close()


### PR DESCRIPTION
#### PR Description 
This is pr updates the global registration form that is used for registering the Content Host. Currently the form uses the Patternfly4 UI widgets. Added some custom widgets based on the requirement for Satellite. Once these changes are approved we can update the WT.PF4 repos with same changes in case of need. I'm trying to limit the scope here for now with this PR. 

####  Test Result
```
Testing started at 7:12 PM ...
/home/okhatavk/okhatavk/Satellite/robottelo/env/bin/python /home/okhatavk/Downloads/pycharm-community-2018.1.4/helpers/pycharm/_jb_pytest_runner.py --path /home/okhatavk/okhatavk/Satellite/robottelo/tests/foreman/ui/test_host.py -- -k test_positive_global_registration_form
Launching py.test with arguments -k test_positive_global_registration_form /home/okhatavk/okhatavk/Satellite/robottelo/tests/foreman/ui/test_host.py in /home/okhatavk/Satellite/robottelo

============================= test session starts ==============================
platform linux -- Python 3.8.6, pytest-6.2.3, py-1.10.0, pluggy-0.13.1
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/okhatavk/okhatavk/Satellite/robottelo, configfile: pyproject.toml
plugins: services-2.2.1, cov-2.10.1, xdist-2.2.1, reportportal-5.0.8, mock-3.5.1, forked-1.3.0, ibutsu-1.14.1, picked-0.4.6collected 37 items / 36 deselected / 1 selected

../../okhatavk/Satellite/robottelo/tests/foreman/ui/test_host.py 2021-07-16 19:12:48 - robottelo.collection - INFO - Processing test items to add testimony token markers
[INFO 210716 19:12:48] Using username and password authentication
[INFO 210716 19:12:58] Using username and password authentication
.       [100%]

=============================== warnings summary ===============================    
```  