### PR TITLE
Only search search bar in the active element, not from DOM root

### DIFF
--- a/airgun/widgets.py
+++ b/airgun/widgets.py
@@ -696,7 +696,7 @@ class Search(Widget):
     """Searchbar for table filtering"""
 
     ROOT = (
-        '//div[contains(@class, "toolbar-pf-filter") or contains(@class, "title_filter")'
+        './/div[contains(@class, "toolbar-pf-filter") or contains(@class, "title_filter")'
         'or contains(@class, "dataTables_filter") or @id="search-bar"]'
     )
     search_field = TextInput(


### PR DESCRIPTION
Since there are multiple search bars in some pages (like CR detail, where one filter is empty but still matches [0]), search fields should be searched within the active tab (or active element, more generally). Only when there are still multiple, the first one is selected, which is usually topmost, which is usually what you intended. So far, always the first one on the page was selected.

I'll think about why that empty filter exists and perhaps file a BZ but this fix is semantically correct anyway, I suppose.

I'm not sure if some tests don't rely on this IMO incorrect behavior so think about it for a minute.

Also, I love this comment of one (1) dot that took me ~2 hours so please accept it! :D

[0]
```
(//div[contains(@class, "toolbar-pf-filter") or contains(@class, "title_filter") or contains(@class, "dataTables_filter") or @id="search-bar"])[1]
```