### PR TITLE
Update the Virtwho configure Edit and Detail view

### DIFF
--- a/airgun/views/virtwho_configure.py
+++ b/airgun/views/virtwho_configure.py
@@ -182,7 +182,7 @@ class VirtwhoConfigureEditView(VirtwhoConfigureCreateView):
         breadcrumb_loaded = self.browser.wait_for_element(self.breadcrumb, exception=False)
         return (
             breadcrumb_loaded
-            and self.breadcrumb.locations[0] == 'Configurations'
+            and self.breadcrumb.locations[0] == 'Virt-who Configurations'
             and self.breadcrumb.read().startswith('Edit ')
         )
 
@@ -197,7 +197,7 @@ class VirtwhoConfigureDetailsView(BaseLoggedInView):
         breadcrumb_loaded = self.browser.wait_for_element(self.breadcrumb, exception=False)
         return (
             breadcrumb_loaded
-            and self.breadcrumb.locations[0] == 'Configurations'
+            and self.breadcrumb.locations[0] == 'Virt-who Configurations'
             and self.breadcrumb.read() != 'Create Config'
         )
 


### PR DESCRIPTION
**Description**
The UI testing for virt-who plugin testing failed due to the error messages:
```
>           raise TimedOutError(timeout_msg)
E           wait_for.TimedOutError: Could not do 'function other_div_displayed()' at /root/plugin/venv/lib/python3.8/site-packages/widgetastic_patternfly/__init__.py:583 in time
```
Some of the cases failed as the UI cannot identify if it is at the right view, the view of virt-who configure has been changed...


**Test Result**
```
(venv) [root@vw-test robottelo]#  pytest tests/foreman/virtwho/ui/test_esx.py -k test_positive_deploy_configure_by_id -s

================== 1 passed, 14 deselected, 9 warnings in 672.63s (0:11:12) ==================
```

