### PR TITLE
updated the usergroup create button locator

### DIFF
--- a/airgun/entities/usergroup.py
+++ b/airgun/entities/usergroup.py
@@ -1,4 +1,5 @@
 from navmazing import NavigateToSibling
+from widgetastic.exceptions import NoSuchElementException
 
 from airgun.entities.base import BaseEntity
 from airgun.navigation import NavigateStep
@@ -72,7 +73,10 @@ class AddNewUserGroup(NavigateStep):
     prerequisite = NavigateToSibling('All')
 
     def step(self, *args, **kwargs):
-        self.parent.new.click()
+        try:
+            self.parent.new.click()
+        except NoSuchElementException:
+            self.parent.new_on_blank_page.click()
 
 
 @navigator.register(UserGroupEntity, 'Edit')

--- a/airgun/views/usergroup.py
+++ b/airgun/views/usergroup.py
@@ -4,6 +4,7 @@ from widgetastic.widget import Text
 from widgetastic.widget import TextInput
 from widgetastic.widget import View
 from widgetastic_patternfly import BreadCrumb
+from widgetastic_patternfly4 import Button as P4Button
 
 from airgun.views.common import BaseLoggedInView
 from airgun.views.common import SatTab
@@ -14,6 +15,7 @@ from airgun.widgets import MultiSelect
 
 class UserGroupsView(BaseLoggedInView, SearchableViewMixin):
     title = Text("//h1[text()='User Groups']")
+    new_on_blank_page = P4Button('Create User group')
     new = Text("//a[contains(@href, '/usergroups/new')]")
     table = Table(
         './/table',


### PR DESCRIPTION
Currently the create new button exist at two location 
1. On blank page when there is no usergroups exists 
2. On all page when usergroups are previously exists 

Both places are containing the different locator's hence adding small path to fix this.   