### PR TITLE
6.9.z backports 

### DIFF
--- a/airgun/browser.py
+++ b/airgun/browser.py
@@ -174,9 +174,6 @@ class SeleniumBrowserFactory:
         manager = BrowserManager.from_conf(self.web_kaifuku)
         self._webdriver = manager.start()
         self._set_session_cookie()
-        idle_timeout = desired_capabilities['idletimeout']
-        if idle_timeout:
-            self._webdriver.command_executor.set_timeout(int(idle_timeout))
         return self._webdriver
 
 

--- a/airgun/exceptions.py
+++ b/airgun/exceptions.py
@@ -1,5 +1,6 @@
 """Exceptions raised by airgun"""
 from selenium.common.exceptions import InvalidElementStateException
+from widgetastic.exceptions import *  # noqa: F403, F401
 
 
 class ReadOnlyWidgetError(Exception):

--- a/airgun/exceptions.py
+++ b/airgun/exceptions.py
@@ -1,4 +1,5 @@
 """Exceptions raised by airgun"""
+from selenium.common.exceptions import InvalidElementStateException
 
 
 class ReadOnlyWidgetError(Exception):
@@ -11,3 +12,6 @@ class DisabledWidgetError(Exception):
 
 class DestinationNotReachedError(Exception):
     """Raised when navigation destination view was not reached (not dispayed)."""
+
+
+__all__ = ["InvalidElementStateException"]

--- a/setup.py
+++ b/setup.py
@@ -20,12 +20,11 @@ setup(
         'fauxfactory',
         'navmazing',
         'pytest',
-        'selenium',
         'wait_for',
         'webdriver-kaifuku',
         'widgetastic.core',
         'widgetastic.patternfly',
-        'widgetastic.patternfly4',
+        'widgetastic.patternfly4 @ git+https://github.com/RedHatQE/widgetastic.patternfly4.git@selenium4#egg=widgetastic.patternfly4',  # noqa
     ],
     packages=find_packages(exclude=['tests*']),
     package_data={'': ['LICENSE']},


### PR DESCRIPTION
This is a series of cherry-picks (most of which look to have already been included) that should hopefully bring our 6.9.z branch up-to-date with what is needed to run against Selenium Grid 4. Let me know if there is anything else needed.