### PR TITLE
Change entity routes to accomodate PF4 navigation with multiple levels

### DIFF
--- a/airgun/entities/activationkey.py
+++ b/airgun/entities/activationkey.py
@@ -94,7 +94,7 @@ class ShowAllActivationKeys(NavigateStep):
 
     @retry_navigation
     def step(self, *args, **kwargs):
-        self.view.menu.select('Content', 'Activation Keys')
+        self.view.menu.select('Content', 'Lifecycle', 'Activation Keys')
 
 
 @navigator.register(ActivationKeyEntity, 'New')

--- a/airgun/entities/ansible_role.py
+++ b/airgun/entities/ansible_role.py
@@ -61,7 +61,7 @@ class ShowAllRoles(NavigateStep):
     VIEW = AnsibleRolesView
 
     def step(self, *args, **kwargs):
-        self.view.menu.select('Configure', 'Roles')
+        self.view.menu.select('Configure', 'Ansible', 'Roles')
 
 
 @navigator.register(AnsibleRolesEntity, 'Import')

--- a/airgun/entities/ansible_variable.py
+++ b/airgun/entities/ansible_variable.py
@@ -59,7 +59,7 @@ class ShowAllVariables(NavigateStep):
     VIEW = AnsibleVariablesView
 
     def step(self, *args, **kwargs):
-        self.view.menu.select('Configure', 'Variables')
+        self.view.menu.select('Configure', 'Ansible', 'Variables')
 
 
 @navigator.register(AnsibleVariablesEntity, 'New')

--- a/airgun/entities/architecture.py
+++ b/airgun/entities/architecture.py
@@ -55,7 +55,7 @@ class ShowAllArchitectures(NavigateStep):
 
     @retry_navigation
     def step(self, *args, **kwargs):
-        self.view.menu.select('Hosts', 'Architectures')
+        self.view.menu.select('Hosts', 'Provisioning Setup', 'Architectures')
 
 
 @navigator.register(ArchitectureEntity, 'New')

--- a/airgun/entities/cloud_insights.py
+++ b/airgun/entities/cloud_insights.py
@@ -78,7 +78,7 @@ class ShowCloudInsightsView(NavigateStep):
 
     @retry_navigation
     def step(self, *args, **kwargs):
-        self.view.menu.select('Configure', 'Insights')
+        self.view.menu.select('Configure', 'RH Cloud', 'Insights')
 
 
 @navigator.register(CloudInsightsEntity, 'Run')

--- a/airgun/entities/cloud_inventory.py
+++ b/airgun/entities/cloud_inventory.py
@@ -57,4 +57,4 @@ class ShowCloudInventoryListView(NavigateStep):
 
     @retry_navigation
     def step(self, *args, **kwargs):
-        self.view.menu.select('Configure', 'Inventory Upload')
+        self.view.menu.select('Configure', 'RH Cloud', 'Inventory Upload')

--- a/airgun/entities/config_report.py
+++ b/airgun/entities/config_report.py
@@ -50,7 +50,7 @@ class ShowAllConfigReports(NavigateStep):
 
     @retry_navigation
     def step(self, *args, **kwargs):
-        self.view.menu.select('Monitor', 'Config Management')
+        self.view.menu.select('Monitor', 'Reports', 'Config Management')
 
 
 @navigator.register(ConfigReportEntity, 'Report Details')

--- a/airgun/entities/containerimagetag.py
+++ b/airgun/entities/containerimagetag.py
@@ -36,7 +36,7 @@ class ShowAllContainerImageTags(NavigateStep):
 
     @retry_navigation
     def step(self, *args, **kwargs):
-        self.view.menu.select('Content', 'Container Image Tags')
+        self.view.menu.select('Content', 'Content Types', 'Container Image Tags')
 
 
 @navigator.register(ContainerImageTagEntity, 'Details')

--- a/airgun/entities/contentview_new.py
+++ b/airgun/entities/contentview_new.py
@@ -31,7 +31,7 @@ class ShowAllContentViewsScreen(NavigateStep):
 
     @retry_navigation
     def step(self, *args, **kwargs):
