### PR TITLE
Remove force puppet attribute

### DIFF
--- a/airgun/views/common.py
+++ b/airgun/views/common.py
@@ -11,6 +11,7 @@ from widgetastic_patternfly import BreadCrumb
 from widgetastic_patternfly import Button
 from widgetastic_patternfly import Tab
 from widgetastic_patternfly import TabWithDropdown
+from widgetastic_patternfly4.ouia import Dropdown
 
 from airgun.utils import get_widget_by_name
 from airgun.utils import normalize_dict_values
@@ -28,7 +29,6 @@ from airgun.widgets import SatTable
 from airgun.widgets import SatVerticalNavigation
 from airgun.widgets import Search
 from airgun.widgets import ValidationErrors
-from widgetastic_patternfly4.ouia import Dropdown
 
 
 class BaseLoggedInView(View):

--- a/airgun/views/computeresource.py
+++ b/airgun/views/computeresource.py
@@ -223,9 +223,7 @@ class ResourceProviderDetailView(BaseLoggedInView):
         TAB_NAME = 'Images'
         ROOT = ".//div[@id='images']"
 
-        filterbox = TextInput(
-            locator=(".//input[contains(@placeholder, 'Filter')]")
-        )
+        filterbox = TextInput(locator=(".//input[contains(@placeholder, 'Filter')]"))
         table = Table(
             './/table',
             column_widgets={

--- a/airgun/views/contentview.py
+++ b/airgun/views/contentview.py
@@ -117,7 +117,6 @@ class ContentViewEditView(BaseLoggedInView):
         label = ReadOnlyEntry(name='Label')
         description = EditableEntry(name='Description')
         composite = ReadOnlyEntry(name='Composite?')
-        force_puppet = EditableEntryCheckbox(name='Force Puppet Environment')
         solve_dependencies = EditableEntryCheckbox(name='Solve Dependencies')
 
     @View.nested


### PR DESCRIPTION
- remove force puppet
- `pre-commit run --all-files` fixes, import reordered and filterbox as one-liner
why we do not run pre commit  by default ?
@latran - Import-only option is missing, but I think if there is no test no need to implement it

