### PR TITLE
removing the idle-timeout, webkaifuku takes care!

### DIFF
--- a/airgun/browser.py
+++ b/airgun/browser.py
@@ -174,9 +174,6 @@ class SeleniumBrowserFactory:
         manager = BrowserManager.from_conf(self.web_kaifuku)
         self._webdriver = manager.start()
         self._set_session_cookie()
-        idle_timeout = desired_capabilities['idletimeout']
-        if idle_timeout:
-            self._webdriver.command_executor.set_timeout(int(idle_timeout))
         return self._webdriver
 
 


### PR DESCRIPTION
No need for the code to set the idleTimeout as it set directly handled by webkaifuku 

For Test Result : git lab satelliteqe-jenkins - 448 PR