### PR TITLE
Recent audits and jobs as table

### DIFF
--- a/airgun/views/host_new.py
+++ b/airgun/views/host_new.py
@@ -17,6 +17,7 @@ from widgetastic_patternfly4.ouia import PatternflyTable
 from airgun.views.common import BaseLoggedInView
 from airgun.widgets import Pf4ActionsDropdown
 from airgun.widgets import Pf4ConfirmationDialog
+from airgun.widgets import SatTableWithoutHeaders
 
 
 class Card(View):
@@ -29,29 +30,6 @@ class DropdownWithDescripton(Dropdown):
     """Dropdown with description below items"""
 
     ITEM_LOCATOR = ".//*[contains(@class, 'pf-c-dropdown__menu-item') and contains(text(), {})]"
-
-
-class ItemList(Widget):
-    """Item list view, similar to table view, but using the ul/li structure"""
-
-    ROW = '//li/div[@class="pf-c-data-list__item-row"]/div'
-    COLUMN = './div'
-
-    def read(self):
-        """Return content of table"""
-        items = []
-        # make sure that parent locator works for str and also Locator object
-        parent_locator = (
-            self.parent.ROOT if type(self.parent.ROOT) == str else f'({self.parent.ROOT.locator})'
-        )
-        rows = self.browser.elements(f'{parent_locator}{self.ROW}')
-        for row in rows:
-            columns = []
-            elements = row.find_elements("xpath", self.COLUMN)
-            for element in elements:
-                columns.append(element.text)
-            items.append(columns)
-        return items
 
 
 class HostDetailsCard(Widget):
@@ -116,7 +94,7 @@ class NewHostDetailsView(BaseLoggedInView):
             ROOT = './/article[.//div[text()="Recent audits"]]'
 
             all_audits = Text('.//a[normalize-space(.)="All audits"]')
-            table = ItemList()
+            table = SatTableWithoutHeaders(locator='.//table[@aria-label="audits table"]')
 
         @View.nested
         class installable_errata(Card):
@@ -138,17 +116,16 @@ class NewHostDetailsView(BaseLoggedInView):
         @View.nested
         class recent_jobs(Card):
             ROOT = './/article[.//div[text()="Recent jobs"]]'
-            is_table_loaded = './/ul[@aria-label="recent-jobs-table"]'
             actions = Dropdown(locator='.//div[contains(@class, "pf-c-dropdown")]')
 
             class finished(Tab):
-                table = ItemList()
+                table = SatTableWithoutHeaders(locator='.//table[@aria-label="recent-jobs-table"]')
 
             class running(Tab):
-                table = ItemList()
+                table = SatTableWithoutHeaders(locator='.//table[@aria-label="recent-jobs-table"]')
 
             class scheduled(Tab):
-                table = ItemList()
+                table = SatTableWithoutHeaders(locator='.//table[@aria-label="recent-jobs-table"]')
 
     @View.nested
     class content(Tab):


### PR DESCRIPTION
As [BZ](https://bugzilla.redhat.com/show_bug.cgi?id=2121739) was resolved, we can use the table element for recent audits and jobs. 
PR for robotello will follow, including tests.