### PR TITLE
Incorrect is_searchable return value | Incorrect condition

### DIFF
--- a/airgun/views/common.py
+++ b/airgun/views/common.py
@@ -417,9 +417,9 @@ class SearchableViewMixin(WTMixin):
         That means that we have search field present on the page and that page
         is not a welcome one
         """
-        if not self.searchbox.search_field.is_displayed and self.welcome_message.is_displayed:
-            return False
-        return True
+        if self.searchbox.search_field.is_displayed and (not self.welcome_message.is_displayed):
+            return True
+        return False
 
     def search(self, query):
         """Perform search using searchbox on the page and return table


### PR DESCRIPTION
False Conditioning in `is_displayed()` returns a wrong boolean value making tests to search entity even though the search field is not available on the page.