### PR TITLE
Use SatTable instead of Table for the LatestErrata widget

### DIFF
--- a/airgun/views/dashboard.py
+++ b/airgun/views/dashboard.py
@@ -162,7 +162,7 @@ class DashboardView(BaseLoggedInView):
     @View.nested
     class LatestErrata(View):
         ROOT = ".//li[@data-name='Latest Errata']"
-        erratas = Table('.//table')
+        erratas = SatTable('.//table')
 
     @View.nested
     class NewHosts(View):


### PR DESCRIPTION
Changed Table to SatTable to be able to read the table in the widget.

Associated robottelo PR: SatelliteQE/robottelo#9537