### PR TITLE
Adding Webhooks CRUD

### DIFF
--- a/airgun/entities/webhook.py
+++ b/airgun/entities/webhook.py
@@ -1,0 +1,134 @@
+from navmazing import NavigateToSibling
+from widgetastic.exceptions import NoSuchElementException
+
+from airgun.entities.base import BaseEntity
+from airgun.navigation import NavigateStep
+from airgun.navigation import navigator
+from airgun.utils import retry_navigation
+from airgun.views.webhook import DeleteWebhookConfirmationView
+from airgun.views.webhook import WebhookCreateView
+from airgun.views.webhook import WebhookEditView
+from airgun.views.webhook import WebhooksView
+
+
+class WebhookEntity(BaseEntity):
+    endpoint_path = '/webhooks'
+
+    def create(self, values):
+        """Create new Webhook
+
+        :param values: Parameters to be assigned to a Webhook,
+            Name, Subscribe to, Target URL, Template and HTTP Method should be provided
+        """
+        view = self.navigate_to(self, 'New')
+        view.wait_for_popup()
+        view.fill(values)
+        view.submit_button.click()
+        view.flash.assert_no_error()
+        view.flash.dismiss()
+
+    def delete(self, entity_name):
+        """Delete corresponding Webhook
+
+        :param str entity_name: name of the corresponding Webhook
+        """
+        view = self.navigate_to(self, 'Delete', entity_name=entity_name)
+        view.wait_animation_end()
+        view.delete_button.click()
+        view.flash.assert_no_error()
+        view.flash.dismiss()
+
+    def search(self, entity_name):
+        """Search for a specific Webhook"""
+        view = self.navigate_to(self, 'All')
+        return view.search(entity_name)
+
+    def read(self, entity_name, widget_names=None):
+        """Reads content of corresponding Webhook
+
+        :param str entity_name: name of the corresponding Webhook
+        :return: dict representing tabs, with nested dicts representing fields
+            and values
+        """
+        view = self.navigate_to(self, 'Edit', entity_name=entity_name)
+        view.wait_for_popup()
+        result = view.read(widget_names=widget_names)
+        view.cancel_button.click()
+        return result
+
+    def update(self, entity_name, values):
+        """Update existing Webhook
+
+        :param str entity_name: name of the corresponding Webhook
+        :param values: parameters to be changed at Webhook
+        """
+        view = self.navigate_to(self, 'Edit', entity_name=entity_name)
+        view.wait_for_popup()
+        view.fill(values)
+        view.submit_button.click()
+        view.flash.assert_no_error()
+        view.flash.dismiss()
+
+
+@navigator.register(WebhookEntity, 'All')
+class ShowAllWebhooks(NavigateStep):
+    """Navigate to All Webhooks screen."""
+
+    VIEW = WebhooksView
+
+    @retry_navigation
+    def step(self, *args, **kwargs):
+        self.view.menu.select('Administer', 'Webhooks')
+
+
+@navigator.register(WebhookEntity, 'New')
+class AddNewWebhook(NavigateStep):
+    """Navigate to Create Webhook page."""
+
+    VIEW = WebhookCreateView
+
+    prerequisite = NavigateToSibling('All')
+
+    def step(self, *args, **kwargs):
+        try:
+            self.parent.new.click()
+        except NoSuchElementException:
+            self.parent.new_on_blank_page.click()
+
+
+@navigator.register(WebhookEntity, 'Edit')
+class EditWebhook(NavigateStep):
+    """Navigate to Edit Webhook page.
+
+    Args:
+        entity_name: name of the Webhook
+    """
+
+    VIEW = WebhookEditView
+
+    def prerequisite(self, *args, **kwargs):
+        return self.navigate_to(self.obj, 'All')
+
+    def step(self, *args, **kwargs):
+        entity_name = kwargs.get('entity_name')
+        self.parent.search(entity_name)
+        self.parent.table.row(name=entity_name)['Name'].widget.click()
+
+
+@navigator.register(WebhookEntity, 'Delete')
+class DeleteWebhook(NavigateStep):
+    """Search for Webhook and confirm deletion in dialog.
+
+    Args:
+        entity_name: name of the Webhook
+    """
+
+    VIEW = DeleteWebhookConfirmationView
+
+    def prerequisite(self, *args, **kwargs):
+        return self.navigate_to(self.obj, 'All')
+
+    def step(self, *args, **kwargs):
+        entity_name = kwargs.get('entity_name')
+        self.parent.search(entity_name)
+        self.parent.table.row(name=entity_name)['Actions'].widget.click()

--- a/airgun/session.py
+++ b/airgun/session.py
@@ -77,6 +77,7 @@ from airgun.entities.task import TaskEntity
 from airgun.entities.user import UserEntity
 from airgun.entities.usergroup import UserGroupEntity
 from airgun.entities.virtwho_configure import VirtwhoConfigureEntity
+from airgun.entities.webhook import WebhookEntity
 from airgun.navigation import Navigate
 from airgun.navigation import navigator
 
@@ -643,3 +644,8 @@ class Session:
     def virtwho_configure(self):
         """Instance of Virtwho Configure entity."""
         return self._open(VirtwhoConfigureEntity)
+
+    @cached_property
+    def webhook(self):
+        """Instance of Webhook entity."""
+        return self._open(WebhookEntity)

