### PR TITLE
[6.13.z] Fix locator for hosts table

### DIFF
--- a/airgun/views/host.py
+++ b/airgun/views/host.py
@@ -206,7 +206,7 @@ class HostsView(BaseLoggedInView, SearchableViewMixin):
         './/table',
         column_widgets={
             0: Checkbox(locator=".//input[@class='host_select_boxes']"),
-            'Name': Text("./a"),
+            'Name': Text("//a[contains(@href, '/new/hosts')]"),
             'Recommendations': Text("./a"),
             'Actions': ActionsDropdown("./div[contains(@class, 'btn-group')]"),
         },


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/airgun/pull/811

Test `test_positive_read_details_page_from_new_ui` is failing in the 6.13 automation.
The test was trying to click hostname in the  Hosts table but it was actually clicking on the Actions dropdown in the same row.
Locator change fixes the test failure.
Tested locally.
![image](https://user-images.githubusercontent.com/62888716/220067746-fe20a6a1-5b4c-4ab7-bed0-d59967eaa261.png)
