### PR TITLE
Changes needed to fix templatesync tests

### DIFF
--- a/airgun/entities/provisioning_template.py
+++ b/airgun/entities/provisioning_template.py
@@ -54,6 +54,14 @@ class ProvisioningTemplateEntity(BaseEntity):
         view.flash.assert_no_error()
         view.flash.dismiss()
 
+    def is_locked(self, entity_name):
+        """Check if provisioning template is locked for editing"""
+        view = self.navigate_to(self, 'All')
+        view.search(entity_name)
+        return "This template is locked for editing." in view.table.row(name=entity_name)[
+            'Locked'
+        ].widget.browser.element('.').get_property('innerHTML')
+
     def update(self, entity_name, values):
         """Update provisioning template"""
         view = self.navigate_to(self, 'Edit', entity_name=entity_name)

--- a/airgun/views/provisioning_template.py
+++ b/airgun/views/provisioning_template.py
@@ -35,6 +35,7 @@ class ProvisioningTemplatesView(BaseLoggedInView, SearchableViewMixin):
         './/table',
         column_widgets={
             'Name': Text('./a'),
+            'Locked': Text('.'),
             'Actions': ActionsDropdown("./div[contains(@class, 'btn-group')]"),
         },
     )

--- a/airgun/views/sync_templates.py
+++ b/airgun/views/sync_templates.py
@@ -33,24 +33,24 @@ class SyncTemplatesView(BaseLoggedInView):
 
     @template.register('Import')
     class ImportTemplates(View):
-        associate = Select(name='associate')
-        branch = TextInput(name='branch')
-        dirname = TextInput(name='dirname')
-        filter = TextInput(name='filter')
-        force_import = Checkbox(name='force')
-        lock = Checkbox(name='lock')
-        negate = Checkbox(name='negate')
-        prefix = TextInput(name='prefix')
-        repo = TextInput(name='repo')
+        associate = Select(name='import.associate')
+        branch = TextInput(name='import.branch')
+        dirname = TextInput(name='import.dirname')
+        filter = TextInput(name='import.filter')
+        force_import = Checkbox(name='import.force')
+        lock = Select(name='import.lock')
+        negate = Checkbox(name='import.negate')
+        prefix = TextInput(name='import.prefix')
+        repo = TextInput(name='import.repo')
 
     @template.register('Export')
     class ExportTemplates(View):
-        branch = TextInput(name='branch')
-        dirname = TextInput(name='dirname')
-        filter = TextInput(name='filter')
-        metadata_export_mode = Select(name='metadata_export_mode')
-        negate = Checkbox(name='negate')
-        repo = TextInput(name='repo')
+        branch = TextInput(name='export.branch')
+        dirname = TextInput(name='export.dirname')
+        filter = TextInput(name='export.filter')
+        metadata_export_mode = Select(name='export.metadata_export_mode')
+        negate = Checkbox(name='export.negate')
+        repo = TextInput(name='export.repo')
 
 
 class TemplatesReportView(BaseLoggedInView):


### PR DESCRIPTION
`tests/foreman/ui/test_templatesync.py::test_positive_import_templates` now passes after https://github.com/SatelliteQE/robottelo/pull/8777 
`tests/foreman/ui/test_templatesync.py::test_positive_export_templates` unfortunately doesn't on 6.10 due to an automation-unrelated bug (but passes on 6.9)