### PR TITLE
[6.13.z] Fix configure_cloud_connector method

### DIFF
--- a/airgun/entities/cloud_inventory.py
+++ b/airgun/entities/cloud_inventory.py
@@ -20,6 +20,7 @@ class CloudInventoryEntity(BaseEntity):
         """Configure Cloud Connector"""
         view = self.navigate_to(self, 'All')
         view.cloud_connector.click()
+        view.dialog.confirm_dialog.click()
 
     def is_cloud_connector_configured(self):
         """Check if Cloud Connector is configured"""


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/airgun/pull/808

The test is failing because of a missing confirmation dialog click.
Fixes https://github.com/SatelliteQE/robottelo/pull/10660