### PR TITLE
Add ansible roles view and entity

### DIFF
--- a/airgun/entities/ansible_role.py
+++ b/airgun/entities/ansible_role.py
@@ -20,8 +20,12 @@ class AnsibleRolesEntity(BaseEntity):
 
     def delete(self, entity_name):
         """Delete Ansible Role from Satellite"""
-        # This method currently does not work as the Name column table header
-        # cell includes the `▲` character used for sorting that column
+        # This method currently relies on searching for a specific role as
+        # directly accessing the 'Name' column is not possible due to the
+        # presence of the `▲` character used for sorting that column in the table
+        # header cell. The Satellite UX team is planning to address this in a
+        # future release, likely by wrapping the sort character in a separate
+        # span tag from the column header text.
         view = self.navigate_to(self, 'All')
         view.search(entity_name)
         view.table.row()['Actions'].widget.fill('Delete')

--- a/airgun/entities/ansible_role.py
+++ b/airgun/entities/ansible_role.py
@@ -1,0 +1,75 @@
+from navmazing import NavigateToSibling
+
+from airgun.entities.base import BaseEntity
+from airgun.navigation import NavigateStep
+from airgun.navigation import navigator
+from airgun.views.ansible_role import AnsibleRolesImportView
+from airgun.views.ansible_role import AnsibleRolesView
+
+
+class AnsibleRolesEntity(BaseEntity):
+    """Main Ansible roles entity"""
+
+    endpoint_path = '/ansible/ansible_roles'
+
+    def search(self, value):
+        """Search for existing Ansible Role"""
+        view = self.navigate_to(self, 'All')
+        view.search(value)
+        return view.table.read()
+
+    def delete(self, entity_name):
+        """Delete Ansible Role from Satellite"""
+        # This method currently does not work as the Name column table header
+        # cell includes the `▲` character used for sorting that column
+        view = self.navigate_to(self, 'All')
+        view.search(entity_name)
+        view.table.row()['Actions'].widget.fill('Delete')
+        view.dialog.confirm_dialog.click()
+        view.flash.assert_no_error()
+        view.flash.dismiss()
+
+    @property
+    def imported_roles_count(self):
+        """Return the number of Ansible roles currently imported into Satellite"""
+        view = self.navigate_to(self, 'All')
+        return int(view.total_imported_roles.read())
+
+    def import_all_roles(self):
+        """Import all available roles and return the number of roles
+        that were available at import time
+        """
+        view = self.navigate_to(self, 'Import')
+        available_roles_count = int(view.total_available_roles.read())
+        view.select_all.fill(True)
+        view.submit.click()
+        return available_roles_count
+
+    # Since Ansible Variables need to be assigned to specific Ansible Roles,
+    # Ansible Variable tests will fail if no Ansible Roles have been imported.
+    def preimport_check(self):
+        view = self.navigate_to(self, 'All')
+        if not view.pagination.is_displayed:
+            return False
+
+
+@navigator.register(AnsibleRolesEntity, 'All')
+class ShowAllRoles(NavigateStep):
+    """Navigate to the Ansible Roles page"""
+
+    VIEW = AnsibleRolesView
+
+    def step(self, *args, **kwargs):
+        self.view.menu.select('Configure', 'Roles')
+
+
+@navigator.register(AnsibleRolesEntity, 'Import')
+class ImportAnsibleRole(NavigateStep):
+    """Navigate to the Import Roles page"""
+
+    VIEW = AnsibleRolesImportView
+
+    prerequisite = NavigateToSibling('All')
+
+    def step(self, *args, **kwargs):
+        self.parent.import_button.click()

