### PR TITLE
Add Virtcard entity

### DIFF
--- a/airgun/entities/computeresource.py
+++ b/airgun/entities/computeresource.py
@@ -91,9 +91,13 @@ class ComputeResourceEntity(BaseEntity):
         if vm['Power'].widget.read() == 'On':
             vm['Actions'].widget.click(handle_alert=True)
 
-    def vm_import(self, entity_name, vm_name, hostgroup, location):
+    def vm_import(self, entity_name, vm_name, hostgroup, location, org=None, name=None):
         """Imports the specified VM"""
         view = self.navigate_to(self, 'VMImport', entity_name=entity_name, vm_name=vm_name)
+        if name:
+            view.fill({'host.name': name})
+        if org:
+            view.fill({'host.organization': org})
         view.fill({'host.hostgroup': hostgroup, 'host.location': location})
         view.submit.click()
 

--- a/airgun/entities/host_new.py
+++ b/airgun/entities/host_new.py
@@ -40,8 +40,8 @@ class NewHostEntity(HostEntity):
         view = self.navigate_to(self, 'NewDetails', entity_name=entity_name)
         view.wait_displayed()
         self.browser.plugin.ensure_page_safe()
+        # Run this read twice to navigate to the page and load it before reading
         view.read(widget_names=widget_names)
-        time.sleep(3)
         return view.read(widget_names=widget_names)
 
     def edit_system_purpose(

--- a/airgun/entities/host_new.py
+++ b/airgun/entities/host_new.py
@@ -40,6 +40,8 @@ class NewHostEntity(HostEntity):
         view = self.navigate_to(self, 'NewDetails', entity_name=entity_name)
         view.wait_displayed()
         self.browser.plugin.ensure_page_safe()
+        view.read(widget_names=widget_names)
+        time.sleep(3)
         return view.read(widget_names=widget_names)
 
     def edit_system_purpose(
@@ -464,7 +466,6 @@ class NewHostEntity(HostEntity):
 
     def get_virtualization(self, entity_name):
         view = self.navigate_to(self, 'NewDetails', entity_name=entity_name)
-        time.sleep(3)
         view.wait_displayed()
         self.browser.plugin.ensure_page_safe()
         return view.details.virtualization.read()

--- a/airgun/entities/host_new.py
+++ b/airgun/entities/host_new.py
@@ -462,6 +462,12 @@ class NewHostEntity(HostEntity):
         self.browser.plugin.ensure_page_safe()
         return view.parameters.read()
 
+    def get_virtualization(self, entity_name):
+        view = self.navigate_to(self, 'NewDetails', entity_name=entity_name)
+        view.wait_displayed()
+        self.browser.plugin.ensure_page_safe()
+        return view.details.virtualization.read()
+
     def add_new_parameter(self, entity_name, parameter_name, parameter_type, parameter_value):
         """
         Function that adds new parameter to the host

--- a/airgun/entities/host_new.py
+++ b/airgun/entities/host_new.py
@@ -464,6 +464,7 @@ class NewHostEntity(HostEntity):
 
     def get_virtualization(self, entity_name):
         view = self.navigate_to(self, 'NewDetails', entity_name=entity_name)
+        time.sleep(3)
         view.wait_displayed()
         self.browser.plugin.ensure_page_safe()
         return view.details.virtualization.read()

--- a/airgun/views/host_new.py
+++ b/airgun/views/host_new.py
@@ -344,6 +344,20 @@ class NewHostDetailsView(BaseLoggedInView):
         class networking_interface(Card):
             pass
 
+        @View.nested
+        class virtualization(Card):
+            ROOT = './/article[contains(@data-ouia-component-id, "card-template-Virtualization")]'
+
+            name = Text('.//div[contains(@class, "pf-c-description-list__group")][1]//dd')
+            core_per_socket = Text(
+                './/div[contains(@class, "pf-c-description-list__group")][2]//dd'
+            )
+            sockets = Text('.//div[contains(@class, "pf-c-description-list__group")][3]//dd')
+            memory = Text('.//div[contains(@class, "pf-c-description-list__group")][4]//dd')
+            display = Text('.//div[contains(@class, "pf-c-description-list__group")][5]//dd')
+            disk = Text('.//div[contains(@class, "pf-c-description-list__group")][6]//dd')
+            running_on = Text('.//div[contains(@class, "pf-c-description-list__group")][13]//dd')
+
     @View.nested
     class content(Tab):
         # TODO Setting ROOT is just a workaround because of BZ 2119076,

--- a/airgun/views/host_new.py
+++ b/airgun/views/host_new.py
@@ -348,14 +348,28 @@ class NewHostDetailsView(BaseLoggedInView):
         class virtualization(Card):
             ROOT = './/article[contains(@data-ouia-component-id, "card-template-Virtualization")]'
 
-            name = Text('.//div[contains(@class, "pf-c-description-list__group")][1]//dd')
-            core_per_socket = Text(
-                './/div[contains(@class, "pf-c-description-list__group")][2]//dd'
+            datacenter = Text('.//div[contains(@class, "pf-c-description-list__group")][1]//dd')
+            cluster = Text('.//div[contains(@class, "pf-c-description-list__group")][2]//dd')
+            memory = Text('.//div[contains(@class, "pf-c-description-list__group")][3]//dd')
+            public_ip_address = Text(
+                './/div[contains(@class, "pf-c-description-list__group")][4]//dd'
             )
-            sockets = Text('.//div[contains(@class, "pf-c-description-list__group")][3]//dd')
-            memory = Text('.//div[contains(@class, "pf-c-description-list__group")][4]//dd')
-            display = Text('.//div[contains(@class, "pf-c-description-list__group")][5]//dd')
-            disk = Text('.//div[contains(@class, "pf-c-description-list__group")][6]//dd')
+            mac_address = Text('.//div[contains(@class, "pf-c-description-list__group")][5]//dd')
+            cpus = Text('.//div[contains(@class, "pf-c-description-list__group")][6]//dd')
+            cores_per_socket = Text(
+                './/div[contains(@class, "pf-c-description-list__group")][7]//dd'
+            )
+            firmware = Text('.//div[contains(@class, "pf-c-description-list__group")][8]//dd')
+            hypervisor = Text('.//div[contains(@class, "pf-c-description-list__group")][9]//dd')
+            connection_state = Text(
+                './/div[contains(@class, "pf-c-description-list__group")][10]//dd'
+            )
+            overall_status = Text(
+                './/div[contains(@class, "pf-c-description-list__group")][11]//dd'
+            )
+            annotation_notes = Text(
+                './/div[contains(@class, "pf-c-description-list__group")][12]//dd'
+            )
             running_on = Text('.//div[contains(@class, "pf-c-description-list__group")][13]//dd')
 
     @View.nested


### PR DESCRIPTION
Adds support for the new Virtualization card added in 6.14. This view will only work for the version of the the card that's returned when the Virtualization platform of the host is RHV, as when other Virtualization platforms are used (vmware, etc) the card will have different fields, since it just displays the info that it recieves from the hypervisor. Not ideal, but I don't have a good way to automatically generate virtualized hosts of other types, so this should cover the basic functionality at least. 