### PR TITLE
Add search_applicable_hosts

### DIFF
--- a/airgun/entities/hostcollection.py
+++ b/airgun/entities/hostcollection.py
@@ -137,6 +137,7 @@ class HostCollectionEntity(BaseEntity):
         view.details.install_errata.click()
         view = HostCollectionInstallErrataView(view.browser)
         uri = view.search_url.__element__().get_attribute('href')
+        view.dialog.confirm()
         return uri
 
     def install_errata(

--- a/airgun/entities/hostcollection.py
+++ b/airgun/entities/hostcollection.py
@@ -125,6 +125,20 @@ class HostCollectionEntity(BaseEntity):
             )
             return job_status_view.overview.read()
 
+    def search_applicable_hosts(self, entity_name, errata_id):
+        """Check for search URI in Host Collection errata view.
+
+        :param str entity_name:  The host collection name.
+        :param str errata_id: the applicable errata id.
+
+        :return: Search URL to list the applicable hosts
+        """
+        view = self.navigate_to(self, 'Edit', entity_name=entity_name)
+        view.details.install_errata.click()
+        view = HostCollectionInstallErrataView(view.browser)
+        uri = view.search_url.__element__().get_attribute('href')
+        return uri
+
     def install_errata(
         self, entity_name, errata_id, install_via='via Katello agent', job_values=None
     ):

--- a/airgun/views/hostcollection.py
+++ b/airgun/views/hostcollection.py
@@ -200,6 +200,7 @@ class HostCollectionInstallErrataView(BaseLoggedInView, SearchableViewMixin):
     title = Text("//h4[contains(., 'Content Host Errata Management')]")
     search = TextInput(locator=".//input[@type='text' and @ng-model='table.searchTerm']")
     refresh = Text(locator=".//button[@ng-click='fetchErrata()']")
+    search_url = Text(locator="//a[contains(@href, 'content_hosts')]")
     install = ActionsDropdown(
         "//span[contains(@class, 'btn-group')]"
         "[button[contains(@class, 'btn') "


### PR DESCRIPTION
Hello

this update is to support a test for applicable host search URI in Host Collection errata bulk update dialog.

Ref:
[BZ#1838800 – Manage Errata from Content Host Page does not provide link to view list of content hosts affected by an Errata.](https://bugzilla.redhat.com/show_bug.cgi?id=1838800)