### PR TITLE
[cherry-pick] Fix configure_cloud_connector method

### DIFF
--- a/airgun/entities/cloud_inventory.py
+++ b/airgun/entities/cloud_inventory.py
@@ -20,6 +20,7 @@ class CloudInventoryEntity(BaseEntity):
         """Configure Cloud Connector"""
         view = self.navigate_to(self, 'All')
         view.cloud_connector.click()
+        view.dialog.confirm_dialog.click()
 
     def is_cloud_connector_configured(self):
         """Check if Cloud Connector is configured"""


### PR DESCRIPTION
The test `test_positive_configure_cloud_connector` is failing because of a missing confirmation dialog click.
Cherry-pick from https://github.com/SatelliteQE/airgun/pull/808