### PR TITLE
fixing the host-group create button locator mix-up

### DIFF
--- a/airgun/entities/hostgroup.py
+++ b/airgun/entities/hostgroup.py
@@ -1,4 +1,5 @@
 from navmazing import NavigateToSibling
+from widgetastic.exceptions import NoSuchElementException
 
 from airgun.entities.base import BaseEntity
 from airgun.navigation import NavigateStep
@@ -71,7 +72,10 @@ class AddNewHostGroup(NavigateStep):
     prerequisite = NavigateToSibling('All')
 
     def step(self, *args, **kwargs):
-        self.parent.new.click()
+        try:
+            self.parent.new.click()
+        except NoSuchElementException:
+            self.parent.new_on_blank_page.click()
 
 
 @navigator.register(HostGroupEntity, 'Edit')

--- a/airgun/views/hostgroup.py
+++ b/airgun/views/hostgroup.py
@@ -4,6 +4,7 @@ from widgetastic.widget import Text
 from widgetastic.widget import TextInput
 from widgetastic.widget import View
 from widgetastic_patternfly import BreadCrumb
+from widgetastic_patternfly4 import Button as PF4Button
 
 from airgun.views.common import BaseLoggedInView
 from airgun.views.common import SatTab
@@ -19,6 +20,7 @@ from airgun.widgets import RadioGroup
 class HostGroupsView(BaseLoggedInView, SearchableViewMixin):
     title = Text("//h1[contains(., 'Host Group Configuration') or text()='Host Groups']")
     new = Text("//a[contains(@href, '/hostgroups/new')]")
+    new_on_blank_page = PF4Button('Create Host Group')
     table = Table(
         './/table',
         column_widgets={


### PR DESCRIPTION
#### PR Description 
Currently Satellite 6.10, some of the entity create button has changed to PF4 elements causing failures in tests which has blank All view 

```
    raise NoSuchElementException(
E   selenium.common.exceptions.NoSuchElementException: Message: Could not find an element Locator(by='xpath', locator="//a[contains(@href, '/hostgroups/new')]")   
```

#### Test Result

```
============================= test session starts ==============================
platform linux -- Python 3.8.6, pytest-6.2.3, py-1.10.0, pluggy-0.13.1
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/okhatavk/okhatavk/Satellite/robottelo, configfile: pyproject.toml
plugins: services-2.2.1, cov-2.10.1, xdist-2.2.1, reportportal-5.0.8, mock-3.5.1, forked-1.3.0, ibutsu-1.14.1, picked-0.4.6collected 71 items / 70 deselected / 1 selected

../../okhatavk/Satellite/robottelo/tests/foreman/ui/test_ldap_authentication.py  [100%]

=============================== warnings summary **===============================** 
```