### PR TITLE
[6.14.z] Change Hardware Model typo

### DIFF
--- a/airgun/views/hardware_model.py
+++ b/airgun/views/hardware_model.py
@@ -16,7 +16,7 @@ class DeleteHardwareModelDialog(ConfirmationDialog):
 
 class HardwareModelsView(BaseLoggedInView, SearchableViewMixin):
     delete_dialog = DeleteHardwareModelDialog()
-    title = Text("//h1[normalize-space(.)='Hardware Models']")
+    title = Text("//h1[normalize-space(.)='Hardware models']")
     new = Text("//a[contains(@href, '/models/new')]")
     table = SatTable(
         './/table',


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/airgun/pull/920

`test_hardwaremodel` fails because of wrong locator for page's title, changed the capitalization to `Hardware models` which fixes the test.