--- a/airgun/entities/ansible_variable.py
+++ b/airgun/entities/ansible_variable.py
@@ -1,0 +1,74 @@
+from navmazing import NavigateToSibling
+
+from airgun.entities.base import BaseEntity
+from airgun.navigation import NavigateStep
+from airgun.navigation import navigator
+from airgun.views.ansible_variable import AnsibleVariablesView
+from airgun.views.ansible_variable import NewAnsibleVariableView
+
+
+class AnsibleVariablesEntity(BaseEntity):
+    """Main Ansible variables entity"""
+
+    endpoint_path = '/ansible/ansible_variables'
+
+    def search(self, value):
+        """Search for existing Ansible variable"""
+        view = self.navigate_to(self, 'All')
+        view.search(value)
+        return view.table.read()
+
+    def delete(self, entity_name):
+        """Delete Ansible variable from Satellite"""
+        view = self.navigate_to(self, 'All')
+        view.search(entity_name)
+        view.table.row(name=entity_name)['Actions'].widget.click(handle_alert=True)
+        view.confirm.confirm_dialog.click()
+        view.flash.assert_no_error()
+        view.flash.dismiss()
+
+    def read_total_variables(self):
+        """Returns the number of Ansible variables currently in Satellite"""
+        view = self.navigate_to(self, 'All')
+        return view.total_variables.read()
+
+    def create(self, values):
+        """Create a new Ansible variable with minimum inputs"""
+        view = self.navigate_to(self, 'New')
+        view.fill(values)
+        view.submit.click()
+        view.flash.assert_no_error()
+        view.flash.dismiss()
+
+    def create_with_overrides(self, values):
+        """Create a new Ansible variable that is managed by Satellite"""
+        view = self.navigate_to(self, 'New')
+        view.override.fill(True)
+        view.expand()
+        view.matcher_section.before_fill(values)
+        view.fill(values)
+        view.submit.click()
+        view.flash.assert_no_error()
+        view.flash.dismiss()
+
+
+@navigator.register(AnsibleVariablesEntity, 'All')
+class ShowAllVariables(NavigateStep):
+    """Navigate to Ansible Variables page"""
+
+    VIEW = AnsibleVariablesView
+
+    def step(self, *args, **kwargs):
+        self.view.menu.select('Configure', 'Variables')
+
+
+@navigator.register(AnsibleVariablesEntity, 'New')
+class NewAnsibleVariable(NavigateStep):
+    """Navigate to Create Ansible Variable page"""
+
+    VIEW = NewAnsibleVariableView
+
+    prerequisite = NavigateToSibling('All')
+
+    def step(self, *args, **kwargs):
+        self.parent.new_variable.click()

--- a/airgun/entities/ansible_variable.py
+++ b/airgun/entities/ansible_variable.py
@@ -22,8 +22,8 @@ class AnsibleVariablesEntity(BaseEntity):
         """Delete Ansible variable from Satellite"""
         view = self.navigate_to(self, 'All')
         view.search(entity_name)
-        view.table.row(name=entity_name)['Actions'].widget.click(handle_alert=True)
-        view.confirm.confirm_dialog.click()
+        view.table.row(name=entity_name)['Actions'].widget.click()
+        view.dialog.confirm_dialog.click()
         view.flash.assert_no_error()
         view.flash.dismiss()
 

--- a/airgun/session.py
+++ b/airgun/session.py
@@ -11,6 +11,8 @@ from airgun import settings
 from airgun.browser import AirgunBrowser
 from airgun.browser import SeleniumBrowserFactory
 from airgun.entities.activationkey import ActivationKeyEntity
+from airgun.entities.ansible_role import AnsibleRolesEntity
+from airgun.entities.ansible_variable import AnsibleVariablesEntity
 from airgun.entities.architecture import ArchitectureEntity
 from airgun.entities.audit import AuditEntity
 from airgun.entities.bookmark import BookmarkEntity
@@ -314,6 +316,16 @@ class Session:
     def activationkey(self):
         """Instance of Activation Key entity."""
         return self._open(ActivationKeyEntity)
+
+    @cached_property
+    def ansibleroles(self):
+        """Instance of Ansible Roles entity."""
+        return self._open(AnsibleRolesEntity)
+
+    @cached_property
+    def ansiblevariables(self):
+        """Instance of Ansible Variables entity."""
+        return self._open(AnsibleVariablesEntity)
 
     @cached_property
     def architecture(self):

