### PR TITLE
[6.13.z] change locator for `Name` in `HostsView`

### DIFF
--- a/airgun/views/host.py
+++ b/airgun/views/host.py
@@ -207,7 +207,9 @@ class HostsView(BaseLoggedInView, SearchableViewMixin):
         './/table',
         column_widgets={
             0: Checkbox(locator=".//input[@class='host_select_boxes']"),
-            'Name': Text("//a[contains(@href, '/new/hosts')]"),
+            'Name': Text(
+                "//a[contains(@href, '/new/hosts/') and not(contains(@href, 'Insights'))]"
+            ),
             'Recommendations': Text("./a"),
             'Actions': ActionsDropdown("./div[contains(@class, 'btn-group')]"),
         },


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/airgun/pull/828

Changed locator for `Name` in `views/host.py/HostsView`. Before, the locator was matching incorrectly to the value in Reccommendations column instead of Name because of similar values.

Fixed by adding condition that Name's locator should not include `'Insights'`, which is the Reccomendations locator.

In Hosts, Reccomendations value points to `'(hostname)/#Insights'` and Name value points to `'(hostname)'`.