### PR TITLE
Add REX support to chost and errata tests

### DIFF
--- a/airgun/entities/contenthost.py
+++ b/airgun/entities/contenthost.py
@@ -40,8 +40,12 @@ class ContentHostEntity(BaseEntity):
         view = self.navigate_to(self, 'Edit', entity_name=entity_name)
         return view.read(widget_names=widget_names)
 
-    def execute_package_action(self, entity_name, action_type, value):
-        """Execute remote package action on a content host
+    def execute_package_action(self, entity_name, action_type, value, installed_via=None):
+        """Execute remote package action on a content host.
+
+        The installation method is not set here, but the path changes according to the method used.
+        For katello-agent, the Content Hosts' Task tab displays the progress. If REX is used,
+        the Job Invocation view displays the progress. In 6.10, REX became the default method.
 
         :param entity_name: content host name to remotely execute package
             action on
@@ -51,14 +55,20 @@ class ContentHostEntity(BaseEntity):
         :param value: Package or package group group name to remotely
             install/upgrade/remove (depending on `action_type`)
 
+        :param installed_via: what installation method was used
+
         :return: Returns a dict containing task status details
         """
         view = self.navigate_to(self, 'Edit', entity_name=entity_name)
         view.packages_actions.action_type.fill(action_type)
         view.packages_actions.name.fill(value)
         view.packages_actions.perform.click()
-        view = ContentHostTaskDetailsView(view.browser)
-        view.progressbar.wait_for_result()
+        if installed_via == 'katello':
+            view = ContentHostTaskDetailsView(view.browser)
+            view.progressbar.wait_for_result()
+        else:
+            view = JobInvocationStatusView(view.browser)
+            view.wait_for_result()
         return view.read()
 
     def bulk_set_syspurpose(self, hosts, values):

--- a/airgun/entities/contenthost.py
+++ b/airgun/entities/contenthost.py
@@ -40,7 +40,7 @@ class ContentHostEntity(BaseEntity):
         view = self.navigate_to(self, 'Edit', entity_name=entity_name)
         return view.read(widget_names=widget_names)
 
-    def execute_package_action(self, entity_name, action_type, value, installed_via=None):
+    def execute_package_action(self, entity_name, action_type, value, installed_via='rex'):
         """Execute remote package action on a content host.
 
         The installation method is not set here, but the path changes according to the method used.
@@ -55,7 +55,7 @@ class ContentHostEntity(BaseEntity):
         :param value: Package or package group group name to remotely
             install/upgrade/remove (depending on `action_type`)
 
-        :param installed_via: what installation method was used
+        :param installed_via: what installation method was used (REX or katello-agent)
 
         :return: Returns a dict containing task status details
         """


### PR DESCRIPTION
Hello airgunners

As REX is default in 6.10 I had to add support for the Job Invocation page which is used when applying errata, to track task progress, rather than CHost Details Task view.

Used by tests in `tests/foreman/ui/test_contenthost.py` and `tests/foreman/ui/test_hostcollection.py`.

Thank you


[Update test ui test_contenthost to use REX #8817](https://github.com/SatelliteQE/robottelo/pull/8817)
[Convert test hostcollection to use REX #8847](https://github.com/SatelliteQE/robottelo/pull/8847)