### PR TITLE
Use Pf4ConfirmationDialog for Http Proxy and Openscap

### DIFF
--- a/airgun/entities/http_proxy.py
+++ b/airgun/entities/http_proxy.py
@@ -49,6 +49,7 @@ class HTTPProxyEntity(BaseEntity):
         view = self.navigate_to(self, 'All')
         self.search(entity_name)
         view.table.row(Name=entity_name)['Actions'].widget.click(handle_alert=True)
+        view.dialog.confirm()
         view.validations.assert_no_errors()
         view.flash.assert_no_error()
         view.flash.dismiss()

--- a/airgun/entities/oscapcontent.py
+++ b/airgun/entities/oscapcontent.py
@@ -33,7 +33,7 @@ class OSCAPContentEntity(BaseEntity):
         view = self.navigate_to(self, 'All')
         view.search(entity_name)
         view.table.row(title=entity_name)['Actions'].widget.fill('Delete')
-        self.browser.handle_alert()
+        view.dialog.confirm()
         view.flash.assert_no_error()
         view.flash.dismiss()
 

--- a/airgun/entities/oscappolicy.py
+++ b/airgun/entities/oscappolicy.py
@@ -33,7 +33,7 @@ class OSCAPPolicyEntity(BaseEntity):
         view = self.navigate_to(self, 'All')
         view.search(entity_name)
         view.table.row(name=entity_name)['Actions'].widget.fill('Delete')
-        self.browser.handle_alert()
+        view.dialog.confirm()
         view.flash.assert_no_error()
         view.flash.dismiss()
 

--- a/airgun/entities/oscaptailoringfile.py
+++ b/airgun/entities/oscaptailoringfile.py
@@ -31,7 +31,7 @@ class OSCAPTailoringFileEntity(BaseEntity):
         view = self.navigate_to(self, 'All')
         view.search(entity_name)
         view.table.row(name=entity_name)['Actions'].widget.fill('Delete')
-        self.browser.handle_alert()
+        view.dialog.confirm()
         view.flash.assert_no_error()
         view.flash.dismiss()
 

--- a/airgun/views/http_proxy.py
+++ b/airgun/views/http_proxy.py
@@ -8,6 +8,7 @@ from airgun.views.common import BaseLoggedInView
 from airgun.views.common import SatTab
 from airgun.views.common import SearchableViewMixin
 from airgun.widgets import MultiSelect
+from airgun.widgets import Pf4ConfirmationDialog
 
 
 class HTTPProxyView(BaseLoggedInView, SearchableViewMixin):
@@ -21,6 +22,7 @@ class HTTPProxyView(BaseLoggedInView, SearchableViewMixin):
             'Actions': Text(".//a[@data-method='delete']"),
         },
     )
+    dialog = Pf4ConfirmationDialog()
 
     @property
     def is_displayed(self):

--- a/airgun/views/oscapcontent.py
+++ b/airgun/views/oscapcontent.py
@@ -9,11 +9,12 @@ from airgun.views.common import SatTab
 from airgun.views.common import SearchableViewMixin
 from airgun.widgets import ActionsDropdown
 from airgun.widgets import MultiSelect
+from airgun.widgets import Pf4ConfirmationDialog
 from airgun.widgets import SatTable
 
 
 class SCAPContentsView(BaseLoggedInView, SearchableViewMixin):
-    title = Text("//h1[text()='SCAP Contents']")
+    title = Text("//h1[text()='SCAP Content']")
     new = Text("//a[contains(@href, 'scap_contents/new')]")
     table = SatTable(
         './/table',
@@ -22,6 +23,7 @@ class SCAPContentsView(BaseLoggedInView, SearchableViewMixin):
             'Actions': ActionsDropdown("./div[contains(@class, 'btn-group')]"),
         },
     )
+    dialog = Pf4ConfirmationDialog()
 
     @property
     def is_displayed(self):

--- a/airgun/views/oscappolicy.py
+++ b/airgun/views/oscappolicy.py
@@ -12,6 +12,7 @@ from airgun.views.dashboard import TotalCount
 from airgun.widgets import ActionsDropdown
 from airgun.widgets import FilteredDropdown
 from airgun.widgets import MultiSelect
+from airgun.widgets import Pf4ConfirmationDialog
 from airgun.widgets import RadioGroup
 from airgun.widgets import SatTable
 
@@ -26,6 +27,7 @@ class SCAPPoliciesView(BaseLoggedInView, SearchableViewMixin):
             'Actions': ActionsDropdown("./div[contains(@class, 'btn-group')]"),
         },
     )
+    dialog = Pf4ConfirmationDialog()
 
     @property
     def is_displayed(self):

--- a/airgun/views/oscaptailoringfile.py
+++ b/airgun/views/oscaptailoringfile.py
@@ -10,6 +10,7 @@ from airgun.views.common import SatTab
 from airgun.views.common import SearchableViewMixin
 from airgun.widgets import ActionsDropdown
 from airgun.widgets import MultiSelect
+from airgun.widgets import Pf4ConfirmationDialog
 
 
 class SCAPTailoringFilesView(BaseLoggedInView, SearchableViewMixin):
@@ -22,6 +23,7 @@ class SCAPTailoringFilesView(BaseLoggedInView, SearchableViewMixin):
             'Actions': ActionsDropdown("./div[contains(@class, 'btn-group')]"),
         },
     )
+    dialog = Pf4ConfirmationDialog()
 
     @property
     def is_displayed(self):


### PR DESCRIPTION
Use `Pf4ConfirmationDialog` widget for Http Proxy and Openscap entities and fix locator of `title` for scap content.

Tried:
```
(Pdb) session.http_proxy.delete('env-proxy-01')
(Pdb) session.oscapcontent.delete('abc')
(Pdb) session.oscappolicy.delete('jkdsa')
(Pdb) session.oscaptailoringfile.delete('xyz')
```

Refer https://github.com/SatelliteQE/airgun/issues/651 and https://github.com/SatelliteQE/airgun/pull/649 for more info.