### PR TITLE
[6.14.z] Added sleep to get_repos_set

### DIFF
--- a/airgun/entities/host_new.py
+++ b/airgun/entities/host_new.py
@@ -324,6 +324,7 @@ class NewHostEntity(HostEntity):
         view.wait_displayed()
         view.content.repository_sets.searchbar.fill(search)
         self.browser.plugin.ensure_page_safe()
+        time.sleep(3)
         return view.content.repository_sets.table.read()
 
     def override_repo_sets(self, entity_name, repo_set, action):


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/airgun/pull/874

It seems like the tests I wrote are failing when get_repos_set is run. Adding a sleep timer allows for the table to load and return the correct value. 

https://github.com/SatelliteQE/robottelo/pull/11380
https://github.com/SatelliteQE/robottelo/pull/11717/files