-        self.view.menu.select('Content', 'Content Views')
+        self.view.menu.select('Content', 'Lifecycle', 'Content Views')
 
 
 @navigator.register(NewContentViewEntity, 'New')

--- a/airgun/entities/errata.py
+++ b/airgun/entities/errata.py
@@ -108,7 +108,7 @@ class ShowAllErratum(NavigateStep):
 
     @retry_navigation
     def step(self, *args, **kwargs):
-        self.view.menu.select('Content', 'Errata')
+        self.view.menu.select('Content', 'Content Types', 'Errata')
 
 
 @navigator.register(ErrataEntity, 'Details')

--- a/airgun/entities/hardware_model.py
+++ b/airgun/entities/hardware_model.py
@@ -64,7 +64,7 @@ class ShowAllHardwareModels(NavigateStep):
 
     @retry_navigation
     def step(self, *args, **kwargs):
-        self.view.menu.select('Hosts', 'Hardware Models')
+        self.view.menu.select('Hosts', 'Provisioning Setup', 'Hardware Models')
 
 
 @navigator.register(HardwareModelEntity, 'New')

--- a/airgun/entities/job_template.py
+++ b/airgun/entities/job_template.py
@@ -75,7 +75,7 @@ class ShowAllTemplates(NavigateStep):
 
     @retry_navigation
     def step(self, *args, **kwargs):
-        self.view.menu.select('Hosts', 'Job templates')
+        self.view.menu.select('Hosts', 'Templates', 'Job templates')
 
 
 @navigator.register(JobTemplateEntity, 'New')

--- a/airgun/entities/lifecycleenvironment.py
+++ b/airgun/entities/lifecycleenvironment.py
@@ -87,7 +87,7 @@ class ShowAllLCE(NavigateStep):
 
     @retry_navigation
     def step(self, *args, **kwargs):
-        self.view.menu.select('Content', 'Lifecycle Environments')
+        self.view.menu.select('Content', 'Lifecycle', 'Lifecycle Environments')
 
 
 @navigator.register(LCEEntity, 'New Path')

--- a/airgun/entities/media.py
+++ b/airgun/entities/media.py
@@ -53,7 +53,7 @@ class ShowAllMedium(NavigateStep):
 
     @retry_navigation
     def step(self, *args, **kwargs):
-        self.view.menu.select('Hosts', 'Installation Media')
+        self.view.menu.select('Hosts', 'Provisioning Setup', 'Installation Media')
 
 
 @navigator.register(MediaEntity, 'New')

--- a/airgun/entities/modulestream.py
+++ b/airgun/entities/modulestream.py
@@ -40,7 +40,7 @@ class ShowAllModuleStreams(NavigateStep):
 
     @retry_navigation
     def step(self, *args, **kwargs):
-        self.view.menu.select('Content', 'Module Streams')
+        self.view.menu.select('Content', 'Content Types', 'Module Streams')
 
 
 @navigator.register(ModuleStreamEntity, 'Details')

--- a/airgun/entities/os.py
+++ b/airgun/entities/os.py
@@ -56,7 +56,7 @@ class ShowAllOperatingSystems(NavigateStep):
 
     @retry_navigation
     def step(self, *args, **kwargs):
-        self.view.menu.select('Hosts', 'Operating Systems')
+        self.view.menu.select('Hosts', 'Provisioning Setup', 'Operating Systems')
 
 
 @navigator.register(OperatingSystemEntity, 'New')

--- a/airgun/entities/oscapcontent.py
+++ b/airgun/entities/oscapcontent.py
@@ -77,7 +77,7 @@ class ShowAllSCAPContents(NavigateStep):
 
     @retry_navigation
     def step(self, *args, **kwargs):
-        self.view.menu.select('Hosts', 'SCAP contents')
+        self.view.menu.select('Hosts', 'Compliance', 'SCAP contents')
 
 
 @navigator.register(OSCAPContentEntity, 'New')

--- a/airgun/entities/oscappolicy.py
+++ b/airgun/entities/oscappolicy.py
@@ -88,7 +88,7 @@ class ShowAllSCAPPolicies(NavigateStep):
 
     @retry_navigation
     def step(self, *args, **kwargs):
