### PR TITLE
Updates to New Host UI Traces tab

### DIFF
--- a/airgun/entities/host_new.py
+++ b/airgun/entities/host_new.py
@@ -171,11 +171,11 @@ class NewHostEntity(HostEntity):
         view.flash.assert_no_error()
         view.flash.dismiss()
 
-    def get_tracer_title(self, entity_name):
+    def get_tracer(self, entity_name):
         view = self.navigate_to(self, 'NewDetails', entity_name=entity_name)
         view.wait_displayed()
         self.browser.plugin.ensure_page_safe()
-        return view.traces.title.read()
+        return view.traces.read()
 
 
 @navigator.register(NewHostEntity, 'NewDetails')

--- a/airgun/entities/host_new.py
+++ b/airgun/entities/host_new.py
@@ -4,6 +4,7 @@ from airgun.entities.host import HostEntity
 from airgun.navigation import NavigateStep
 from airgun.navigation import navigator
 from airgun.views.host_new import AllAssignedRolesView
+from airgun.views.host_new import EnableTracerView
 from airgun.views.host_new import InstallPackagesView
 from airgun.views.host_new import ModuleStreamDialog
 from airgun.views.host_new import NewHostDetailsView
@@ -158,6 +159,23 @@ class NewHostEntity(HostEntity):
         view.wait_displayed()
         self.browser.plugin.ensure_page_safe()
         return view.table.read()
+
+    def enable_tracer(self, entity_name):
+        view = self.navigate_to(self, 'NewDetails', entity_name=entity_name)
+        view.wait_displayed()
+        self.browser.plugin.ensure_page_safe()
+        view.traces.enable_traces.click()
+        modal = EnableTracerView(self.browser)
+        if modal.is_displayed:
+            modal.confirm.click()
+        view.flash.assert_no_error()
+        view.flash.dismiss()
+
+    def get_tracer_title(self, entity_name):
+        view = self.navigate_to(self, 'NewDetails', entity_name=entity_name)
+        view.wait_displayed()
+        self.browser.plugin.ensure_page_safe()
+        return view.traces.title.read()
 
 
 @navigator.register(NewHostEntity, 'NewDetails')

--- a/airgun/views/host_new.py
+++ b/airgun/views/host_new.py
@@ -254,7 +254,7 @@ class NewHostDetailsView(BaseLoggedInView):
         ROOT = './/div'
 
         title = Text('//h2')
-        enable_traces = Button(locator='.//button[@data-ouia-component-id="enable-traces-button"]')
+        enable_traces = OUIAButton('enable-traces-button')
 
     @View.nested
     class insights(Tab):

--- a/airgun/views/host_new.py
+++ b/airgun/views/host_new.py
@@ -251,7 +251,10 @@ class NewHostDetailsView(BaseLoggedInView):
 
     @View.nested
     class traces(Tab):
-        enable_traces = OUIAButton('OUIA-Generated-Button-primary-1')
+        ROOT = './/div'
+
+        title = Text('//h2')
+        enable_traces = Button(locator='.//button[@data-ouia-component-id="enable-traces-button"]')
 
     @View.nested
     class insights(Tab):
@@ -399,6 +402,14 @@ class AllAssignedRolesView(View):
         column_widgets={'Name': Text('.//a'), 'Source': Text('.//a')},
     )
     pagination = Pagination()
+
+
+class EnableTracerView(View):
+    """Enable Tracer Modal"""
+
+    ROOT = './/div[@data-ouia-component-id="enable-tracer-modal"]'
+
+    confirm = Button(locator='//*[@data-ouia-component-id="enable-tracer-modal"]/footer/button[1]')
 
 
 class EditAnsibleRolesView(View):


### PR DESCRIPTION
Updates to the traces tab, as well as some support for the new Enable Traces modal. I didn't bother supporting all the possible uses of this modal, as it's not relevant for the current test. This can be added later if more traces tests are desired. 
