### PR TITLE
Added flash data cleanup before logout

### DIFF
--- a/airgun/entities/login.py
+++ b/airgun/entities/login.py
@@ -13,9 +13,9 @@ class LoginEntity(BaseEntity):
 
     def logout(self):
         view = BaseLoggedInView(self.browser)
-        view.select_logout()
         view.flash.assert_no_error()
         view.flash.dismiss()
+        view.select_logout()
         view = LoginView(self.browser)
         return view.read()
 

--- a/airgun/views/login.py
+++ b/airgun/views/login.py
@@ -7,7 +7,7 @@ from widgetastic.widget import View
 class LoginView(View, ClickableMixin):
     username = TextInput(id="login_login")
     password = TextInput(id="login_password")
-    login_text = Text('//p[@id="login_text"]')
+    login_text = Text('//*[@id="login-footer-text"]')
     logo = Text('//img[@alt="logo"]')
     submit = Text('//button[@type="submit"]')
 


### PR DESCRIPTION
There is a cache cleanup problem observed with logout due to the recent pattern fly update, Earlier the cache cleanup didn't impact if we ran it after logout, but now cache cleanup is pre-requirement for logout, if we do not use it then logout will not work.

In this PR, I have added two fixes.

1. flash data cleanup before logout
2. Updated the x-path of login_text

**Test Result:**

```
pytest tests/foreman/ui/test_settings.py::test_positive_update_login_page_footer_text_with_long_string
=============================================================================================== test session starts ===============================================================================================
platform linux -- Python 3.8.0, pytest-6.2.4, py-1.10.0, pluggy-0.13.1
collected 1 item                                                                                                                                                                                                  

tests/foreman/ui/test_settings.py .                                                                                                                               
.....................
....................
==================================================================================== 1 passed, 11 warnings in 74.08s (0:01:14) ==================================================================================
```