### PR TITLE
Fix locators for create new buttons

### DIFF
--- a/airgun/views/configgroup.py
+++ b/airgun/views/configgroup.py
@@ -10,7 +10,7 @@ from airgun.widgets import PuppetClassesMultiSelect
 
 class ConfigGroupsView(BaseLoggedInView, SearchableViewMixin):
     title = Text("//h1[text()='Config Groups']")
-    new = Text("//a[contains(@href, '/config_groups/new')]")
+    new = Text("//a[text()='Create Config Group']")
     table = Table(
         './/table',
         column_widgets={

--- a/airgun/views/puppet_environment.py
+++ b/airgun/views/puppet_environment.py
@@ -20,7 +20,7 @@ class PuppetEnvironmentTableView(BaseLoggedInView, SearchableViewMixin):
     """
 
     title = Text(".//h1[contains(., 'Puppet Environments')]")
-    new = Text(".//a[contains(@href, '/environments/new')]")
+    new = Text(".//a[text()='Create Puppet Environment']")
     import_environments = Text(
         ".//span[contains(@class, 'btn')]/a[contains(@href, 'import_environments')]"
     )


### PR DESCRIPTION
The _Create New_ buttons in the _Environments_ and _Config Groups_ were changed to the PF type on the blank page (when no entities of it's type exist), losing the href attribute used in locator.

For now I replace them with text until html ids are added to the buttons (BZ: https://bugzilla.redhat.com/show_bug.cgi?id=2016332)

Previously failing tests:
```
(venv39) [vsedmik@localhost robottelo]$ pytest tests/foreman/ui/test_puppetenvironment.py::test_positive_availability_for_host_and_hostgroup_in_multiple_orgs tests/foreman/ui/test_config_group.py::test_positive_end_to_end
=========================================================================================================== test session starts ===========================================================================================================
platform linux -- Python 3.9.7, pytest-6.2.5, py-1.10.0, pluggy-0.13.1
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/vsedmik/PycharmProjects/robottelo, configfile: pyproject.toml
plugins: forked-1.3.0, services-2.2.1, xdist-2.4.0, reportportal-5.0.8, ibutsu-1.16, mock-3.6.1
collected 2 items                                                                                                                                                                                                                         

tests/foreman/ui/test_puppetenvironment.py .                                                                                                                                                                                        [ 50%]
tests/foreman/ui/test_config_group.py .                                                                                                                                                                                             [100%]
...
=============================================================================================== 2 passed, 37 warnings in 872.95s (0:14:32) ================================================================================================
(venv39) [vsedmik@localhost robottelo]$ 

```