### PR TITLE
Add delete confirmation dialog on virtwhopluginConfigure

### DIFF
--- a/airgun/views/virtwho_configure.py
+++ b/airgun/views/virtwho_configure.py
@@ -15,7 +15,6 @@ from airgun.views.common import SatTab
 from airgun.views.common import SearchableViewMixin
 from airgun.widgets import ActionsDropdown
 from airgun.widgets import FilteredDropdown
-from airgun.widgets import Pf4ConfirmationDialog
 
 
 class VirtwhoConfigureStatus(GenericLocatorWidget):
@@ -112,7 +111,6 @@ class VirtwhoConfiguresView(BaseLoggedInView, SearchableViewMixin):
             'Actions': ActionsDropdown("./div[contains(@class, 'btn-group')]"),
         },
     )
-    dialog = Pf4ConfirmationDialog()
 
     @property
     def is_displayed(self):


### PR DESCRIPTION
**Add delete confirmation dialog on virtwhopluginConfigure**

Robottelo TestCases Run：
```
(robottelo_vv) [yanpliu@yanpliu robottelo]$ pytest tests/foreman/virtwho/ui/test_libvirt.py  -k test_positive_deploy_configure_by_id  
=============================================================================================== test session starts ===============================================================================================
platform linux -- Python 3.8.12, pytest-7.1.1, pluggy-1.0.0
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/yanpliu/gitrepo/robottelo, configfile: pyproject.toml
plugins: services-2.2.1, reportportal-5.0.12, mock-3.7.0, ibutsu-2.0.2, forked-1.4.0, xdist-2.5.0, cov-3.0.0, metadata-1.11.0, html-3.1.1
collected 3 items / 5 deselected / -2 selected                                                                                                                                                                    

tests/foreman/virtwho/ui/test_libvirt.py .                                                                                                                                                                  [100%]

================================================================================================ warnings summary =================================================================================================
../../data/virtualenv_38/robottelo_vv/lib/python3.8/site-packages/swiftclient/client.py:84
../../data/virtualenv_38/robottelo_vv/lib/python3.8/site-packages/swiftclient/client.py:84
  /home/yanpliu/data/virtualenv_38/robottelo_vv/lib/python3.8/site-packages/swiftclient/client.py:84: DeprecationWarning: distutils Version classes are deprecated. Use packaging.version instead.
    if StrictVersion(requests.__version__) < StrictVersion('2.0.0') \

tests/foreman/virtwho/ui/test_libvirt.py::TestVirtwhoConfigforLibvirt::test_positive_deploy_configure_by_id
tests/foreman/virtwho/ui/test_libvirt.py::TestVirtwhoConfigforLibvirt::test_positive_deploy_configure_by_id
tests/foreman/virtwho/ui/test_libvirt.py::TestVirtwhoConfigforLibvirt::test_positive_deploy_configure_by_id
tests/foreman/virtwho/ui/test_libvirt.py::TestVirtwhoConfigforLibvirt::test_positive_deploy_configure_by_id
  /home/yanpliu/data/virtualenv_38/robottelo_vv/lib/python3.8/site-packages/urllib3/connectionpool.py:1043: InsecureRequestWarning: Unverified HTTPS request is being made to host 'intel-waimeabay-hedt-01.ml3.eng.bos.redhat.com'. Adding certificate verification is strongly advised. See: https://urllib3.readthedocs.io/en/1.26.x/advanced-usage.html#ssl-warnings
    warnings.warn(

tests/foreman/virtwho/ui/test_libvirt.py::TestVirtwhoConfigforLibvirt::test_positive_deploy_configure_by_id
  /home/yanpliu/data/virtualenv_38/robottelo_vv/lib/python3.8/site-packages/webdriver_kaifuku/tries.py:33: DeprecationWarning: executable_path has been deprecated, please pass in a Service object
    return f(*args, **kwargs)

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
============================================================================= 1 passed, 5 deselected, 7 warnings in 112.07s (0:01:52) ====
```