### PR TITLE
70 UI host test fix

### DIFF
--- a/airgun/entities/host.py
+++ b/airgun/entities/host.py
@@ -97,11 +97,9 @@ class HostEntity(BaseEntity):
         view = self.navigate_to(self, 'All')
         view.search(entity_name)
         view.table.row(name=entity_name)['Actions'].widget.fill('Delete')
-        alert_message = self.browser.get_alert().text
-        self.browser.handle_alert(cancel=cancel)
+        view.dialog.confirm()
         view.flash.assert_no_error()
         view.flash.dismiss()
-        return alert_message
 
     def delete_interface(self, entity_name, interface_id):
         """Delete host network interface.
@@ -330,6 +328,10 @@ class ShowHostDetails(NavigateStep):
         entity_name = kwargs.get('entity_name')
         self.parent.search(entity_name)
         self.parent.table.row(name=entity_name)['Name'].widget.click()
+        host_view = NewHostDetailsView(self.parent.browser)
+        host_view.wait_displayed()
+        host_view.dropdown.wait_displayed()
+        host_view.dropdown.item_select('Legacy UI')
 
 
 @navigator.register(HostEntity, 'Edit')

--- a/airgun/views/host.py
+++ b/airgun/views/host.py
@@ -34,6 +34,7 @@ from airgun.widgets import FilteredDropdown
 from airgun.widgets import GenericRemovableWidgetItem
 from airgun.widgets import Link
 from airgun.widgets import MultiSelect
+from airgun.widgets import Pf4ConfirmationDialog
 from airgun.widgets import PuppetClassesMultiSelect
 from airgun.widgets import RadioGroup
 from airgun.widgets import RemovableWidgetsItemsListView
@@ -212,6 +213,7 @@ class HostsView(BaseLoggedInView, SearchableViewMixin):
     )
     host_status = "//span[contains(@class, 'host-status')]"
     actions = ActionsDropdown("//div[@id='submit_multiple']")
+    dialog = Pf4ConfirmationDialog()
 
     @property
     def is_displayed(self):

--- a/airgun/views/host_new.py
+++ b/airgun/views/host_new.py
@@ -78,7 +78,7 @@ class NewHostDetailsView(BaseLoggedInView):
 
     @View.nested
     class Traces(Tab):
-        enable_traces = Button('Enable Traces')
+        enable_traces = Button('OUIA-Generated-Button-primary-1')
 
     @View.nested
     class RepositorySets(Tab):


### PR DESCRIPTION
this branch is build up on #673 
before you review, please look at  #673 

the old UI host details tests are now using new UI -> dropdown -> legacy UI 
dialog = Pf4ConfirmationDialog()

this is introducing 
Robottelo [PR](https://github.com/SatelliteQE/robottelo/pull/9401)

