### PR TITLE
[6.13.z] View for multiple host tabs added

### DIFF
--- a/airgun/entities/host_new.py
+++ b/airgun/entities/host_new.py
@@ -178,6 +178,142 @@ class NewHostEntity(HostEntity):
         self.browser.plugin.ensure_page_safe()
         return view.traces.read()
 
+    def get_os_info(self, entity_name):
+        view = self.navigate_to(self, 'NewDetails', entity_name=entity_name)
+        view.wait_displayed()
+        self.browser.plugin.ensure_page_safe()
+        return view.details.operating_system.read()
+
+    def get_provisioning_info(self, entity_name):
+        view = self.navigate_to(self, 'NewDetails', entity_name=entity_name)
+        view.wait_displayed()
+        self.browser.plugin.ensure_page_safe()
+        return view.details.provisioning.read()
+
+    def get_bios_info(self, entity_name):
+        view = self.navigate_to(self, 'NewDetails', entity_name=entity_name)
+        view.wait_displayed()
+        self.browser.plugin.ensure_page_safe()
+        return view.details.bios.read()
+
+    def get_registration_details(self, entity_name):
+        view = self.navigate_to(self, 'NewDetails', entity_name=entity_name)
+        view.wait_displayed()
+        self.browser.plugin.ensure_page_safe()
+        return view.details.registration_details.read()
+
+    def get_hw_properties(self, entity_name):
+        view = self.navigate_to(self, 'NewDetails', entity_name=entity_name)
+        view.wait_displayed()
+        self.browser.plugin.ensure_page_safe()
+        return view.details.hw_properties.read()
+
+    def get_provisioning_templates(self, entity_name):
+        view = self.navigate_to(self, 'NewDetails', entity_name=entity_name)
+        view.wait_displayed()
+        self.browser.plugin.ensure_page_safe()
+        d = view.details.read()
+        return d['provisioning_templates']['templates_table']
+
+    def get_networking_interfaces(self, entity_name):
+        view = self.navigate_to(self, 'NewDetails', entity_name=entity_name)
+        view.wait_displayed()
+        self.browser.plugin.ensure_page_safe()
+        return view.details.networking_interfaces.networking_interfaces_accordion.items()
+
+    def get_networking_interfaces_details(self, entity_name):
+        view = self.navigate_to(self, 'NewDetails', entity_name=entity_name)
+        view.wait_displayed()
+        self.browser.plugin.ensure_page_safe()
+        net_devices = [
+            i.split()[0]
+            for i in view.details.networking_interfaces.networking_interfaces_accordion.items()
+        ]
+
+        for dev in net_devices[1:]:
+            view.details.networking_interfaces.networking_interfaces_accordion.toggle(dev)
+
+        def dict_val_gen(item_name):
+            """Generator needed to fill the networking interface dictionary"""
+            locator_templ = (
+                './/div[contains(@class, "pf-c-accordion__expanded-content-body")]'
+                '//div[.//dt[normalize-space(.)="{}"]]//div'
+            )
+            values = self.browser.elements(locator_templ.format(item_name))
+            yield values
+
+        networking_interface_dict = {}
+        tmp = {
+            'fqdn': [i.text for i in list(dict_val_gen('FQDN'))[0]],
+            'ipv4': [i.text for i in list(dict_val_gen('IPv4'))[0]],
+            'ipv6': [i.text for i in list(dict_val_gen('IPv6'))[0]],
+            'mac': [i.text for i in list(dict_val_gen('MAC'))[0]],
+            # TODO: After RFE BZ2183086 is resolved, uncomment line below
+            # 'subnet': [i.text for i in list(dict_val_gen('Subnet'))[0]],
+            'mtu': [i.text for i in list(dict_val_gen('MTU'))[0]],
+        }
+
+        for i, dev in enumerate(net_devices):
+            networking_interface_dict[dev] = {key: tmp[key][i] for key in tmp}
+
+        return networking_interface_dict
+
+    def get_installed_products(self, entity_name):
+        view = self.navigate_to(self, 'NewDetails', entity_name=entity_name)
+        view.wait_displayed()
+        self.browser.plugin.ensure_page_safe()
+        installed_products_list = view.details.installed_products.read()
+        return installed_products_list['installed_products_list']
+
+    def get_parameters(self, entity_name):
+        view = self.navigate_to(self, 'NewDetails', entity_name=entity_name)
+        view.wait_displayed()
+        self.browser.plugin.ensure_page_safe()
+        return view.parameters.read()
+
+    def add_new_parameter(self, entity_name, parameter_name, parameter_type, parameter_value):
+        view = self.navigate_to(self, 'NewDetails', entity_name=entity_name)
+        view.wait_displayed()
+        self.browser.plugin.ensure_page_safe()
+        view.parameters.add_parameter.click()
+        view.parameters.new_parameter_name.fill(parameter_name)
+        view.parameters.new_parameter_type.fill(parameter_type)
+        view.parameters.new_parameter_value.fill(parameter_value)
+        view.parameters.confirm_addition.click()
+
+    def get_traces(self, entity_name):
+        view = self.navigate_to(self, 'NewDetails', entity_name=entity_name)
+        view.wait_displayed()
+        self.browser.plugin.ensure_page_safe()
+        return view.traces.read()
+
+    def get_puppet_details(self, entity_name):
+        view = self.navigate_to(self, 'NewDetails', entity_name=entity_name)
+        view.wait_displayed()
+        self.browser.plugin.ensure_page_safe()
+        reports_table = view.puppet.puppet_reports_table.read()
+        x = view.puppet.puppet_details.read()
+        x['reports_table'] = reports_table
+        return x
+
+    def get_puppet_enc_preview(self, entity_name):
+        view = self.navigate_to(self, 'NewDetails', entity_name=entity_name)
+        view.wait_displayed()
+        self.browser.plugin.ensure_page_safe()
+        return view.puppet.enc_preview.read()
+
+    def get_reports(self, entity_name):
+        view = self.navigate_to(self, 'NewDetails', entity_name=entity_name)
+        view.wait_displayed()
+        self.browser.plugin.ensure_page_safe()
+        return view.reports.read()
+
+    def get_insights(self, entity_name):
+        view = self.navigate_to(self, 'NewDetails', entity_name=entity_name)
+        view.wait_displayed()
+        self.browser.plugin.ensure_page_safe()
+        return view.insights.read()
+
 
 @navigator.register(NewHostEntity, 'NewDetails')
 class ShowNewHostDetails(NavigateStep):

