### PR TITLE
[UI] -Test fixes for rh_cloud inventory

### DIFF
--- a/airgun/entities/cloud_inventory.py
+++ b/airgun/entities/cloud_inventory.py
@@ -1,5 +1,3 @@
-from wait_for import wait_for
-
 from airgun.entities.base import BaseEntity
 from airgun.navigation import NavigateStep
 from airgun.navigation import navigator
@@ -42,13 +40,6 @@ class CloudInventoryEntity(BaseEntity):
         view = self.navigate_to(self, 'All')
         view.inventory_list.toggle(entity_name)
         view.browser.click(view.inventory_list.uploading.download_report, ignore_ajax=True)
-        wait_for(
-            lambda: view.inventory_list.status == 'idle',
-            handle_exception=True,
-            timeout=180,
-            delay=1,
-            logger=view.logger,
-        )
         return self.browser.save_downloaded_file()
 
     def update(self, values):

--- a/airgun/views/cloud_inventory.py
+++ b/airgun/views/cloud_inventory.py
@@ -59,7 +59,7 @@ class InventoryItemsView(Accordion):
     @property
     def is_generating(self):
         try:
-            self.parent_browser.selenium.find_element_by_xpath(f'{self.STATUS_ELEMENTS}[1]/span')
+            self.parent_browser.element(f'{self.STATUS_ELEMENTS}[1]')
             return True
         except NoSuchElementException:
             return False
@@ -67,7 +67,7 @@ class InventoryItemsView(Accordion):
     @property
     def is_uploading(self):
         try:
-            self.parent_browser.selenium.find_element_by_xpath(f'{self.STATUS_ELEMENTS}[2]/span')
+            self.parent_browser.element(f'{self.STATUS_ELEMENTS}[2]')
             return True
         except NoSuchElementException:
             return False


### PR DESCRIPTION
```
pytest tests/foreman/ui/test_rhcloud_inventory.py 
=============================================================================================== test session starts ===============================================================================================
platform linux -- Python 3.8.6, pytest-7.1.2, pluggy-1.0.0
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/addubey/work/robottelo, configfile: pyproject.toml
plugins: services-2.2.1, mock-3.7.0, forked-1.3.0, cov-3.0.0, xdist-2.5.0, ibutsu-2.2.2, reportportal-5.1.2
collected 8 items / 3 deselected / 5 selected                                                                                                                                                                     

tests/foreman/ui/test_rhcloud_inventory.py .....                                                                                                                                                            [100%]

============================================================================ 5 passed, 3 deselected, 98 warnings in 5642.28s (1:34:02) ============================================================================
```
