### PR TITLE
Fixing PF4ConfirmationDialog

### DIFF
--- a/airgun/widgets.py
+++ b/airgun/widgets.py
@@ -1134,9 +1134,9 @@ class Pf4ConfirmationDialog(ConfirmationDialog):
     right corner."""
 
     ROOT = '//div[@id="app-confirm-modal" or @data-ouia-component-type="PF4/ModalContent"]'
-    confirm_dialog = PF4Button('OUIA-Generated-Button-danger-1')
-    cancel_dialog = PF4Button('OUIA-Generated-Button-link-1')
-    discard_dialog = PF4Button('OUIA-Generated-Button-plain-1')
+    confirm_dialog = PF4Button('btn-modal-confirm')
+    cancel_dialog = PF4Button('btn-modal-cancel')
+    discard_dialog = PF4Button('OUIA-Generated-Modal-small-1-ModalBoxCloseButton')
 
 
 class LCESelector(GenericLocatorWidget):


### PR DESCRIPTION
Was seeing some errors in 6.12 since these PF4 Buttons were changed in the DOM a little (might be worth getting static ids for these?). Switched out the type of widget here so we could locate with locators and button text. I used `aria-label` for the close button so that it could be used in 6.11 also. Although I think most people will be using the cancel button instead.