### PR TITLE
Fix locator of host/puppet_class_parameters

### DIFF
--- a/airgun/views/host.py
+++ b/airgun/views/host.py
@@ -383,7 +383,7 @@ class HostCreateView(BaseLoggedInView):
         """Host parameters tab"""
 
         puppet_class_parameters = Table(
-            ".//table[@id='inherited_puppetclasses_parameters']",
+            ".//div[@id='inherited_puppetclasses_parameters']/table",
             column_widgets={'Value': PuppetClassParameterValue()},
         )
 


### PR DESCRIPTION
In 6.10 a deprecation warning was added to Host > Parameters > Puppet Class Parameters and the id used in locator moved from from table to div.

6.9:
```
<fieldset>
  <h2>Puppet Class Parameters</h2>
  <table class="table table-fixed" id="inherited_puppetclasses_parameters">
```
6.10
```
<fieldset>
  <h2>Puppet Class Parameters</h2>
  <div id="inherited_puppetclasses_parameters">
    <div class="alert alert-warning "><span class="pficon pficon-warning-triangle-o "></span> <span class="text">Puppet ENC is deprecated and will be removed in Satellite 7.0</span></div>
    <table class="table table-fixed">
```