### PR TITLE
Fixing new Webhook button

### DIFF
--- a/airgun/entities/webhook.py
+++ b/airgun/entities/webhook.py
@@ -1,5 +1,4 @@
 from navmazing import NavigateToSibling
-from widgetastic.exceptions import NoSuchElementException
 
 from airgun.entities.base import BaseEntity
 from airgun.navigation import NavigateStep
@@ -90,10 +89,7 @@ class AddNewWebhook(NavigateStep):
     prerequisite = NavigateToSibling('All')
 
     def step(self, *args, **kwargs):
-        try:
-            self.parent.new.click()
-        except NoSuchElementException:
-            self.parent.new_on_blank_page.click()
+        self.parent.new.click()
 
 
 @navigator.register(WebhookEntity, 'Edit')

--- a/airgun/views/webhook.py
+++ b/airgun/views/webhook.py
@@ -15,8 +15,7 @@ from airgun.widgets import SatTable
 
 class WebhooksView(BaseLoggedInView, SearchableViewMixin):
     title = Text("//h1[normalize-space(.)='Webhooks']")
-    new = Button('Create Webhook')
-    new_on_blank_page = PF4Button('Create Webhook')
+    new = PF4Button('Create new')
     table = SatTable(
         './/table',
         column_widgets={


### PR DESCRIPTION
Webhook page in 6.12 was updated. No longer need `new_on_blank`.

Results:
```
============================= test session starts ==============================
platform linux -- Python 3.9.13, pytest-7.1.3, pluggy-0.13.1
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/gsulliva/Programming/robottelo, configfile: pyproject.toml
plugins: forked-1.3.0, services-2.2.1, cov-2.12.1, xdist-2.5.0, reportportal-5.1.2, mock-3.8.2, ibutsu-2.2.4
collected 1 item

tests/foreman/ui/test_webhook.py .                                       [100%]

================== 1 passed, 7 warnings in 329.15s (0:05:29) ===================
```