### PR TITLE
Replace find_element_by_xpath with find_element

### DIFF
--- a/airgun/widgets.py
+++ b/airgun/widgets.py
@@ -2392,7 +2392,7 @@ class BaseMultiSelect(BaseSelect, Dropdown):
         try:
             for item in items:
                 element = self.item_element(item, close=False)
-                if not element.find_element_by_xpath("./..").get_attribute('aria-selected'):
+                if not element.find_element("xpath", "./..").get_attribute('aria-selected'):
                     element.click()
         finally:
             self.browser.click(self.BUTTON_LOCATOR)


### PR DESCRIPTION
Starting Selenium 4.3.0 all of `find_element_by_*` was removed and replaced by `find_element(by=*)`
https://stackoverflow.com/questions/72754651/attributeerror-webdriver-object-has-no-attribute-find-element-by-xpath