### PR TITLE
Moved delete confirmation dialog to common.py

### DIFF
--- a/airgun/entities/location.py
+++ b/airgun/entities/location.py
@@ -26,7 +26,7 @@ class LocationEntity(BaseEntity):
         view = self.navigate_to(self, 'All')
         view.search(entity_name)
         view.table.row(name=entity_name)['Actions'].widget.fill('Delete')
-        self.browser.handle_alert()
+        view.dialog.confirm()
         view.flash.assert_no_error()
         view.flash.dismiss()
 

--- a/airgun/views/common.py
+++ b/airgun/views/common.py
@@ -21,6 +21,7 @@ from airgun.widgets import FilteredDropdown
 from airgun.widgets import GenericRemovableWidgetItem
 from airgun.widgets import ItemsList
 from airgun.widgets import LCESelector
+from airgun.widgets import Pf4ConfirmationDialog
 from airgun.widgets import ProgressBar
 from airgun.widgets import ReadOnlyEntry
 from airgun.widgets import SatFlashMessages
@@ -40,6 +41,7 @@ class BaseLoggedInView(View):
     taxonomies = ContextSelector()
     flash = SatFlashMessages()
     validations = ValidationErrors()
+    dialog = Pf4ConfirmationDialog()
     logout = Text("//a[@href='/users/logout']")
     current_user = Dropdown('OUIA-Generated-Dropdown-1')
     account_menu = Dropdown('OUIA-Generated-Dropdown-1')

--- a/airgun/views/http_proxy.py
+++ b/airgun/views/http_proxy.py
@@ -8,7 +8,6 @@ from airgun.views.common import BaseLoggedInView
 from airgun.views.common import SatTab
 from airgun.views.common import SearchableViewMixin
 from airgun.widgets import MultiSelect
-from airgun.widgets import Pf4ConfirmationDialog
 
 
 class HTTPProxyView(BaseLoggedInView, SearchableViewMixin):
@@ -22,7 +21,6 @@ class HTTPProxyView(BaseLoggedInView, SearchableViewMixin):
             'Actions': Text(".//a[@data-method='delete']"),
         },
     )
-    dialog = Pf4ConfirmationDialog()
 
     @property
     def is_displayed(self):

--- a/airgun/views/organization.py
+++ b/airgun/views/organization.py
@@ -12,7 +12,6 @@ from airgun.widgets import ActionsDropdown
 from airgun.widgets import CustomParameter
 from airgun.widgets import FilteredDropdown
 from airgun.widgets import MultiSelect
-from airgun.widgets import Pf4ConfirmationDialog
 
 
 class OrganizationsView(BaseLoggedInView, SearchableViewMixin):
@@ -25,7 +24,6 @@ class OrganizationsView(BaseLoggedInView, SearchableViewMixin):
             'Actions': ActionsDropdown("./div[contains(@class, 'btn-group')]"),
         },
     )
-    dialog = Pf4ConfirmationDialog()
 
     @property
     def is_displayed(self):

--- a/airgun/views/oscapcontent.py
+++ b/airgun/views/oscapcontent.py
@@ -9,7 +9,6 @@ from airgun.views.common import SatTab
 from airgun.views.common import SearchableViewMixin
 from airgun.widgets import ActionsDropdown
 from airgun.widgets import MultiSelect
-from airgun.widgets import Pf4ConfirmationDialog
 from airgun.widgets import SatTable
 
 
@@ -23,7 +22,6 @@ class SCAPContentsView(BaseLoggedInView, SearchableViewMixin):
             'Actions': ActionsDropdown("./div[contains(@class, 'btn-group')]"),
         },
     )
-    dialog = Pf4ConfirmationDialog()
 
     @property
     def is_displayed(self):

--- a/airgun/views/oscappolicy.py
+++ b/airgun/views/oscappolicy.py
@@ -12,7 +12,6 @@ from airgun.views.dashboard import TotalCount
 from airgun.widgets import ActionsDropdown
 from airgun.widgets import FilteredDropdown
 from airgun.widgets import MultiSelect
-from airgun.widgets import Pf4ConfirmationDialog
 from airgun.widgets import RadioGroup
 from airgun.widgets import SatTable
 
@@ -27,7 +26,6 @@ class SCAPPoliciesView(BaseLoggedInView, SearchableViewMixin):
             'Actions': ActionsDropdown("./div[contains(@class, 'btn-group')]"),
         },
     )
-    dialog = Pf4ConfirmationDialog()
 
     @property
     def is_displayed(self):

--- a/airgun/views/oscaptailoringfile.py
+++ b/airgun/views/oscaptailoringfile.py
@@ -10,7 +10,6 @@ from airgun.views.common import SatTab
 from airgun.views.common import SearchableViewMixin
 from airgun.widgets import ActionsDropdown
 from airgun.widgets import MultiSelect
-from airgun.widgets import Pf4ConfirmationDialog
 
 
 class SCAPTailoringFilesView(BaseLoggedInView, SearchableViewMixin):
@@ -23,7 +22,6 @@ class SCAPTailoringFilesView(BaseLoggedInView, SearchableViewMixin):
             'Actions': ActionsDropdown("./div[contains(@class, 'btn-group')]"),
         },
     )
-    dialog = Pf4ConfirmationDialog()
 
     @property
     def is_displayed(self):


### PR DESCRIPTION
PF4 confirmation dialog is common across the components so moving confirmation dialog to common.py 

Components impacted:
1. Organization
2. Http proxy
3. Oscatailoringfile
4. oscapcontent
5. oscappolicy
