### PR TITLE
Missing delete confirmation function

### DIFF
--- a/airgun/entities/lifecycleenvironment.py
+++ b/airgun/entities/lifecycleenvironment.py
@@ -62,6 +62,7 @@ class LCEEntity(BaseEntity):
         """Deletes existing lifecycle environment entity"""
         view = self.navigate_to(self, 'Edit', entity_name=entity_name)
         view.remove.click()
+        self.browser.handle_alert()
         view.flash.assert_no_error()
         view.flash.dismiss()
 


### PR DESCRIPTION
The confirmation dialogue page to remove lce was missing.  Adding that in so lce can be deleted.

Test result
```
pytest tests/foreman/ui/test_lifecycleenvironment.py -k test_positive_end_to_end

=========== 1 passed, 5 deselected, 3 warnings in 189.68s (0:03:09) ============
```