### PR TITLE
fix the locator issue in action drop down

### DIFF
--- a/airgun/widgets.py
+++ b/airgun/widgets.py
@@ -566,8 +566,8 @@ class ActionsDropdown(GenericLocatorWidget):
     )
     pf4_drop_down = Dropdown('OUIA-Generated-Dropdown-2')
     button = Text(
-        "//*[self::button or self::span][contains(@class, 'btn')]"
-        "[contains(@aria-label, 'search button')]"
+        ".//*[self::button or self::span][contains(@class, 'btn') or "
+        "contains(@aria-label, 'search button')]"
         "[not(*[self::span or self::i][contains(@class, 'caret')])]"
     )
     ITEMS_LOCATOR = './/ul/li/a'


### PR DESCRIPTION
- Remove the redundant `self.open` as `self.items` has that step
- Fixed the correct locator here (https://github.com/SatelliteQE/airgun/pull/711/files#diff-b6d36691d2c9b246c1a2f7fff90473fe0098b4a6846694417e9acc246e35ea30R569) because of this line commit  

@vsedmik Can you please test your changes as well as 1 bookmark test passes with this change.  (from my side it looks okay)