### PR TITLE
New Host UI - Manage columns functions

### DIFF
--- a/airgun/views/host.py
+++ b/airgun/views/host.py
@@ -198,6 +198,7 @@ class HostInterface(View):
 
 class HostsView(BaseLoggedInView, SearchableViewMixin):
     title = Text("//h1[normalize-space(.)='Hosts']")
+    manage_columns = PF4Button("OUIA-Generated-Button-link-1")
     export = Text(".//a[contains(@class, 'btn')][contains(@href, 'hosts.csv')]")
     new = Text(".//div[@id='rails-app-content']//a[contains(normalize-space(.),'Create Host')]")
     register = PF4Button('OUIA-Generated-Button-secondary-2')
@@ -211,6 +212,7 @@ class HostsView(BaseLoggedInView, SearchableViewMixin):
             'Actions': ActionsDropdown("./div[contains(@class, 'btn-group')]"),
         },
     )
+    displayed_table_headers = ".//table/thead/tr/th[not(@hidden)]"
     host_status = "//span[contains(@class, 'host-status')]"
     actions = ActionsDropdown("//div[@id='submit_multiple']")
     dialog = Pf4ConfirmationDialog()
@@ -218,6 +220,17 @@ class HostsView(BaseLoggedInView, SearchableViewMixin):
     @property
     def is_displayed(self):
         return self.browser.wait_for_element(self.title, exception=False) is not None
+
+    @property
+    def displayed_table_header_names(self) -> list:
+        """
+        Return names of the displayed headers in the hosts table.
+
+        Note: Cannot use 'self.table.headers' for this because it returns also hidden headers.
+        """
+        return [
+            header.text.strip() for header in self.browser.elements(self.displayed_table_headers)
+        ]
 
 
 class HostCreateView(BaseLoggedInView):

--- a/airgun/views/host_new.py
+++ b/airgun/views/host_new.py
@@ -18,6 +18,7 @@ from widgetastic_patternfly4.ouia import ExpandableTable
 from widgetastic_patternfly4.ouia import PatternflyTable
 
 from airgun.views.common import BaseLoggedInView
+from airgun.widgets import CheckboxGroup
 from airgun.widgets import Pf4ActionsDropdown
 from airgun.widgets import Pf4ConfirmationDialog
 from airgun.widgets import SatTableWithoutHeaders
@@ -418,3 +419,83 @@ class RecurringJobDialog(Pf4ConfirmationDialog):
 
     confirm_dialog = Button(locator='.//button[@data-ouia-component-id="btn-modal-confirm"]')
     cancel_dialog = Button(locator='.//button[@data-ouia-component-id="btn-modal-cancel"]')
+
+
+class PF4CheckboxTreeView(CheckboxGroup):
+    """
+    Modified :class:`airgun.widgets.CheckboxGroup` for PF4 tree view with checkboxes:
+        https://www.patternfly.org/v4/components/tree-view#with-checkboxes
+    """
+
+    ITEMS_LOCATOR = './/*[self::span|self::label][contains(@class, "pf-c-tree-view__node-text")]'
+    CHECKBOX_LOCATOR = (
+        './/*[self::span|self::label][contains(@class, "pf-c-tree-view__node-text")]'
+        '[normalize-space(.)="{}"]/preceding-sibling::span/input[@type="checkbox"]'
+    )
+
+
+class ManageColumnsView(BaseLoggedInView):
+    """Manage columns modal."""
+
+    ROOT = '//div[contains(@class, "pf-c-modal-box")]'
+
+    CHECKBOX_SECTION_TOGGLE = (
+        './/*[self::span|self::label][contains(@class, "pf-c-tree-view__node-text")]'
+        '[normalize-space(.)="{}"]/preceding-sibling::button'
+    )
+    DEFAULT_COLLAPSED_SECTIONS = [
+        CHECKBOX_SECTION_TOGGLE.format('Content'),
+        CHECKBOX_SECTION_TOGGLE.format('Network'),
+        CHECKBOX_SECTION_TOGGLE.format('Reported data'),
+        CHECKBOX_SECTION_TOGGLE.format('RH Cloud'),
+    ]
+    is_tree_collapsed = True
+    title = Text(
+        './/header//span[contains(@class, "pf-c-modal-box__title")]'
+        '[normalize-space(.)="Manage columns"]'
+    )
+    confirm_dialog = Button(locator='.//button[normalize-space(.)="Save"]')
+    cancel_dialog = Button(locator='.//button[normalize-space(.)="Cancel"]')
+    checkbox_group = PF4CheckboxTreeView(locator='.//div[contains(@class, "pf-c-tree-view")]')
+
+    def collapsed_sections(self):
+        return (self.browser.element(locator) for locator in self.DEFAULT_COLLAPSED_SECTIONS)
+
+    @property
+    def is_displayed(self):
+        title = self.browser.wait_for_element(self.title, exception=False)
+        return title is not None and title.is_diaplyed()
+
+    def expand_all(self):
+        """Expand all tree sections that are collapsed by default"""
+        if self.is_tree_collapsed:
+            for checkbox_group in self.collapsed_sections():
+                checkbox_group.click()
+                self.is_tree_collapsed = False
+
+    def read(self):
+        """
+        Get labels and values of all checkboxes in the dialog.
+
+        :return dict: mapping of `label: value` items
+        """
+        self.expand_all()
+        return self.checkbox_group.read()
+
+    def fill(self, values):
+        """
+        Set value of given checkboxes.
+        Example: values={'Operating system': True, 'Owner': False}
+
+        :param dict values: mapping of `label: value` items
+        """
+        self.expand_all()
+        self.checkbox_group.fill(values)
+
+    def submit(self):
+        """Submit the dialog and wait for the page to reload."""
+        self.confirm_dialog.click()
+        # the submit and page reload does not kick in immediately
+        # so ensure_page_safe() does not catches it
+        time.sleep(2)
+        self.browser.plugin.ensure_page_safe()


### PR DESCRIPTION
This adds few functions to the HostEntity to work
with the Manage columns dialog and the hosts table:
- `manage_table_columns`
- `get_displayed_table_headers`


[SOLVED] ~~*Note:* for some reason, when using `manage_table_columns()` (which then reloads the page)
and then calling `get_table_headers()`, `StaleElementReferenceException` is always thrown.
It may do something that the widget `widgetastic.widget.table.Table` implements `headers`
as a `@cached_property`.
I've tried to use `Table().clear_cache()` (and other hacks) but to no avail.~~
