### PR TITLE
Remove preimport_check and move functionality

### DIFF
--- a/airgun/entities/ansible_role.py
+++ b/airgun/entities/ansible_role.py
@@ -37,7 +37,12 @@ class AnsibleRolesEntity(BaseEntity):
     def imported_roles_count(self):
         """Return the number of Ansible roles currently imported into Satellite"""
         view = self.navigate_to(self, 'All')
-        return int(view.total_imported_roles.read())
+        # Before any roles have been imported, no table or pagination widget are
+        # present on the page
+        if not view.pagination.is_displayed:
+            return 0
+        else:
+            return int(view.total_imported_roles.read())
 
     def import_all_roles(self):
         """Import all available roles and return the number of roles
@@ -48,13 +53,6 @@ class AnsibleRolesEntity(BaseEntity):
         view.select_all.fill(True)
         view.submit.click()
         return available_roles_count
-
-    # Since Ansible Variables need to be assigned to specific Ansible Roles,
-    # Ansible Variable tests will fail if no Ansible Roles have been imported.
-    def preimport_check(self):
-        view = self.navigate_to(self, 'All')
-        if not view.pagination.is_displayed:
-            return False
 
 
 @navigator.register(AnsibleRolesEntity, 'All')


### PR DESCRIPTION
The preimport_check function in the Ansible Role view was ambiguously
named based on what it returned and how it was used. This commit 
removes that function and incorporates its functionality into the 
imported_roles_count property.