### PR TITLE
Fix Pagination for Content Hosts

### DIFF
--- a/airgun/views/contenthost.py
+++ b/airgun/views/contenthost.py
@@ -106,7 +106,9 @@ class ContentHostsView(BaseLoggedInView, SearchableViewMixin):
             'Installable Updates': InstallableUpdatesCellView(),
         },
     )
-    pagination = Pagination()
+
+    total_items = Text("//span[@class='pagination-pf-items-total ng-binding']")
+    pages = Text("//span[@class='pagination-pf-pages ng-binding ng-scope']")
 
     @property
     def is_displayed(self):


### PR DESCRIPTION
Pagination wasn't working for Content Hosts, so this replaces the non functional Pagination widget with some more specific locators. Necessary for https://github.com/SatelliteQE/robottelo/pull/11193