### PR TITLE
[6.12.z] add orgnization option for virt-who configuration UI page

### DIFF
--- a/airgun/views/virtwho_configure.py
+++ b/airgun/views/virtwho_configure.py
@@ -120,6 +120,7 @@ class VirtwhoConfiguresView(BaseLoggedInView, SearchableViewMixin):
 class VirtwhoConfigureCreateView(BaseLoggedInView):
     breadcrumb = BreadCrumb()
     name = TextInput(id='foreman_virt_who_configure_config_name')
+    organization_id = FilteredDropdown(id='foreman_virt_who_configure_config_organization_id')
     interval = FilteredDropdown(id='foreman_virt_who_configure_config_interval')
     satellite_url = TextInput(id='foreman_virt_who_configure_config_satellite_url')
     hypervisor_id = FilteredDropdown(id='foreman_virt_who_configure_config_hypervisor_id')


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/airgun/pull/863

when create a virt-who config without chose the organization, the organization option will display on the virt-who configuration UI page
Case PASS
```
(robottelo_vv) [virtwho@dell-per740-68-vm-04 robottelo]$ pytest ./tests/foreman/virtwho/ui/test_esx.py -k test_positive_organization_id_option --disable-pytest-warnings -q
.                                                                                                                                                                                                           [100%]
1 passed, 35 deselected, 5 warnings in 128.66s (0:02:08)

```