--- a/airgun/views/host_new.py
+++ b/airgun/views/host_new.py
@@ -15,10 +15,13 @@ from widgetastic_patternfly4 import Tab
 from widgetastic_patternfly4.ouia import BreadCrumb
 from widgetastic_patternfly4.ouia import Button as OUIAButton
 from widgetastic_patternfly4.ouia import ExpandableTable
+from widgetastic_patternfly4.ouia import Modal
 from widgetastic_patternfly4.ouia import PatternflyTable
 
 from airgun.views.common import BaseLoggedInView
+from airgun.widgets import Accordion
 from airgun.widgets import CheckboxGroup
+from airgun.widgets import ItemsList
 from airgun.widgets import Pf4ActionsDropdown
 from airgun.widgets import Pf4ConfirmationDialog
 from airgun.widgets import SatTableWithoutHeaders
@@ -34,6 +37,27 @@ class SearchInput(TextInput):
         return changed
 
 
+class RemediationView(Modal):
+    """Remediation window view"""
+
+    OUIA_ID = 'OUIA-Generated-Modal-large-1'
+    remediate = Button('Remediate')
+    cancel = Button('Cancel')
+    table = PatternflyTable(
+        component_id='OUIA-Generated-Table-4',
+        column_widgets={
+            'Hostname': Text('.//td[1]'),
+            'Recommendation': Text('.//td[2]'),
+            'Resolution': Text('.//td[3]'),
+            'Reboot Required': Text('.//td[4]'),
+        },
+    )
+
+    @property
+    def is_displayed(self):
+        return self.title.wait_displayed()
+
+
 class Card(View):
     """Each card in host view has it's own title with same locator"""
 
