### PR TITLE
[cherry-pick] Remove SyspurposeBulkActionView confirm step (#606)

### DIFF
--- a/airgun/entities/contenthost.py
+++ b/airgun/entities/contenthost.py
@@ -70,7 +70,6 @@ class ContentHostEntity(BaseEntity):
         view = SyspurposeBulkActionView(view.browser)
         view.fill(values)
         self.browser.click(view.assign)
-        self.browser.click(view.confirm)
 
     def execute_module_stream_action(
         self,

--- a/airgun/views/contenthost.py
+++ b/airgun/views/contenthost.py
@@ -337,7 +337,6 @@ class SyspurposeBulkActionView(BaseLoggedInView):
     role = Select(id='selectedRoles')
     usage_type = Select(id='selectedUsages')
     assign = Text(".//span[text()='Assign']")
-    confirm = Text(".//button[text()='Assign']")
 
     @property
     def is_displayed(self):


### PR DESCRIPTION
its no longer used in the web UI

cherry-pick from https://github.com/SatelliteQE/airgun/pull/606