--- a/airgun/views/ansible_role.py
+++ b/airgun/views/ansible_role.py
@@ -1,0 +1,70 @@
+from widgetastic.widget import Checkbox
+from widgetastic.widget import Table
+from widgetastic.widget import Text
+from widgetastic_patternfly import BreadCrumb
+from widgetastic_patternfly4 import Button
+from widgetastic_patternfly4 import PatternflyTable
+
+from airgun.views.common import BaseLoggedInView
+from airgun.views.common import SearchableViewMixin
+from airgun.widgets import ActionsDropdown
+from airgun.widgets import Pagination
+
+
+class ImportPagination(Pagination):
+    PER_PAGE_BUTTON_DROPDOWN = ".//div[button[@id='pagination-options-menu-toggle-2']]"
+
+
+class AnsibleRolesView(BaseLoggedInView, SearchableViewMixin):
+    """Main Ansible Roles view. Prior to importing any roles, only the import_button
+    is present, without the search widget or table.
+    """
+
+    title = Text("//h1[contains(., text()='Ansible Roles')")
+    import_button = Text("//a[contains(@href, '/ansible_roles/import')]")
+    submit = Button('Submit')
+    total_imported_roles = Text("//span[contains(@class, 'pagination-pf-items-total')]")
+    table = Table(
+        './/table',
+        column_widgets={
+            'Name': Text("./a"),
+            'Hostgroups': Text("./a"),
+            'Hosts': Text("./a"),
+            'Imported at': Text("./a"),
+            'Actions': ActionsDropdown("./div[contains(@class, 'btn-group')]"),
+        },
+    )
+    pagination = Pagination()
+
+    @property
+    def is_displayed(self):
+        return self.title.is_displayed and self.import_button.is_displayed
+
+
+class AnsibleRolesImportView(BaseLoggedInView):
+    """View while selecting Ansible roles to import."""
+
+    breadcrumb = BreadCrumb()
+    total_available_roles = Text("//div[@class='pf-c-pagination__total-items']/b[2]")
+    select_all = Checkbox(locator="//input[@id='select-all']")
+    table = PatternflyTable(
+        component_id='OUIA-Generated-Table-2',
+        column_widgets={
+            0: Checkbox(locator='.//input[@type="checkbox"]'),
+            'Name': Text('.//a'),
+            'Operation': Text('.//a'),
+            'Variables': Text('.//a'),
+            'Hosts Count': Text('.//a'),
+            'Hostgroups Count': Text('.//a'),
+        },
+    )
+    pagination = ImportPagination()
+    submit = Button('Submit')
+    cancel = Button('Cancel')
+
+    @property
+    def is_displayed(self):
+        return (
+            self.breadcrumb.locations[0] == 'Roles'
+            and self.breadcrumb.read() == 'Changed Ansible roles'
+        )

--- a/airgun/views/ansible_role.py
+++ b/airgun/views/ansible_role.py
@@ -7,12 +7,13 @@ from widgetastic_patternfly4 import PatternflyTable
 
 from airgun.views.common import BaseLoggedInView
 from airgun.views.common import SearchableViewMixin
-from airgun.widgets import ActionsDropdown
+from airgun.widgets import ActionsDropdown, Pf4ConfirmationDialog
 from airgun.widgets import Pagination
 
 
 class ImportPagination(Pagination):
     PER_PAGE_BUTTON_DROPDOWN = ".//div[button[@id='pagination-options-menu-toggle-2']]"
+    total_items = Text("//span[@class='pf-c-optionsmenu__toggle-text']/b[2]")
 
 
 class AnsibleRolesView(BaseLoggedInView, SearchableViewMixin):
@@ -23,14 +24,10 @@ class AnsibleRolesView(BaseLoggedInView, SearchableViewMixin):
     title = Text("//h1[contains(., text()='Ansible Roles')")
     import_button = Text("//a[contains(@href, '/ansible_roles/import')]")
     submit = Button('Submit')