--- a/airgun/views/webhook.py
+++ b/airgun/views/webhook.py
@@ -1,0 +1,119 @@
+from wait_for import wait_for
+from widgetastic.widget import Checkbox
+from widgetastic.widget import Text
+from widgetastic.widget import TextInput
+from widgetastic.widget import View
+from widgetastic_patternfly import Button
+from widgetastic_patternfly4 import Button as PF4Button
+from widgetastic_patternfly4 import Tab
+
+from airgun.views.common import BaseLoggedInView
+from airgun.views.common import SearchableViewMixin
+from airgun.widgets import AutoCompleteTextInput
+from airgun.widgets import SatTable
+
+
+class WebhooksView(BaseLoggedInView, SearchableViewMixin):
+    title = Text("//h1[normalize-space(.)='Webhooks']")
+    new = Button('Create Webhook')
+    new_on_blank_page = PF4Button('Create Webhook')
+    table = SatTable(
+        './/table',
+        column_widgets={
+            'Name': Text('//span[@type="button"]'),
+            'Actions': Button('Delete'),
+        },
+    )
+
+    @property
+    def is_displayed(self):
+        return self.browser.wait_for_element(self.title, exception=False) is not None
+
+
+class WebhookCreateView(BaseLoggedInView):
+    ROOT = '//div[@role="dialog" and @tabindex][div//h4]'
+    cancel_button = Button('Cancel')
+    submit_button = Button('contains', 'Submit')
+
+    @View.nested
+    class general(Tab):
+        subscribe_to = AutoCompleteTextInput(
+            locator=(
+                "//div[@class='webhook-form-tab-content']"
+                "/div[label[normalize-space(.)='Subscribe to*']]/div/div/div/input"
+            )
+        )
+        name = TextInput(name="name")
+        target_url = TextInput(name="target_url")
+        template = AutoCompleteTextInput(
+            locator=(
+                "//div[@class='webhook-form-tab-content']"
+                "/div[label[normalize-space(.)='Template*']]/div/div/div/input"
+            )
+        )
+        http_method = AutoCompleteTextInput(
+            locator=(
+                "//div[@class='webhook-form-tab-content']"
+                "/div[label[normalize-space(.)='HTTP Method*']]/div/div/div/input"
+            )
+        )
+        enabled = Checkbox(name="enabled")
+
+    @View.nested
+    class credentials(Tab):
+        user = TextInput(name="user")
+        password = TextInput(name="password")
+        verify_ssl = Checkbox(name="verify_ssl")
+        capsule_auth = Checkbox(name="proxy_authorization")
+        certs = TextInput(name="ssl_ca_certs")
+
+    @View.nested
+    class additional(Tab):
+        content_type = TextInput(name="http_content_type")
+        headers = TextInput(name="http_headers")
+
+    @property
+    def is_displayed(self):
+        return self.browser.wait_for_element(
+            locator=self.cancel_button, visible=True, exception=True
+        ) is not None and 'in' in self.browser.classes(self)
+
+    def wait_for_popup(self):
+        is_popup_visible = self.browser.wait_for_element(
+            self.cancel_button, visible=True, exception=False
+        ) is not None and 'in' in self.browser.classes(self)
+        are_fields_visible = self.browser.wait_for_element(
+            self.general.subscribe_to, visible=True, exception=False
+        )
+        return is_popup_visible and are_fields_visible
+
+
+class WebhookEditView(WebhookCreateView):
+    @property
+    def is_displayed(self):
+        return self.browser.wait_for_element(
+            self.cancel_button, visible=True, exception=False
+        ) is not None and 'in' in self.browser.classes(self)
+
+
+class DeleteWebhookConfirmationView(BaseLoggedInView):
+    ROOT = (
+        '//div[@role="dialog" and @tabindex]'
+        '[div//h4[normalize-space(.)="Confirm Webhook Deletion"]]'
+    )
+    delete_button = Button('contains', 'Delete')
+    cancel_button = Button('Cancel')
+
+    @property
+    def is_displayed(self):
+        return self.browser.wait_for_element(
+            self.delete_button, visible=True, exception=False
+        ) is not None and 'in' in self.browser.classes(self)
+
+    def wait_animation_end(self):
+        wait_for(
+            lambda: 'in' in self.browser.classes(self),
+            handle_exception=True,
+            logger=self.logger,
+            timeout=10,
+        )

--- a/airgun/widgets.py
+++ b/airgun/widgets.py
@@ -2132,6 +2132,8 @@ class AutoCompleteTextInput(TextInput):
         """
         if self.clear_button.is_displayed:
             self.clear_button.click()
+        else:
+            self.browser.clear(self)
 
     def fill(self, value):
         old_value = self.value


### PR DESCRIPTION
Basic Create, Update, Read, and Delete functions added for Administer > Webhooks. There are no unique ids for the AutoCompleteTextInputs on the Create page, so I am searching for them based on their neighboring `<label>` elements right now. I will reach out to UX to get some unique ids for these, so we don't have to worry about new updates to the DOM. Because the Webhook create, update, and read is based on a popup window (there's no separate page for these actions), we have to do some waiting for elements to be loaded in the popup which is handled by `wait_for_popup`. There are two checks because the popup and it's child elements all load asynchronously of each other.