### PR TITLE
nutanix support on airgun

### DIFF
--- a/airgun/entities/virtwho_configure.py
+++ b/airgun/entities/virtwho_configure.py
@@ -21,6 +21,7 @@ class VirtwhoConfigureEntity(BaseEntity):
             'rhevm': 'Red Hat Virtualization Hypervisor (rhevm)',
             'libvirt': 'libvirt',
             'kubevirt': 'Container-native virtualization',
+            'ahv': 'Nutanix AHV (ahv)',
         }
         vals = values.copy()
         if 'hypervisor_type' in vals:

--- a/airgun/views/virtwho_configure.py
+++ b/airgun/views/virtwho_configure.py
@@ -150,6 +150,14 @@ class VirtwhoConfigureCreateView(BaseLoggedInView):
         server = TextInput(id='foreman_virt_who_configure_config_hypervisor_server')
         kubeconfig = TextInput(id='foreman_virt_who_configure_config_kubeconfig_path')
 
+    @hypervisor_content.register('Nutanix AHV (ahv)')
+    class NutanixForm(View):
+        server = TextInput(id='foreman_virt_who_configure_config_hypervisor_server')
+        username = TextInput(id='foreman_virt_who_configure_config_hypervisor_username')
+        password = TextInput(id='foreman_virt_who_configure_config_hypervisor_password')
+        prism_flavor = FilteredDropdown(id='foreman_virt_who_configure_config_prism_flavor')
+        filtering_content = ConditionalSwitchableView(reference='prism_flavor')
+
     @filtering_content.register('Unlimited', default=True)
     class FilterUnlimitedForm(View):
         pass
@@ -219,6 +227,7 @@ class VirtwhoConfigureDetailsView(BaseLoggedInView):
         proxy = Text('.//span[contains(@class,"config-http_proxy_id")]')
         no_proxy = Text('.//span[contains(@class,"config-no_proxy")]')
         kubeconfig_path = Text('.//span[contains(@class,"config-kubeconfig_path")]')
+        prism_flavor = Text('.//span[contains(@class,"config-prism_flavor")]')
 
         _label_locator = (
             "//span[contains(@class, '{class_name}')]/../preceding-sibling::div/strong"
@@ -247,6 +256,7 @@ class VirtwhoConfigureDetailsView(BaseLoggedInView):
         proxy_label = Text(_label_locator.format(class_name="config-http_proxy_id"))
         no_proxy_label = Text(_label_locator.format(class_name="config-no_proxy"))
         kubeconfig_path_label = Text(_label_locator.format(class_name="config-kubeconfig_path"))
+        prism_flavor_label = Text(_label_locator.format(class_name="config-prism_flavor"))
 
     @View.nested
     class deploy(SatTab):


### PR DESCRIPTION
Hey,
Add nutanix support on airgun.

Nutanix cases: PASS
```
(robottelo_vv) [yanpliu@yanpliu robottelo]$ pytest ./tests/foreman/virtwho/ui/test_nutanix.py -k test_positive_deploy_configure_by_id
=============================================================================================== test session starts ===============================================================================================
platform linux -- Python 3.8.12, pytest-7.1.2, pluggy-1.0.0
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/yanpliu/gitrepo/robottelo, configfile: pyproject.toml
plugins: services-2.2.1, ibutsu-2.0.2, forked-1.4.0, xdist-2.5.0, cov-3.0.0, metadata-1.11.0, html-3.1.1, mock-3.7.0, reportportal-5.0.12
collected 3 items / 5 deselected / -2 selected                                                                                                                                                                    

tests/foreman/virtwho/ui/test_nutanix.py .                                                                                                                                                                  [100%]

================================================================================================ warnings summary =================================================================================================
../../data/virtualenv_38/robottelo_vv/lib/python3.8/site-packages/swiftclient/client.py:84
../../data/virtualenv_38/robottelo_vv/lib/python3.8/site-packages/swiftclient/client.py:84
  /home/yanpliu/data/virtualenv_38/robottelo_vv/lib/python3.8/site-packages/swiftclient/client.py:84: DeprecationWarning: distutils Version classes are deprecated. Use packaging.version instead.
    if StrictVersion(requests.__version__) < StrictVersion('2.0.0') \

tests/foreman/virtwho/ui/test_nutanix.py::TestVirtwhoConfigforNutanix::test_positive_deploy_configure_by_id
tests/foreman/virtwho/ui/test_nutanix.py::TestVirtwhoConfigforNutanix::test_positive_deploy_configure_by_id
tests/foreman/virtwho/ui/test_nutanix.py::TestVirtwhoConfigforNutanix::test_positive_deploy_configure_by_id
tests/foreman/virtwho/ui/test_nutanix.py::TestVirtwhoConfigforNutanix::test_positive_deploy_configure_by_id
  /home/yanpliu/data/virtualenv_38/robottelo_vv/lib/python3.8/site-packages/urllib3/connectionpool.py:1043: InsecureRequestWarning: Unverified HTTPS request is being made to host 'dell-per740-68-vm-03.lab.eng.pek2.redhat.com'. Adding certificate verification is strongly advised. See: https://urllib3.readthedocs.io/en/1.26.x/advanced-usage.html#ssl-warnings
    warnings.warn(

tests/foreman/virtwho/ui/test_nutanix.py::TestVirtwhoConfigforNutanix::test_positive_deploy_configure_by_id
  /home/yanpliu/data/virtualenv_38/robottelo_vv/lib/python3.8/site-packages/webdriver_kaifuku/tries.py:33: DeprecationWarning: desired_capabilities has been deprecated, please pass in an Options object with options kwarg
    return f(*args, **kwargs)

tests/foreman/virtwho/ui/test_nutanix.py::TestVirtwhoConfigforNutanix::test_positive_deploy_configure_by_id
tests/foreman/virtwho/ui/test_nutanix.py::TestVirtwhoConfigforNutanix::test_positive_deploy_configure_by_id
tests/foreman/virtwho/ui/test_nutanix.py::TestVirtwhoConfigforNutanix::test_positive_deploy_configure_by_id
tests/foreman/virtwho/ui/test_nutanix.py::TestVirtwhoConfigforNutanix::test_positive_deploy_configure_by_id
  /home/yanpliu/data/virtualenv_38/robottelo_vv/lib/python3.8/site-packages/widgetastic/browser.py:260: DeprecationWarning: desired_capabilities is deprecated. Please call capabilities.
    version = self.selenium.desired_capabilities.get("browserVersion")

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
============================================================================ 1 passed, 5 deselected, 11 warnings in 588.61s (0:09:48) =============================================================================
(
```