### PR TITLE
Upgrading to selenium grid 4 needs upgrade in the version 

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -21,12 +21,11 @@ setup(
         'navmazing',
         'python-box',
         'pytest',
-        'selenium',
         'wait_for',
         'webdriver-kaifuku',
         'widgetastic.core',
         'widgetastic.patternfly',
-        'widgetastic.patternfly4',
+        'widgetastic.patternfly4 @ git+https://github.com/RedHatQE/widgetastic.patternfly4.git@selenium4#egg=widgetastic.patternfly4',  # noqa
     ],
     packages=find_packages(exclude=['tests*']),
     package_data={'': ['LICENSE']},


### PR DESCRIPTION
$subject

> pip list | grep selenium
selenium                4.1.0
selenium-smart-locator  0.2.0
> pip list | grep pattern
widgetastic.patternfly  1.3.4
widgetastic.patternfly4 0.23.2.dev2+gcb3bf05

