### PR TITLE
disable new host ui details by default

### DIFF
--- a/airgun/entities/host.py
+++ b/airgun/entities/host.py
@@ -26,7 +26,6 @@ from airgun.views.host import HostsJobInvocationStatusView
 from airgun.views.host import HostsUnassignCompliancePolicy
 from airgun.views.host import HostsView
 from airgun.views.host import RecommendationListView
-from airgun.views.host_new import NewHostDetailsView
 
 
 class HostEntity(BaseEntity):
@@ -40,7 +39,7 @@ class HostEntity(BaseEntity):
         view.fill(values)
         self.browser.click(view.submit, ignore_ajax=True)
         self.browser.plugin.ensure_page_safe(timeout='600s')
-        host_view = NewHostDetailsView(self.browser)
+        host_view = HostDetailsView(self.browser)
         host_view.wait_displayed()
         host_view.flash.assert_no_error()
         host_view.flash.dismiss()
@@ -328,10 +327,6 @@ class ShowHostDetails(NavigateStep):
         entity_name = kwargs.get('entity_name')
         self.parent.search(entity_name)
         self.parent.table.row(name=entity_name)['Name'].widget.click()
-        host_view = NewHostDetailsView(self.parent.browser)
-        host_view.wait_displayed()
-        host_view.dropdown.wait_displayed()
-        host_view.dropdown.item_select('Legacy UI')
 
 
 @navigator.register(HostEntity, 'Edit')

--- a/airgun/entities/host_new.py
+++ b/airgun/entities/host_new.py
@@ -5,6 +5,17 @@ from airgun.views.host_new import NewHostDetailsView
 
 
 class NewHostEntity(HostEntity):
+    def create(self, values):
+        """Create new host entity"""
+        view = self.navigate_to(self, 'New')
+        view.fill(values)
+        self.browser.click(view.submit, ignore_ajax=True)
+        self.browser.plugin.ensure_page_safe(timeout='600s')
+        host_view = NewHostDetailsView(self.browser)
+        host_view.wait_displayed()
+        host_view.flash.assert_no_error()
+        host_view.flash.dismiss()
+
     def get_details(self, entity_name, widget_names=None):
         """Read host values from Host Details page, optionally only the widgets in widget_names
         will be read.


### PR DESCRIPTION
Adressed #695.

in 6.11 the new host details are disabled by default, this PR should be re-added for 6.12

I can manually change it in 6.11 for all host modules so the change without this PR fix would work, but I want to have a 1:1 setup with customers. 

I run two tests from this [PR](https://github.com/SatelliteQE/robottelo/pull/9553 ) one using old and one that is using new host details 

```
tests/foreman/ui/test_host.py::test_positive_read_from_details_page
tests/foreman/ui/test_host.py::test_positive_read_details_page_from_new_ui[host_details_ui]
=========== 2 passed, 40 deselected, 5 warnings in 262.28s (0:04:22) ===========
```