### PR TITLE
Fix deleting a repo entity

### DIFF
--- a/airgun/entities/repository.py
+++ b/airgun/entities/repository.py
@@ -80,19 +80,13 @@ class RepositoryEntity(BaseEntity):
 
     def delete(self, product_name, entity_name):
         """Delete specific product repository"""
-        view = self.navigate_to(self, 'All', product_name=product_name)
+        view = self.navigate_to(self, 'All', product_name=product_name, entity_name=entity_name)
         view.search(entity_name)
         view.table.row(name=entity_name)[0].fill(True)
         view.delete.click()
         view.dialog.confirm()
         view.flash.assert_no_error()
         view.flash.dismiss()
-        wait_for(
-            lambda: view.search(f'name = "{entity_name}"') == [],
-            timeout=30,
-            delay=2,
-            logger=view.logger,
-        )
 
     def synchronize(self, product_name, entity_name):
         """Synchronize repository"""


### PR DESCRIPTION
Failure in some test cases that relies on this entity

results:
```
pytest tests/foreman/ui/test_repository.py::test_positive_delete_random_docker_repo
===== 1 passed, 3 warnings in 224.62s (0:03:44) ======

pytest tests/foreman/ui/test_repository.py::test_positive_end_to_end_custom_yum_crud
======== 1 passed, 3 warnings in 632.45s (0:10:32) ===============

pytest tests/foreman/ui/test_repository.py::test_positive_end_to_end_custom_module_streams_crud
======== 1 passed, 3 warnings in 781.31s (0:13:01) ================
```