### PR TITLE
[6.13.z] NewHostEntity::get_details() wait check added

### DIFF
--- a/airgun/entities/host_new.py
+++ b/airgun/entities/host_new.py
@@ -28,6 +28,7 @@ class NewHostEntity(HostEntity):
         will be read.
         """
         view = self.navigate_to(self, 'NewDetails', entity_name=entity_name)
+        view.wait_displayed()
         self.browser.plugin.ensure_page_safe()
         return view.read(widget_names=widget_names)
 


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/airgun/pull/826

Added `view.wait_displayed()` to `NewHostEntity::get_details()`
so it is ensured the host detail page is fully loaded.
