### PR TITLE
Fixing AutoCompleteTextInput blur

### DIFF
--- a/airgun/widgets.py
+++ b/airgun/widgets.py
@@ -2138,7 +2138,7 @@ class AutoCompleteTextInput(TextInput):
         self.clear()
         super().fill(value)
         self.browser.plugin.ensure_page_safe()
-        self.browser.execute_script('arguments[0].blur();', self.__element__())
+        self.browser.send_keys_to_focused_element('\t')
         return self.value != old_value
 
 


### PR DESCRIPTION
The `foreman_autocomplete` component has different behavior in 6.11 where once you finish typing the search, the dropdown stays open even if you run `<element>.blur()`. Replacing this with a tab makes sure the element is out of focus. Tested on 6.10 and 6.11 and it seems to work. Waiting for https://github.com/SatelliteQE/airgun/pull/716 to be merged and I will test this change on the DiscoveryPlugin pipeline.