-        self.view.menu.select('Hosts', 'Policies')
+        self.view.menu.select('Hosts', 'Compliance', 'Policies')
 
 
 @navigator.register(OSCAPPolicyEntity, 'New')

--- a/airgun/entities/oscaptailoringfile.py
+++ b/airgun/entities/oscaptailoringfile.py
@@ -76,7 +76,7 @@ class ShowAllSCAPTailoringFiles(NavigateStep):
 
     @retry_navigation
     def step(self, *args, **kwargs):
-        self.view.menu.select('Hosts', 'Tailoring Files')
+        self.view.menu.select('Hosts', 'Compliance', 'Tailoring Files')
 
 
 @navigator.register(OSCAPTailoringFileEntity, 'New')

--- a/airgun/entities/package.py
+++ b/airgun/entities/package.py
@@ -43,7 +43,7 @@ class ShowAllPackages(NavigateStep):
 
     @retry_navigation
     def step(self, *args, **kwargs):
-        self.view.menu.select('Content', 'Packages')
+        self.view.menu.select('Content', 'Content Types', 'Packages')
 
 
 @navigator.register(PackageEntity, 'Details')

--- a/airgun/entities/partitiontable.py
+++ b/airgun/entities/partitiontable.py
@@ -84,7 +84,7 @@ class ShowAllPartitionTables(NavigateStep):
 
     @retry_navigation
     def step(self, *args, **kwargs):
-        self.view.menu.select('Hosts', 'Partition Tables')
+        self.view.menu.select('Hosts', 'Templates', 'Partition Tables')
 
 
 @navigator.register(PartitionTableEntity, 'New')

--- a/airgun/entities/provisioning_template.py
+++ b/airgun/entities/provisioning_template.py
@@ -89,7 +89,7 @@ class ShowAllProvisioningTemplates(NavigateStep):
 
     @retry_navigation
     def step(self, *args, **kwargs):
-        self.view.menu.select('Hosts', 'Provisioning Templates')
+        self.view.menu.select('Hosts', 'Templates', 'Provisioning Templates')
 
 
 @navigator.register(ProvisioningTemplateEntity, 'New')

--- a/airgun/entities/report_template.py
+++ b/airgun/entities/report_template.py
@@ -125,7 +125,7 @@ class ShowAllReportTemplates(NavigateStep):
 
     @retry_navigation
     def step(self, *args, **kwargs):
-        self.view.menu.select('Monitor', 'Report Templates')
+        self.view.menu.select('Monitor', 'Reports', 'Report Templates')
 
 
 @navigator.register(ReportTemplateEntity, 'New')

--- a/airgun/entities/sync_templates.py
+++ b/airgun/entities/sync_templates.py
@@ -39,7 +39,7 @@ class SyncMainPageNavigation(NavigateStep):
 
     @retry_navigation
     def step(self, *args, **kwargs):
-        self.view.menu.select('Hosts', 'Sync Templates')
+        self.view.menu.select('Hosts', 'Templates', 'Sync Templates')
 
 
 @navigator.register(SyncTemplatesEntity, 'Sync')

--- a/airgun/entities/task.py
+++ b/airgun/entities/task.py
@@ -54,7 +54,7 @@ class ShowAllTasks(NavigateStep):
 
     @retry_navigation
     def step(self, *args, **kwargs):
-        self.view.menu.select('Monitor', 'Tasks')
+        self.view.menu.select('Monitor', 'Satellite Tasks', 'Tasks')
 
 
 @navigator.register(TaskEntity, 'Details')

--- a/airgun/entities/webhook.py
+++ b/airgun/entities/webhook.py
@@ -77,7 +77,7 @@ class ShowAllWebhooks(NavigateStep):
 
     @retry_navigation
     def step(self, *args, **kwargs):
-        self.view.menu.select('Administer', 'Webhooks')
+        self.view.menu.select('Administer', 'Webhook', 'Webhooks')
 
 
 @navigator.register(WebhookEntity, 'New')


### PR DESCRIPTION
In the old navigation, all items were visible and clickable after selecting first navigation level. In the new implementation of the PF4 Navigation, two levels must be clicked to see the destination.

This PR updates the routes so the Navigation works. 