### PR TITLE
Add generic wt exceptions import to airgun.exceptions

### DIFF
--- a/airgun/exceptions.py
+++ b/airgun/exceptions.py
@@ -1,5 +1,6 @@
 """Exceptions raised by airgun"""
 from selenium.common.exceptions import InvalidElementStateException
+from widgetastic.exceptions import *  # noqa: F403, F401
 
 
 class ReadOnlyWidgetError(Exception):


### PR DESCRIPTION
Allows for import of wt.exceptions classes/module attrs directly through
airgun