### PR TITLE
Fixing DiscoveryPlugin failures

### DIFF
--- a/airgun/entities/discoveredhosts.py
+++ b/airgun/entities/discoveredhosts.py
@@ -118,6 +118,13 @@ class DiscoveredHostsEntity(BaseEntity):
             self, 'Select Action', action_name=action_name, entities_list=entities_list
         )
         view.fill(values)
+        wait_for(
+            lambda: view.submit.disabled,
+            fail_condition=True,
+            timeout=10,
+            delay=0.2,
+            logger=view.logger,
+        )
         view.submit.click()
         view.flash.assert_no_error()
         view.flash.dismiss()

--- a/airgun/entities/discoveryrule.py
+++ b/airgun/entities/discoveryrule.py
@@ -1,4 +1,5 @@
 from navmazing import NavigateToSibling
+from widgetastic.exceptions import NoSuchElementException
 
 from airgun.entities.base import BaseEntity
 from airgun.navigation import NavigateStep
@@ -137,7 +138,10 @@ class AddNewDiscoveryRule(NavigateStep):
     prerequisite = NavigateToSibling('All')
 
     def step(self, *args, **kwargs):
-        self.parent.browser.click(self.parent.new)
+        try:
+            self.parent.new.click()
+        except NoSuchElementException:
+            self.parent.new_on_blank_page.click()
 
 
 @navigator.register(DiscoveryRuleEntity, 'Edit')

--- a/airgun/views/discoveredhosts.py
+++ b/airgun/views/discoveredhosts.py
@@ -5,6 +5,7 @@ from widgetastic.widget import TableColumn
 from widgetastic.widget import TableRow
 from widgetastic.widget import Text
 from widgetastic_patternfly import BreadCrumb
+from widgetastic_patternfly import Button
 
 from airgun.views.common import BaseLoggedInView
 from airgun.views.common import SearchableViewMixin
@@ -137,7 +138,7 @@ class DiscoveredHostsActionDialog(BaseLoggedInView):
 
     title = None
     table = SatTable("//div[@class='modal-body']//table")
-    submit = Text("//button[@onclick='tfm.hosts.table.submitModalForm()']")
+    submit = Button("Submit")
 
     @property
     def is_displayed(self):

--- a/airgun/views/discoveryrule.py
+++ b/airgun/views/discoveryrule.py
@@ -3,6 +3,7 @@ from widgetastic.widget import Text
 from widgetastic.widget import TextInput
 from widgetastic.widget import View
 from widgetastic_patternfly import BreadCrumb
+from widgetastic_patternfly4 import Button as PF4Button
 
 from airgun.views.common import BaseLoggedInView
 from airgun.views.common import SatTab
@@ -16,6 +17,7 @@ from airgun.widgets import SatTable
 class DiscoveryRulesView(BaseLoggedInView):
     title = Text("//h1[text()='Discovery Rules']")
     new = Text("//a[contains(@href, '/discovery_rules/new')]")
+    new_on_blank_page = PF4Button('Create Rule')
     table = SatTable(
         './/table',
         column_widgets={


### PR DESCRIPTION
In the new UI, the Discovery Rules page has a different Create button depending on if there are any rules yet or not. My updates made a simple change to address this. I also added a `wait_for` during an Auto Provision dialog step in Discovered Hosts, since one of my tests was failing due to the dialog not submitting properly.