### PR TITLE
Add support for reading host status

### DIFF
--- a/airgun/entities/host.py
+++ b/airgun/entities/host.py
@@ -63,6 +63,12 @@ class HostEntity(BaseEntity):
         view = self.navigate_to(self, 'All')
         return view.search(value)
 
+    def host_status(self, value):
+        """Get Host status"""
+        view = self.navigate_to(self, 'All')
+        view.search(value)
+        return view.browser.element(view.host_status).get_attribute('data-original-title')
+
     def get_details(self, entity_name, widget_names=None):
         """Read host values from Host Details page, optionally only the widgets in widget_names
         will be read.

--- a/airgun/views/host.py
+++ b/airgun/views/host.py
@@ -209,6 +209,7 @@ class HostsView(BaseLoggedInView, SearchableViewMixin):
             'Actions': ActionsDropdown("./div[contains(@class, 'btn-group')]"),
         },
     )
+    host_status = "//span[contains(@class, 'host-status')]"
     actions = ActionsDropdown("//div[@id='submit_multiple']")
 
     @property


### PR DESCRIPTION
This PR adds support for reading host status.
Host status is the one you see when you hover over icon before hostname on "All Hosts" page.