@@ -47,10 +71,10 @@ class DropdownWithDescripton(Dropdown):
 
 
 class HostDetailsCard(Widget):
-    """Details card body contains multiple host detail information"""
+    """Overview/Details & Details/SystemProperties card body contains multiple host detail info"""
 
     LABELS = '//div[@class="pf-c-description-list__group"]//dt//span'
-    VALUES = '//div[@class="pf-c-description-list__group"]//dd//descendant::*/text()/..'
+    VALUES = '//div[@class="pf-c-description-list__group"]//*[self::dd or self::ul]'
 
     def read(self):
         """Return a dictionary where keys are property names and values are property values.
@@ -81,7 +105,7 @@ class NewHostDetailsView(BaseLoggedInView):
         breadcrumb_loaded = self.browser.wait_for_element(self.breadcrumb, exception=False)
         return breadcrumb_loaded and self.breadcrumb.locations[0] == 'Hosts'
 
-    edit = OUIAButton('OUIA-Generated-Button-secondary-1')
+    edit = OUIAButton('host-edit-button')
     dropdown = Dropdown(locator='//button[@id="hostdetails-kebab"]/..')
     schedule_job = Pf4ActionsDropdown(locator='.//div[div/button[@aria-label="Select"]]')
 
@@ -92,12 +116,17 @@ class NewHostDetailsView(BaseLoggedInView):
         @View.nested
         class details(Card):
             ROOT = './/article[.//div[text()="Details"]]'
+
             details = HostDetailsCard()
+
+            power_operations = OUIAButton('power-status-dropdown-toggle')
 
         @View.nested
         class host_status(Card):
             ROOT = './/article[.//span[text()="Host status"]]'
+
             status = Text('.//h4[contains(@data-ouia-component-id, "global-state-title")]')
+            manage_all_statuses = Text('.//a[normalize-space(.)="Manage all statuses"]')
 
             status_success = Text('.//a[span[@class="status-success"]]')
             status_warning = Text('.//a[span[@class="status-warning"]]')
@@ -111,6 +140,25 @@ class NewHostDetailsView(BaseLoggedInView):
             table = SatTableWithoutHeaders(locator='.//table[@aria-label="audits table"]')
 
         @View.nested
+        class recent_communication(Card):
+            ROOT = './/article[.//div[text()="Recent communication"]]'
+
+            last_checkin_value = Text('.//div[@class="pf-c-description-list__text"]')
+
+        @View.nested
+        class errata(Card):
+            ROOT = './/article[.//div[text()="Errata"]]'
+
+            enable_repository_sets = Text('.//a[normalize-space(.)="Enable repository sets"]')
+
+        @View.nested
+        class content_view_details(Card):
+            ROOT = './/article[.//div[text()="Content view details"]]'
+            actions = Dropdown(locator='.//div[contains(@class, "pf-c-dropdown")]')
+
+            org_view = Text('.//a[contains(@href, "content_views")]')
+
+        @View.nested
         class installable_errata(Card):
             ROOT = './/article[.//div[text()="Installable errata"]]'
 
@@ -121,6 +169,7 @@ class NewHostDetailsView(BaseLoggedInView):
         @View.nested
         class total_risks(Card):
             ROOT = './/article[.//div[text()="Total risks"]]'
+            actions = Dropdown(locator='.//div[contains(@class, "pf-c-dropdown")]')
 
             low = Text('.//*[@id="legend-labels-0"]/*')
             moderate = Text('.//*[@id="legend-labels-1"]/*')
@@ -140,6 +189,139 @@ class NewHostDetailsView(BaseLoggedInView):
 
             class scheduled(Tab):
                 table = SatTableWithoutHeaders(locator='.//table[@aria-label="recent-jobs-table"]')
+
+        @View.nested
+        class system_purpose(Card):
+            ROOT = './/article[.//div[text()="System purpose"]]'
+            edit_system_purpose = Text(
+                './/button[@data-ouia-component-id="syspurpose-edit-button"]'
+            )
+
+            role = Text('.//dd[contains(@class, "pf-c-description-list__description")][1]')
+            sla = Text('.//dd[contains(@class, "pf-c-description-list__description")][2]')
+            usage_type = Text('.//dd[contains(@class, "pf-c-description-list__description")][3]')
+            release_version = Text(
+                './/dd[contains(@class, "pf-c-description-list__description")][4]'
+            )
+            addons = Text('.//dd[contains(@class, "pf-c-description-list__description")][5]')
+
+    @View.nested
+    class details(Tab):
+        ROOT = './/div[contains(@class, "host-details-tab-item")]'
+
+        card_collapse_switch = Text(
+            './/button[contains(@data-ouia-component-id, "expand-button")]'
+        )
+
+        @View.nested
+        class system_properties(Card):
+            ROOT = './/article[.//div[text()="System properties"]]'
+
+            sys_properties = HostDetailsCard()
+
+        @View.nested
+        class operating_system(Card):
+            ROOT = './/article[.//div[text()="Operating system"]]'
+
+            architecture = Text(
+                './/a[contains(@data-ouia-component-id, "OUIA-Generated-Button-link-1")]'
+            )
+            os = Text('.//a[contains(@data-ouia-component-id, "OUIA-Generated-Button-link-2")]')
+            boot_time = Text('.//div[contains(@class, "pf-c-description-list__group")][3]/dd/div')
+            kernel_release = Text(
+                './/div[contains(@class, "pf-c-description-list__group")][4]/dd/div'
+            )
+
+        @View.nested
+        class provisioning(Card):
+            ROOT = './/article[.//div[text()="Provisioning"]]'
+
+            build_duration = Text(
+                './/div[contains(@class, "pf-c-description-list__group")][1]/dd/div'
+            )
+            token = Text('.//div[contains(@class, "pf-c-description-list__group")][2]/dd/div')
+            pxe_loader = Text('.//div[contains(@class, "pf-c-description-list__group")][3]/dd/div')
+
+        @View.nested
+        class bios(Card):
+            ROOT = './/article[.//div[text()="BIOS"]]'
+
+            vendor = Text('.//div[contains(@class, "pf-c-description-list__group")][1]/dd/div')
+            version = Text('.//div[contains(@class, "pf-c-description-list__group")][2]/dd/div')
+            release_date = Text(
+                './/div[contains(@class, "pf-c-description-list__group")][3]/dd/div'
+            )
+
+        @View.nested
+        class registration_details(Card):
+            ROOT = './/article[.//div[text()="Registration details"]]'
+
+            registered_on = Text(
+                './/div[contains(@class, "pf-c-description-list__group")][1]/dd/div'
+            )
+            registration_type = Text(
+                './/div[contains(@class, "pf-c-description-list__group")][2]/ul/h4'
+            )
+            activation_key_name = Text(
+                './/div[contains(@class, "pf-c-description-list__group")][2]//a'
+            )
+            registered_through = Text(
+                './/div[contains(@class, "pf-c-description-list__group")][3]/dd/div'
+            )
+
+        @View.nested
+        class hw_properties(Card):
+            ROOT = './/article[.//div[text()="HW properties"]]'
+
+            model = Text('.//div[contains(@class, "pf-c-description-list__group")][1]//dd')
+            number_of_cpus = Text(
+                './/div[contains(@class, "pf-c-description-list__group")][2]//dd'
+            )
+            sockets = Text('.//div[contains(@class, "pf-c-description-list__group")][3]//dd')
+            cores_per_socket = Text(
+                './/div[contains(@class, "pf-c-description-list__group")][4]//dd'
+            )
+            ram = Text('.//div[contains(@class, "pf-c-description-list__group")][5]//dd')
+            storage = Text('.//div[contains(@class, "pf-c-description-list__group")][6]//h4')
+
+        @View.nested
+        class provisioning_templates(Card):
+            ROOT = './/article[.//div[text()="Provisioning templates"]]'
+
+            templates_table = SatTableWithoutHeaders(
+                locator='.//table[@aria-label="templates table"]'
+            )
+
+        @View.nested
+        class installed_products(Card):
+            ROOT = './/article[.//div[text()="Installed products"]]'
+
+            installed_products_list = ItemsList(locator='.//ul[contains(@class, "pf-c-list")]')
+
+        @View.nested
+        class networking_interfaces(Card):
+            ROOT = './/article[.//div[text()="Networking interfaces"]]'
+
+            networking_interfaces_accordion = Accordion(
+                locator='.//div[contains(@class, "pf-c-card__expandable-content")]'
+            )
+            locator_templ = (
+                './/div[contains(@class, "pf-c-accordion__expanded-content-body")]'
+                '//div[.//dt[normalize-space(.)="{}"]]//div'
+            )
+            networking_interfaces_dict = {
+                'fqdn': Text(locator_templ.format('FQDN')),
+                'ipv4': Text(locator_templ.format('IPv4')),
+                'ipv6': Text(locator_templ.format('IPv6')),
+                'mac': Text(locator_templ.format('MAC')),
+                'subnet': Text(locator_templ.format('Subnet')),
+                'mtu': Text(locator_templ.format('MTU')),
+            }
+            edit_interfaces = Text('.//a[contains(@href, "/hosts/")]')
+
+        @View.nested
+        class networking_interface(Card):
+            pass
 
     @View.nested
     class content(Tab):
@@ -251,15 +433,61 @@ class NewHostDetailsView(BaseLoggedInView):
             pagination = Pagination()
 
     @View.nested
+    class parameters(Tab):
+        ROOT = './/div'
+
+        add_parameter = Button(locator='.//button[text()="Add parameter"]')
+        searchbar = SearchInput(
+            locator='//input[contains(@class, "pf-c-search-input__text-input")]'
+        )
+        new_parameter_name = TextInput(locator='.//td//input[contains(@aria-label, "name")]')
+        new_parameter_type = Select(
+            locator='.//td[2]//div[@data-ouia-component-type="PF4/Select"]'
+        )
+        new_parameter_value = TextInput(locator='.//td[3]//textarea')
+        cancel_addition = Button(locator='.//td[5]//button[1]')
+        confirm_addition = Button(locator='.//td[5]//button[2]')
+
+        parameters_table = Table(
+            locator='.//table[@aria-label="Parameters table"]',
+            column_widgets={
+                'Name': Text('.//td[contains(@data-label, "Name")]'),
+                'Type': Text('.//td[contains(@data-label, "Type")]'),
+                'Value': Text('.//td[contains(@data-label, "Value")]'),
+                'Source': Text('.//td[contains(@data-label, "Source")]'),
+                4: Button(
+                    locator=(
+                        './/button'
+                        '[contains(@data-ouia-component-id, "OUIA-Generated-Button-plain-")]'
+                    )
+                ),
+                5: Button(locator='.//td[contains(@class, "parameters-actions")]//button'),
+            },
+        )
+        pagination = Pagination()
+
+    @View.nested
     class traces(Tab):
         ROOT = './/div'
 
         title = Text('//h2')
         enable_traces = OUIAButton('enable-traces-button')
-
-    @View.nested
-    class insights(Tab):
-        pass
+        select_all = Checkbox(locator='.//input[contains(@aria-label, "Select all")]')
+        searchbar = SearchInput(locator='.//input[contains(@aria-label, "Select all")]')
+        Pf4ActionsDropdown = Button(
+            locator='.//div[contains(@aria-label, "bulk_actions_dropdown")]'
+        )
+        traces_table = PatternflyTable(
+            component_id='host-traces-table',
+            column_widgets={
+                0: Checkbox(locator='.//input[contains(@aria-label, "Select row")]'),
+                'Application': Text('.//td[2]'),
+                'Type': Text('.//td[3]'),
+                'Helper': Text('.//td[4]'),
+                4: Button(locator='.//button[contains(@aria-label, "Actions")]'),
+            },
+        )
+        pagination = Pagination()
 
     @View.nested
     class ansible(Tab):
@@ -369,6 +597,89 @@ class NewHostDetailsView(BaseLoggedInView):
                 @property
                 def is_displayed(self):
                     return self.previousText.is_displayed
+
+    @View.nested
+    class puppet(Tab):
+        ROOT = './/div'
+
+        search_bar = SearchInput(locator='.//input[contains(@class, "search-input")]')
+        puppet_reports_table = PatternflyTable(
+            component_id='reports-table',
+            column_widgets={
+                'reported_at': Text('.//a'),
+                'failed': Text('.//td[2]'),
+                'failed_restarts': Text('.//td[3]'),
+                'restarted': Text('.//td[4]'),
+                'applied': Text('.//td[5]'),
+                'skipped': Text('.//td[6]'),
+                'pending': Text('.//td[7]'),
+                7: Button(locator='.//button[contains(@aria-label, "Actions")]'),
+            },
+        )
+        pagination = Pagination()
+
+        @View.nested
+        class enc_preview(Tab):
+            ROOT = './/div[@class="enc-preview-tab"]'
+            TAB_NAME = "ENC Preview"
+            preview = Text('.//code')
+
+        @View.nested
+        class puppet_details(Card):
+            ROOT = './/article[.//div[text()="Puppet details"]]'
+            puppet_environment = Text(
+                './div[2]//div[contains(@class, "pf-c-description-list__group")][1]//dd'
+            )
+            puppet_capsule = Text(
+                './div[2]//div[contains(@class, "pf-c-description-list__group")][2]//dd'
+            )
+            puppet_ca_capsule = Text(
+                './div[2]//div[contains(@class, "pf-c-description-list__group")][3]//dd'
+            )
+
+    @View.nested
+    class reports(Tab):
+        ROOT = './/div'
+
+        search_bar = SearchInput(locator='.//input[contains(@class, "search-input")]')
+        reports_table = PatternflyTable(
+            component_id='reports-table',
+            column_widgets={
+                'reported_at': Text('.//a'),
+                'failed': Text('.//td[2]'),
+                'failed_restarts': Text('.//td[3]'),
+                'restarted': Text('.//td[4]'),
+                'applied': Text('.//td[5]'),
+                'skipped': Text('.//td[6]'),
+                'origin': Text('.//td[7]'),
+                'pending': Text('.//td[8]'),
+                8: Button(locator='.//button[contains(@aria-label, "Actions")]'),
+            },
+        )
+
+        pagination = Pagination()
+
+    @View.nested
+    class insights(Tab):
+        ROOT = './/div'
+
+        search_bar = SearchInput(locator='.//input[contains(@class, "search-input")]')
+        remediate = Button(locator='.//button[text()="Remediate"]')
+        insights_dropdown = Dropdown(locator='.//div[contains(@class, "insights-dropdown")]')
+
+        select_all = Checkbox(locator='.//input[@name="check-all"]')
+        recommendations_table = PatternflyTable(
+            component_id='OUIA-Generated-Table-2',
+            column_widgets={
+                0: Checkbox(locator='.//input[@type="checkbox"]'),
+                'Recommendation': Text('.//td[2]'),
+                'Total Risk': Text('.//td[3]'),
+                'Remediate': Text('.//td[4]'),
+                4: Button(locator='.//button[contains(@aria-label, "Actions")]'),
+            },
+        )
+        pagination = Pagination()
+        remediation_window = View.nested(RemediationView)
 
 
 class InstallPackagesView(View):


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/airgun/pull/822

In this PR, I am improving airgun by adding new host details cards and finishing unfinished views (Overview, Details, Content, Parameters, Traces, Reports, Insights, Puppet). Basic entities for reading values from UI are present too.

For more info see SAT-16452.