### PR TITLE
[6.14.z] Bump GHA python version check to 3.10 and 3.11

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.8, 3.9]
+        python-version: ['3.10', '3.11']
     steps:
       - name: Checkout Airgun
         uses: actions/checkout@v2

--- a/setup.py
+++ b/setup.py
@@ -39,8 +39,7 @@ setup(
         'Natural Language :: English',
         'Operating System :: POSIX :: LinuxProgramming Language :: Python',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.6',
-        'Programming Language :: Python :: 3.7',
-        'Programming Language :: Python :: 3.8',
+        'Programming Language :: Python :: 3.10',
+        'Programming Language :: Python :: 3.11',
     ],
 )


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/airgun/pull/877

As our automation uses 3.11 at this moment, let's bump the version we check in the airgun from [3.8, 3.9] to [3.10, 3.11]