-    total_imported_roles = Text("//span[contains(@class, 'pagination-pf-items-total')]")
+    total_imported_roles = Text(".//span[contains(@class, 'pagination-pf-items-total')]")
     table = Table(
         './/table',
         column_widgets={
-            'Name': Text("./a"),
-            'Hostgroups': Text("./a"),
-            'Hosts': Text("./a"),
-            'Imported at': Text("./a"),
             'Actions': ActionsDropdown("./div[contains(@class, 'btn-group')]"),
         },
     )
@@ -51,11 +48,6 @@ class AnsibleRolesImportView(BaseLoggedInView):
         component_id='OUIA-Generated-Table-2',
         column_widgets={
             0: Checkbox(locator='.//input[@type="checkbox"]'),
-            'Name': Text('.//a'),
-            'Operation': Text('.//a'),
-            'Variables': Text('.//a'),
-            'Hosts Count': Text('.//a'),
-            'Hostgroups Count': Text('.//a'),
         },
     )
     pagination = ImportPagination()

--- a/airgun/views/ansible_role.py
+++ b/airgun/views/ansible_role.py
@@ -7,7 +7,7 @@ from widgetastic_patternfly4 import PatternflyTable
 
 from airgun.views.common import BaseLoggedInView
 from airgun.views.common import SearchableViewMixin
-from airgun.widgets import ActionsDropdown, Pf4ConfirmationDialog
+from airgun.widgets import ActionsDropdown
 from airgun.widgets import Pagination
 
 

--- a/airgun/views/ansible_variable.py
+++ b/airgun/views/ansible_variable.py
@@ -11,7 +11,6 @@ from airgun.views.common import SearchableViewMixin
 from airgun.widgets import CustomParameter
 from airgun.widgets import FilteredDropdown
 from airgun.widgets import Pagination
-from airgun.widgets import Pf4ConfirmationDialog
 from airgun.widgets import SatSelect
 
 

