### PR TITLE
Fix locators for RHRepo Search box and Search button

### DIFF
--- a/airgun/views/redhat_repository.py
+++ b/airgun/views/redhat_repository.py
@@ -211,8 +211,8 @@ class RedHatRepositoriesView(BaseLoggedInView):
 
     title = Text("//h1[contains(., 'Red Hat Repositories')]")
     search_category = RepositorySearchCategory(".//div[button[@id='search-list-select']]")
-    search_box = TextInput(id='downshift-0-input')
-    search_button = Text(".//button[normalize-space(.) = 'Search']")
+    search_box = TextInput(locator=".//input[@aria-label='Search input']")
+    search_button = Text(".//button[@aria-label='Search']")
     search_types = RepositorySearchTypes(".//div[button[@data-id='formControlsSelectMultiple']]")
     search_clear = Text(".//span[@class = 'fa fa-times']")
     recommended_repos = Text(".//div[contains(@class, 'bootstrap-switch wrapper')]")


### PR DESCRIPTION
Quick fix for the Search box on the Red Hat Repositories page. Makes the box itself, and the search button operational.