### PR TITLE
AutoCherrypick GHAs

### DIFF
--- a/.github/workflows/auto_cherry_pick.yml
+++ b/.github/workflows/auto_cherry_pick.yml
@@ -1,0 +1,43 @@
+# CI stages to execute against all branches on PR merge
+name: auto_cherry_pick_commits
+
+on:
+  pull_request_target:
+    types:
+      - closed
+
+jobs:
+  branch-matrix:
+    if: github.event.pull_request.merged == true && contains(github.event.pull_request.labels.*.name, 'CherryPick')
+    name: Generate a branch matrix to apply cherrypicks
+    runs-on: ubuntu-latest
+    outputs:
+      branches: ${{ steps.set-matrix.outputs.branches }}
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - id: set-matrix
+        run: echo "::set-output name=branches::$(git branch -rl --sort=-authordate 'origin/6.*.z' --format='%(refname:lstrip=-1)' | head -n2 | jq -cnR '[inputs | select(length>0)]')"
+  auto_cherry_picking:
+    if: github.event.pull_request.merged == true && contains(github.event.pull_request.labels.*.name, 'CherryPick')
+    name: Auto Cherry picking
+    needs: branch-matrix
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        to_branch: ${{ fromJson(needs.branch-matrix.outputs.branches) }}
+    steps:
+      - name: Checkout Airgun
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+        if: matrix.to_branch != github.base_ref
+      - name: Cherry pick into ${{ matrix.to_branch }}
+        uses: carloscastrojumo/github-cherry-pick-action@v1.0.2
+        with:
+          branch: ${{ matrix.to_branch }}
+          labels: |
+            Auto_Cherry_Picked
+        # skipping PRs remote target_branch from cherrypicking into itself
+        if: matrix.to_branch != github.base_ref

--- a/.github/workflows/required_labels.yml
+++ b/.github/workflows/required_labels.yml
@@ -1,0 +1,17 @@
+# CI jobs to check specific labels present / absent
+name: required_labels
+
+on:
+  pull_request:
+    types: [opened, labeled, unlabeled, synchronize]
+
+jobs:
+  cherrypick_label:
+    name: Enforcing cherrypick labels
+    runs-on: ubuntu-latest
+    steps:
+      - uses: mheap/github-action-required-labels@v2
+        with:
+          mode: exactly
+          count: 1
+          labels: "CherryPick, No-CherryPick"


### PR DESCRIPTION
### Description of changes

This PR adds the AutoCherryPick Github Actions for enforcing CherryPick labels and the cherrypick labeled PRs has been autocherrypicked to previous branches!

The parent PR to master should cherrypick PRs in n-2 branches , n-1 parent PR should open in n-1 branch and n-2 doesnt opens a cherrypick PR !