--- a/airgun/views/ansible_variable.py
+++ b/airgun/views/ansible_variable.py
@@ -84,6 +84,9 @@ class NewAnsibleVariableView(BaseLoggedInView):
         add_matcher = Text("//a[contains(@class, 'add_nested_fields')]")
         params = MatcherTable(
             locator=".//table[@class='table white-header']",
+            # new_row_bottom is passed to the __init__ method of the
+            # CustomParameter widget, see comment there for additional details
+            new_row_bottom=True,
             column_widgets={
                 'Attribute type': MatcherActions(),
                 'Value': TextInput(locator=".//textarea[@id='new_lookup_value_value']"),

--- a/airgun/views/ansible_variable.py
+++ b/airgun/views/ansible_variable.py
@@ -55,19 +55,26 @@ class NewAnsibleVariableView(BaseLoggedInView):
     """View while creating a new Ansible Variable"""
 
     breadcrumb = BreadCrumb()
+
+    # 'Ansible Variable Details' section
     key = TextInput(id='ansible_variable_key')
     description = TextInput(id='ansible_variable_description')
     ansible_role = FilteredDropdown(id='ansible_variable_ansible_role_id')
-    override = Checkbox(id='ansible_variable_override')
 
+    # 'Default Behavior' section
+    override = Checkbox(id='ansible_variable_override')
     # Accessing all widgets except the ones above requires that the `override` checkbox is filled
     parameter_type = SatSelect(id='ansible_variable_parameter_type')
     default_value = TextInput(id='ansible_variable_default_value')
     hidden_value = Checkbox(id='ansible_variable_hidden_value')
+
+    # 'Optional Input Validator' section
     expand_optional_input_validator = Text("//h2[@class='expander collapsed']")
     required = Checkbox(id='ansible_variable_required')
     validator_type = SatSelect(id='ansible_variable_validator_type')
     validator_rule = TextInput(id='ansible_variable_validator_rule')
+
+    # 'Prioritize Attribute Order' section
     attribute_order = TextInput(id='order')
     merge_overrides = Checkbox(id='ansible_variable_merge_overrides')
     merge_default = Checkbox(id='ansible_variable_merge_default')
@@ -77,6 +84,8 @@ class NewAnsibleVariableView(BaseLoggedInView):
 
     @View.nested
     class matcher_section(View):
+        """'Specify Matchers' section"""
+
         add_matcher = Text("//a[contains(@class, 'add_nested_fields')]")
         params = MatcherTable(
             locator=".//table[@class='table white-header']",

--- a/airgun/views/ansible_variable.py
+++ b/airgun/views/ansible_variable.py
@@ -20,19 +20,14 @@ class AnsibleVariablesView(BaseLoggedInView, SearchableViewMixin):
 
     title = Text("//h1[contains(., text()='Ansible Variables')")
     new_variable = Text("//a[contains(@href, '/ansible/ansible_variables/new')]")
-    total_variables = Text("//span[@class='pagination-pf-items-total']")
+    total_variables = Text(".//span[@class='pagination-pf-items-total']")
     table = SatTable(
         './/table',
         column_widgets={
-            'Name': Text("./a"),
-            'Role': Text("./a"),
-            'Type': Text("./a"),
-            'Imported?': Text("./a"),
             'Actions': Text(".//a[@data-method='delete']"),
         },
     )
     pagination = Pagination()
-    confirm = Pf4ConfirmationDialog()
 
     @property
     def is_displayed(self):

--- a/airgun/views/ansible_variable.py
+++ b/airgun/views/ansible_variable.py
@@ -1,0 +1,116 @@
+from widgetastic.widget import Checkbox
+from widgetastic.widget import Select
+from widgetastic.widget import Text
+from widgetastic.widget import TextInput
+from widgetastic.widget import View
+from widgetastic_patternfly import BreadCrumb
+
+from airgun.views.common import BaseLoggedInView
+from airgun.views.common import SatTable
+from airgun.views.common import SearchableViewMixin
+from airgun.widgets import CustomParameter
+from airgun.widgets import FilteredDropdown
+from airgun.widgets import Pagination
+from airgun.widgets import Pf4ConfirmationDialog
+from airgun.widgets import SatSelect
+
+
+class AnsibleVariablesView(BaseLoggedInView, SearchableViewMixin):
+    """Main Ansible Variables view"""
+
+    title = Text("//h1[contains(., text()='Ansible Variables')")
+    new_variable = Text("//a[contains(@href, '/ansible/ansible_variables/new')]")
+    total_variables = Text("//span[@class='pagination-pf-items-total']")
+    table = SatTable(
+        './/table',
+        column_widgets={
+            'Name': Text("./a"),
+            'Role': Text("./a"),
+            'Type': Text("./a"),
+            'Imported?': Text("./a"),
+            'Actions': Text(".//a[@data-method='delete']"),
+        },
+    )
+    pagination = Pagination()
+    confirm = Pf4ConfirmationDialog()
+
+    @property
+    def is_displayed(self):
+        return self.title.is_displayed and self.new_variable.is_displayed
+
+
+class MatcherTable(CustomParameter):
+    add_new_value = Text("..//a[contains(text(),'+ Add Matcher')]")
+
+
+class MatcherActions(View):
+    """Interface table has Attribute type column that contains select field and
+    text input field."""
+
+    matcher_key = Select(".//select")
+    matcher_value = TextInput(locator=".//input[@class='matcher_value']")
+
+
+class NewAnsibleVariableView(BaseLoggedInView):
+    """View while creating a new Ansible Variable"""
+
+    breadcrumb = BreadCrumb()
+    key = TextInput(id='ansible_variable_key')
+    description = TextInput(id='ansible_variable_description')
+    ansible_role = FilteredDropdown(id='ansible_variable_ansible_role_id')
+    override = Checkbox(id='ansible_variable_override')
+
+    # Accessing all widgets except the ones above requires that the `override` checkbox is filled
+    parameter_type = SatSelect(id='ansible_variable_parameter_type')
+    default_value = TextInput(id='ansible_variable_default_value')
+    hidden_value = Checkbox(id='ansible_variable_hidden_value')
+    expand_optional_input_validator = Text("//h2[@class='expander collapsed']")
+    required = Checkbox(id='ansible_variable_required')
+    validator_type = SatSelect(id='ansible_variable_validator_type')
+    validator_rule = TextInput(id='ansible_variable_validator_rule')
+    attribute_order = TextInput(id='order')
+    merge_overrides = Checkbox(id='ansible_variable_merge_overrides')
+    merge_default = Checkbox(id='ansible_variable_merge_default')
+    avoid_duplicates = Checkbox(id='ansible_variable_avoid_duplicates')
+    submit = Text('//input[@value="Submit"]')
+    cancel = Text("//a[contains(., text()='Cancel']")
+
+    @View.nested
+    class matcher_section(View):
+        add_matcher = Text("//a[contains(@class, 'add_nested_fields')]")
+        params = MatcherTable(
+            locator=".//table[@class='table white-header']",
+            column_widgets={
+                'Attribute type': MatcherActions(),
+                'Value': TextInput(locator=".//textarea[@id='new_lookup_value_value']"),
+                'Actions': Text(".//a"),
+            },
+        )
+
+        def before_fill(self, values):
+            if not self.params.is_displayed:
+                self.add_matcher.click()
+
+    @property
+    def expand_button(self):
+        """Return the Optional Input Validator section expander element"""
+        return self.browser.element(self.expand_optional_input_validator, parent=self)
+
+    @property
+    def expanded(self):
+        """Check whether this section is expanded"""
+        return 'active' in self.browser.get_attribute(
+            'class', self.expand_optional_input_validator
+        )
+
+    def expand(self):
+        """Expand the Optional Input Validator section"""
+        if not self.expanded:
+            self.browser.click(self.expand_optional_input_validator, parent=self)
+
+    @property
+    def is_displayed(self):
+        return (
+            self.breadcrumb.locations[0] == 'Ansible Variables'
+            and self.breadcrumb.read() == 'Create Ansible Variable'
+        )

--- a/airgun/widgets.py
+++ b/airgun/widgets.py
@@ -959,13 +959,19 @@ class CustomParameter(Table):
 
     add_new_value = Text("..//a[contains(normalize-space(.),'+ Add Parameter')]")
 
-    def __init__(self, parent, locator=None, id=None, logger=None):
+    # def __init__(self, parent, locator=None, id=None, logger=None, column_widgets=None):
+    def __init__(self, parent, **kwargs):
         """Supports initialization via ``locator=`` or ``id=``"""
-        if locator and id or not locator and not id:
+        if (
+            kwargs.get('locator')
+            and kwargs.get('id')
+            or not kwargs.get('locator')
+            and not kwargs.get('id')
+        ):
             raise ValueError('Please specify either locator or id')
-        locator = locator or f".//table[@id='{id}']"
+        locator = kwargs.get('locator') or f".//table[@id='{kwargs.get('id')}']"
 
-        column_widgets = {
+        column_widgets = kwargs.get('column_widgets') or {
             'Name': TextInput(locator=".//input[@placeholder='Name']"),
             'Value': TextInput(locator=".//textarea[@placeholder='Value']"),
             'Actions': Text(
@@ -973,7 +979,14 @@ class CustomParameter(Table):
                 "or @title='Remove Parameter']"
             ),
         }
-        super().__init__(parent, locator=locator, logger=logger, column_widgets=column_widgets)
+        self.name = list(column_widgets.keys())[0]
+        self.name_key = '_'.join(self.name.lower().split(' '))
+        self.value = list(column_widgets.keys())[1]
+        self.value_key = '_'.join(self.value.lower().split(' '))
+
+        super().__init__(
+            parent, locator=locator, logger=kwargs.get('logger'), column_widgets=column_widgets
+        )
 
     def read(self):
         """Return a list of dictionaries. Each dictionary consists of name and
@@ -981,9 +994,9 @@ class CustomParameter(Table):
         """
         parameters = []
         for row in self.rows():
-            name = row['Name'].widget.read()
-            value = row['Value'].widget.read()
-            parameters.append({'name': name, 'value': value})
+            name = row[self.name].widget.read()
+            value = row[self.value].widget.read()
+            parameters.append({self.name_key: name, self.value_key: value})
         return parameters
 
     def add(self, value):
@@ -992,9 +1005,9 @@ class CustomParameter(Table):
         :param value: dict with format {'name': str, 'value': str}
         """
         self.add_new_value.click()
-        new_row = self.__getitem__(0)
-        new_row['Name'].widget.fill(value['name'])
-        new_row['Value'].widget.fill(value['value'])
+        new_row = self.__getitem__(-1)
+        new_row[self.name].widget.fill(value[self.name_key])
+        new_row[self.value].widget.fill(value[self.value_key])
 
     def remove(self, name):
         """Remove parameter entries from the table based on name.
@@ -1002,7 +1015,7 @@ class CustomParameter(Table):
         :param value: dict with format {'name': str, 'value': str}
         """
         for row in self.rows():
-            if row['Name'].widget.read() == name:
+            if row[self.name].widget.read() == name:
                 row['Actions'].widget.click()  # click 'Remove'
 
     def fill(self, values):
@@ -1021,22 +1034,23 @@ class CustomParameter(Table):
             params_to_fill = values
 
         try:
-            names_to_fill = [param['name'] for param in params_to_fill]
+            names_to_fill = [param[self.name_key] for param in params_to_fill]
         except KeyError:
             raise KeyError("parameter value is missing 'name' key")
 
-        # Check if duplicate names were passed in
-        if len(set(names_to_fill)) < len(names_to_fill):
-            raise ValueError(
-                "Cannot use fill() with duplicate parameter names. "
-                "If you wish to explicitly add a duplicate name, "
-                "use CustomParameter.add()"
-            )
+        # Check if duplicate names were passed in and skip incase list
+        if not isinstance(names_to_fill[0], dict):
+            if len(set(names_to_fill)) < len(names_to_fill):
+                raise ValueError(
+                    "Cannot use fill() with duplicate parameter names. "
+                    "If you wish to explicitly add a duplicate name, "
+                    "use CustomParameter.add()"
+                )
 
         # Check if we need to update or remove any rows
         for row in self.rows():
-            this_name = row['Name'].widget.read()
-            this_value = row['Value'].widget.read()
+            this_name = row[self.name].widget.read()
+            this_value = row[self.value].widget.read()
             if this_name not in names_to_fill:
                 # Delete row if its name/value is not in desired values
                 row['Actions'].widget.click()  # click 'Remove' icon
@@ -1045,14 +1059,14 @@ class CustomParameter(Table):
                 # First get the desired value for this param name
                 desired_value = None
                 for index, param in enumerate(params_to_fill):
-                    if param['name'] == this_name:
-                        desired_value = param['value']
+                    if param[self.name_key] == this_name:
+                        desired_value = param[self.value_key]
                         # Since we're editing this name now, don't add it later
                         params_to_fill.pop(index)
                         break
                 if desired_value is not None and this_value != desired_value:
                     # Update row's value for this name
-                    row['Value'].widget.fill(desired_value)
+                    row[self.value].widget.fill(desired_value)
                 else:
                     # Desired parameter name/value is already filled
                     continue


### PR DESCRIPTION
This PR adds views and entities for the Ansible Roles page (located in the webUI at Configure > Roles) and the Ansible Variables page (located in the webUI at Configured > Variables).

This is my first Airgun PR, so I would appreciate any feedback.

Note that there are two widgets in the `NewAnsibleVariableView` view that are not currently functioning properly; I have marked these with comments. However, in the interest of getting these changes merged ahead of 6.10 branching next week, I thought it best to get this up for review in its current state. 