### PR TITLE
[6.14.z] account_menu dropdown 'data-ouia-component-id' is changed now

### DIFF
--- a/airgun/views/common.py
+++ b/airgun/views/common.py
@@ -45,7 +45,7 @@ class BaseLoggedInView(View):
     dialog = Pf4ConfirmationDialog()
     logout = Text("//a[@href='/users/logout']")
     current_user = Dropdown('user-info-dropdown')
-    account_menu = Dropdown('OUIA-Generated-Dropdown-1')
+    account_menu = Dropdown('user-info-dropdown')
     permission_denied = Text('//*[@id="content"]')
 
     def select_logout(self):


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/airgun/pull/917

- test `test_positive_update_login_page_footer_text` was failing due to **NoSuchElementException**
- Error details
> selenium.common.exceptions.NoSuchElementException: Message: Could not find an element Locator(by='xpath', locator='.//*[@data-ouia-component-type="PF4/Dropdown" and @data-ouia-component-id="OUIA-Generated-Dropdown-1"]'); For documentation on this error, please visit: https://www.selenium.dev/documentation/webdriver/troubleshooting/errors#no-such-element-exception

- Provided id will fix the issue