### PR TITLE
Fix one of many locators changed in data-ouia-id rework

### DIFF
--- a/airgun/widgets.py
+++ b/airgun/widgets.py
@@ -699,7 +699,8 @@ class Search(Widget):
 
     ROOT = (
         './/div[contains(@class, "toolbar-pf-filter") or contains(@class, "title_filter")'
-        'or contains(@class, "dataTables_filter") or @id="search-bar"]'
+        'or contains(@class, "dataTables_filter") or @id="search-bar" '
+        'or @data-ouia-component-id="table-toolbar"]'
     )
     search_field = TextInput(
         locator=(


### PR DESCRIPTION
I just fixed this to make `tests/foreman/ui/test_webhook.py::test_positive_end_to_end` green, there are more errors caused by locator changes in data-ouia-id rework