### PR TITLE
Click in ignored ensuresafepage. Set low timeout.

### DIFF
--- a/airgun/browser.py
+++ b/airgun/browser.py
@@ -258,7 +258,11 @@ class AirgunBrowserPlugin(DefaultPlugin):
         some bugs, e.g. https://bugzilla.redhat.com/show_bug.cgi?id=2106022
         """
         try:
-            super().ensure_page_safe()
+            if self.ignore_ensure_page_safe_timeout:
+                # set lower timeout, otherwise the page will be stuck in a lot of waiting because
+                # once broken, ensure_page_safe will always timeout until loading a new page
+                timeout = '2s'  # experiments show 5s let the page load properly w/o much waiting
+            super().ensure_page_safe(timeout)
         except TimedOutError:
             if not self.ignore_ensure_page_safe_timeout:
                 raise

--- a/airgun/entities/computeresource.py
+++ b/airgun/entities/computeresource.py
@@ -104,7 +104,7 @@ class ComputeResourceEntity(BaseEntity):
         )
         with self.browser.ignore_ensure_page_safe_timeout():
             view.fill(values)
-        view.submit.click()
+            view.submit.click()
 
     def read_computeprofile(self, entity_name, compute_profile, widget_names=None):
         """Read specific compute profile attributes through CR detail view"""


### PR DESCRIPTION
1) Click method is called still on the same page as fill so it's affected by the same issue (the linked bug). Call it also in the block with ignored timeout.

2) Point for discussion. When the bug manifests, it affects the page until it is reloaded. `ensure_page_safe` is called many times, always waiting half a minute to timeout. In case of this test, filling the page took so long (more than an hour) that the user got logged out of satellite meanwhile, causing the test to fail. I experimentally tested that for this test, `2s` is a value where the page manages to load while also not waiting to the point of timeout. (`5s` is too much)
There are definitely multiple solutions for 2):
a) This one. When we expect timeout, don't wait for it that long, by default.
b) Create another property, allowing for manual setting of timeout.
c) Straight ignoring the method and just sleep instead.
I think the solution in this PR is reasonably universal and easy. Can't break anything at this time because `ignore_ensure_page_safe_timeout` is only used in this test.

3) In the previous PR https://github.com/SatelliteQE/airgun/pull/724/files , I accidentally dropped the `timeout` parameter from `ensure_page_safe` call. This fixes it, regardless of 2).