### PR TITLE
[6.13.z] Fix locator for content host table

### DIFF
--- a/airgun/views/contenthost.py
+++ b/airgun/views/contenthost.py
@@ -101,7 +101,7 @@ class ContentHostsView(BaseLoggedInView, SearchableViewMixin):
         './/table',
         column_widgets={
             0: Checkbox(locator="./input[@type='checkbox']"),
-            'Name': Text('./a'),
+            'Name': Text('.//a'),
             'Subscription Status': StatusIcon(),
             'Installable Updates': InstallableUpdatesCellView(),
         },


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/airgun/pull/814

Test `test_positive_view_hosts_with_non_admin_user` is failing in the 6.13 automation.
Locator change fixes the test failure.
![image](https://user-images.githubusercontent.com/62888716/221514519-b3bd7f5e-c882-4cd6-86b0-46442ac0f711.png)
