### PR TITLE
Rework new CV UI Search

### DIFF
--- a/airgun/widgets.py
+++ b/airgun/widgets.py
@@ -748,14 +748,9 @@ class Search(Widget):
 class PF4Search(Search):
     """PF4 Searchbar for table filtering"""
 
-    ROOT = '//div[@role="combobox" or @aria-haspopup="listbox"]'
-    search_field = TextInput(
-        locator=(
-            ".//input[@type='text' or @id='downshift-0-input' or"
-            " contains(@class, 'pf-m-search') or data-ouia-component-type='PF4/TextInput']"
-        )
-    )
-    clear_button = Button(locator=".//button[contains(@class,'search-clear')]")
+    ROOT = '//div[@class="foreman-search-bar"]'
+    search_field = TextInput(locator=(".//input[@aria-label='Search input']"))
+    clear_button = Button(locator=(".//input[@aria-label='Reset search']"))
 
     def clear(self):
         """Clears search field value and re-trigger search to remove all


### PR DESCRIPTION
The first in a long line of PRs fleshing out functionality for the "new" CV UI page - this one is simple, just updates the PF4Search widget to have accurate locators, so that it functions properly. 

Exercised in a test in a sister PR.