### PR TITLE
[6.14.z] fix in audit log search

### DIFF
--- a/airgun/views/audit.py
+++ b/airgun/views/audit.py
@@ -49,4 +49,5 @@ class AuditsView(BaseLoggedInView):
 
     def search(self, query):
         self.searchbox.search(query)
+        self.title.click()  # to exit the search field
         return self.entry.read()


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/airgun/pull/887

The problem is that with 6.14, the suggestions dropdown stays open even after the search is submitted, so we need to change focus from the search field to be able to expand the result. I didn't find a smarter way to do it other than clicking on the title. All audit log UI tests were failing due to this, with this change:

```
pytest tests/foreman/ui/test_audit.py -k test_positive_add_event
============================================================ test session starts ============================================================


collected 6 items / 5 deselected / 1 selected                                                                                               

tests/foreman/ui/test_audit.py .                                                                                                      [100%]


================================================ 1 passed, 5 deselected, 1 warning in 33.27s ==============================================
```