### PR TITLE
Do not crop schema off of filepath. It is not there anymore.

### DIFF
--- a/airgun/browser.py
+++ b/airgun/browser.py
@@ -342,7 +342,11 @@ class AirgunBrowser(Browser):
         )
 
         # it must be local absolute path, without protocol
-        elem.send_keys(unquote(uri[7:]))
+        # In some version <= 98, this changed so schema is not included in the path
+        if 'file://' in uri or 'http://' in uri:
+            elem.send_keys(unquote(uri[7:]))
+        else:
+            elem.send_keys(unquote(uri))
 
         result = self.selenium.execute_async_script(
             "var input = arguments[0], callback = arguments[1]; "


### PR DESCRIPTION
```
$ pytest tests/foreman/ui/test_reporttemplates.py::test_positive_end_to_end
======================================== test session starts ========================================
platform linux -- Python 3.8.5, pytest-6.2.5, py-1.10.0, pluggy-0.13.1 -- /home/lhellebr/broker/venv/bin/python
cachedir: .pytest_cache
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/lhellebr/git/robottelo, configfile: pytest.ini
plugins: ibutsu-2.0.2, services-2.2.1, xdist-2.5.0, forked-1.3.0, reportportal-5.0.11, mock-3.6.1
collected 1 item                                                                                    

tests/foreman/ui/test_reporttemplates.py::test_positive_end_to_end git branch
PASSED                     [100%]

========================================= warnings summary ==========================================
tests/foreman/ui/test_reporttemplates.py::test_positive_end_to_end
tests/foreman/ui/test_reporttemplates.py::test_positive_end_to_end
tests/foreman/ui/test_reporttemplates.py::test_positive_end_to_end
tests/foreman/ui/test_reporttemplates.py::test_positive_end_to_end
tests/foreman/ui/test_reporttemplates.py::test_positive_end_to_end
tests/foreman/ui/test_reporttemplates.py::test_positive_end_to_end
  /home/lhellebr/broker/venv/lib/python3.8/site-packages/urllib3/connectionpool.py:1043: InsecureRequestWarning: Unverified HTTPS request is being made to host 'dhcp-3-47.vms.sat.rdu2.redhat.com'. Adding certificate verification is strongly advised. See: https://urllib3.readthedocs.io/en/1.26.x/advanced-usage.html#ssl-warnings
    warnings.warn(

tests/foreman/ui/test_reporttemplates.py::test_positive_end_to_end
  /home/lhellebr/broker/venv/lib/python3.8/site-packages/webdriver_kaifuku/tries.py:33: DeprecationWarning: desired_capabilities has been deprecated, please pass in an Options object with options kwarg
    return f(*args, **kwargs)

tests/foreman/ui/test_reporttemplates.py::test_positive_end_to_end
  /home/lhellebr/broker/venv/lib/python3.8/site-packages/widgetastic/browser.py:260: DeprecationWarning: desired_capabilities is deprecated. Please call capabilities.
    version = self.selenium.desired_capabilities.get("browserVersion")

-- Docs: https://docs.pytest.org/en/stable/warnings.html
============================ 1 passed, 8 warnings in 1545.93s (0:25:45) =============================

```