### PR TITLE
[6.14.z] update Search widgets to PF4 class

### DIFF
--- a/airgun/views/ansible_variable.py
+++ b/airgun/views/ansible_variable.py
@@ -7,14 +7,14 @@ from widgetastic_patternfly import BreadCrumb
 
 from airgun.views.common import BaseLoggedInView
 from airgun.views.common import SatTable
-from airgun.views.common import SearchableViewMixin
+from airgun.views.common import SearchableViewMixinPF4
 from airgun.widgets import CustomParameter
 from airgun.widgets import FilteredDropdown
 from airgun.widgets import Pagination
 from airgun.widgets import SatSelect
 
 
-class AnsibleVariablesView(BaseLoggedInView, SearchableViewMixin):
+class AnsibleVariablesView(BaseLoggedInView, SearchableViewMixinPF4):
     """Main Ansible Variables view"""
 
     title = Text("//h1[contains(normalize-space(.),'Ansible Variables')]")

--- a/airgun/views/architecture.py
+++ b/airgun/views/architecture.py
@@ -4,11 +4,11 @@ from widgetastic.widget import TextInput
 from widgetastic_patternfly import BreadCrumb
 
 from airgun.views.common import BaseLoggedInView
-from airgun.views.common import SearchableViewMixin
+from airgun.views.common import SearchableViewMixinPF4
 from airgun.widgets import MultiSelect
 
 
-class ArchitecturesView(BaseLoggedInView, SearchableViewMixin):
+class ArchitecturesView(BaseLoggedInView, SearchableViewMixinPF4):
     title = Text("//h1[normalize-space(.)='Architectures']")
     new = Text("//a[contains(@href, '/architectures/new')]")
     table = Table(

--- a/airgun/views/audit.py
+++ b/airgun/views/audit.py
@@ -3,8 +3,8 @@ from widgetastic.widget import View
 
 from airgun.exceptions import ReadOnlyWidgetError
 from airgun.views.common import BaseLoggedInView
+from airgun.views.common import SearchableViewMixinPF4
 from airgun.widgets import SatTableWithoutHeaders
-from airgun.widgets import Search
 
 
 class AuditEntry(View):
@@ -38,16 +38,10 @@ class AuditEntry(View):
         raise ReadOnlyWidgetError('View is read only, fill is prohibited')
 
 
-class AuditsView(BaseLoggedInView):
+class AuditsView(BaseLoggedInView, SearchableViewMixinPF4):
     title = Text("//h1[normalize-space(.)='Audits']")
-    searchbox = Search()
-    entry = AuditEntry()
+    table = AuditEntry()
 
     @property
     def is_displayed(self):
         return self.browser.wait_for_element(self.title, exception=False) is not None
-
-    def search(self, query):
-        self.searchbox.search(query)
-        self.title.click()  # to exit the search field
-        return self.entry.read()

--- a/airgun/views/bookmark.py
+++ b/airgun/views/bookmark.py
@@ -4,11 +4,11 @@ from widgetastic.widget import TextInput
 from widgetastic_patternfly import BreadCrumb
 
 from airgun.views.common import BaseLoggedInView
-from airgun.views.common import SearchableViewMixin
+from airgun.views.common import SearchableViewMixinPF4
 from airgun.widgets import SatTable
 
 
-class BookmarksView(BaseLoggedInView, SearchableViewMixin):
+class BookmarksView(BaseLoggedInView, SearchableViewMixinPF4):
     title = Text("//h1[normalize-space(.)='Bookmarks']")
     table = SatTable(
         ".//table",

--- a/airgun/views/cloud_insights.py
+++ b/airgun/views/cloud_insights.py
@@ -1,4 +1,3 @@
-from selenium.webdriver.common.keys import Keys
 from widgetastic.widget import Checkbox
 from widgetastic.widget import Text
 from widgetastic.widget import TextInput
@@ -11,7 +10,7 @@ from widgetastic_patternfly4.ouia import PatternflyTable
 from widgetastic_patternfly4.ouia import Switch
 
 from airgun.views.common import BaseLoggedInView
-from airgun.views.common import SearchableViewMixin
+from airgun.views.common import SearchableViewMixinPF4
 
 
 class CloudTokenView(BaseLoggedInView):
@@ -46,7 +45,7 @@ class RemediationView(Modal):
         return self.title.wait_displayed()
 
 
-class CloudInsightsView(BaseLoggedInView, SearchableViewMixin):
+class CloudInsightsView(BaseLoggedInView, SearchableViewMixinPF4):
     """Main RH Cloud Insights view."""
 
     title = Text('//h1[normalize-space(.)="Red Hat Insights"]')
@@ -71,23 +70,4 @@ class CloudInsightsView(BaseLoggedInView, SearchableViewMixin):
 
     @property
     def is_displayed(self):
-        return self.title.wait_displayed()
-
-    def search(self, query):
-        """Perform search using searchbox on the page and return table
-        contents.
-
-        :param str query: search query to type into search field. E.g. ``foo``
-            or ``name = "bar"``.
-        :return: list of dicts representing table rows
-        :rtype: list
-        """
-        if not hasattr(self.__class__, 'table'):
-            raise AttributeError(
-                f'Class {self.__class__.__name__} does not have attribute "table". '
-                'SearchableViewMixin only works with views, which have table for results. '
-                'Please define table or use custom search implementation instead'
-            )
-        self.searchbox.search(query + Keys.ENTER)
-        self.table.wait_displayed()
-        return self.table.read()
+        return self.browser.wait_for_element(self.title, exception=False) is not None

--- a/airgun/views/common.py
+++ b/airgun/views/common.py
@@ -442,7 +442,7 @@ class SearchableViewMixin(WTMixin):
         if not self.is_searchable():
             return None
         self.searchbox.search(query)
-
+        self.title.click()
         return self.table.read()
 
 
@@ -485,6 +485,7 @@ class SearchableViewMixinPF4(SearchableViewMixin):
         self.searchbox.search(query)
         self.browser.plugin.ensure_page_safe(timeout='60s')
         self.table.wait_displayed()
+        self.title.click()
         return self.table.read()
 
 

--- a/airgun/views/computeprofile.py
+++ b/airgun/views/computeprofile.py
@@ -4,11 +4,11 @@ from widgetastic.widget import TextInput
 from widgetastic_patternfly import BreadCrumb
 
 from airgun.views.common import BaseLoggedInView
-from airgun.views.common import SearchableViewMixin
+from airgun.views.common import SearchableViewMixinPF4
 from airgun.widgets import ActionsDropdown
 
 
-class ComputeProfilesView(BaseLoggedInView, SearchableViewMixin):
+class ComputeProfilesView(BaseLoggedInView, SearchableViewMixinPF4):
     title = Text('//*[(self::h1 or self::h5) and normalize-space(.)="Compute Profiles"]')
     new = Text('//a[normalize-space(.)="Create Compute Profile"]')
     table = Table(

--- a/airgun/views/domain.py
+++ b/airgun/views/domain.py
@@ -6,13 +6,13 @@ from widgetastic_patternfly import BreadCrumb
 
 from airgun.views.common import BaseLoggedInView
 from airgun.views.common import SatTab
-from airgun.views.common import SearchableViewMixin
+from airgun.views.common import SearchableViewMixinPF4
 from airgun.widgets import CustomParameter
 from airgun.widgets import FilteredDropdown
 from airgun.widgets import MultiSelect
 
 
-class DomainListView(BaseLoggedInView, SearchableViewMixin):
+class DomainListView(BaseLoggedInView, SearchableViewMixinPF4):
     """List of all domains."""
 
     title = Text('//*[(self::h1 or self::h5) and normalize-space(.)="Domains"]')

--- a/airgun/views/hardware_model.py
+++ b/airgun/views/hardware_model.py
@@ -4,7 +4,7 @@ from widgetastic_patternfly import BreadCrumb
 from widgetastic_patternfly import Button
 
 from airgun.views.common import BaseLoggedInView
-from airgun.views.common import SearchableViewMixin
+from airgun.views.common import SearchableViewMixinPF4
 from airgun.widgets import ConfirmationDialog
 from airgun.widgets import SatTable
 
@@ -14,7 +14,7 @@ class DeleteHardwareModelDialog(ConfirmationDialog):
     cancel_dialog = Text(".//button[normalize-space(.)='Cancel']")
 
 
-class HardwareModelsView(BaseLoggedInView, SearchableViewMixin):
+class HardwareModelsView(BaseLoggedInView, SearchableViewMixinPF4):
     delete_dialog = DeleteHardwareModelDialog()
     title = Text("//h1[normalize-space(.)='Hardware Models']")
     new = Text("//a[contains(@href, '/models/new')]")

--- a/airgun/views/host.py
+++ b/airgun/views/host.py
@@ -21,7 +21,7 @@ from widgetastic_patternfly4.tabs import Tab
 
 from airgun.views.common import BaseLoggedInView
 from airgun.views.common import SatTab
-from airgun.views.common import SearchableViewMixin
+from airgun.views.common import SearchableViewMixinPF4
 from airgun.views.job_invocation import JobInvocationCreateView
 from airgun.views.job_invocation import JobInvocationStatusView
 from airgun.views.task import TaskDetailsView
@@ -196,7 +196,7 @@ class HostInterface(View):
         return self.browser.wait_for_element(self.title, visible=True, exception=False) is not None
 
 
-class HostsView(BaseLoggedInView, SearchableViewMixin):
+class HostsView(BaseLoggedInView, SearchableViewMixinPF4):
     title = Text("//h1[normalize-space(.)='Hosts']")
     manage_columns = PF4Button("OUIA-Generated-Button-link-1")
     export = Text(".//a[contains(@class, 'btn')][contains(@href, 'hosts.csv')]")

--- a/airgun/views/hostgroup.py
+++ b/airgun/views/hostgroup.py
@@ -8,7 +8,7 @@ from widgetastic_patternfly4 import Button as PF4Button
 
 from airgun.views.common import BaseLoggedInView
 from airgun.views.common import SatTab
-from airgun.views.common import SearchableViewMixin
+from airgun.views.common import SearchableViewMixinPF4
 from airgun.widgets import ActionsDropdown
 from airgun.widgets import ConfigGroupMultiSelect
 from airgun.widgets import FilteredDropdown
@@ -29,7 +29,7 @@ class ActivationKeyDropDown(ActionsDropdown):
         ]
 
 
-class HostGroupsView(BaseLoggedInView, SearchableViewMixin):
+class HostGroupsView(BaseLoggedInView, SearchableViewMixinPF4):
     title = Text(
         "//h1[contains(., 'Host Group Configuration') or normalize-space(.)='Host Groups']"
     )

--- a/airgun/views/job_template.py
+++ b/airgun/views/job_template.py
@@ -8,7 +8,7 @@ from widgetastic_patternfly import BreadCrumb
 
 from airgun.views.common import BaseLoggedInView
 from airgun.views.common import SatTab
-from airgun.views.common import SearchableViewMixin
+from airgun.views.common import SearchableViewMixinPF4
 from airgun.views.common import TemplateEditor
 from airgun.views.common import TemplateInputItem
 from airgun.widgets import ActionsDropdown
@@ -18,7 +18,7 @@ from airgun.widgets import MultiSelect
 from airgun.widgets import RemovableWidgetsItemsListView
 
 
-class JobTemplatesView(BaseLoggedInView, SearchableViewMixin):
+class JobTemplatesView(BaseLoggedInView, SearchableViewMixinPF4):
     title = Text("//h1[contains(., 'Job Templates')]")
     import_template = Text("//a[normalize-space(.)='Import']")
     new = Text("//a[contains(@href, '/job_templates/new')]")

--- a/airgun/views/location.py
+++ b/airgun/views/location.py
@@ -7,14 +7,14 @@ from widgetastic_patternfly import BreadCrumb
 
 from airgun.views.common import BaseLoggedInView
 from airgun.views.common import SatVerticalTab
-from airgun.views.common import SearchableViewMixin
+from airgun.views.common import SearchableViewMixinPF4
 from airgun.widgets import ActionsDropdown
 from airgun.widgets import CustomParameter
 from airgun.widgets import FilteredDropdown
 from airgun.widgets import MultiSelect
 
 
-class LocationsView(BaseLoggedInView, SearchableViewMixin):
+class LocationsView(BaseLoggedInView, SearchableViewMixinPF4):
     title = Text("//h1[normalize-space(.)='Locations']")
     new = Text("//a[contains(@href, '/locations/new')]")
     table = Table(

--- a/airgun/views/media.py
+++ b/airgun/views/media.py
@@ -6,12 +6,12 @@ from widgetastic_patternfly import BreadCrumb
 
 from airgun.views.common import BaseLoggedInView
 from airgun.views.common import SatTab
-from airgun.views.common import SearchableViewMixin
+from airgun.views.common import SearchableViewMixinPF4
 from airgun.widgets import FilteredDropdown
 from airgun.widgets import MultiSelect
 
 
-class MediumView(BaseLoggedInView, SearchableViewMixin):
+class MediumView(BaseLoggedInView, SearchableViewMixinPF4):
     title = Text("//h1[normalize-space(.)='Installation Media']")
     new = Text("//a[contains(@href, '/media/new')]")
     table = Table(

--- a/airgun/views/modulestream.py
+++ b/airgun/views/modulestream.py
@@ -1,41 +1,20 @@
 from widgetastic.widget import Table
 from widgetastic.widget import Text
-from widgetastic.widget import TextInput
 from widgetastic.widget import View
 from widgetastic_patternfly import BreadCrumb
-from widgetastic_patternfly import Button
 
 from airgun.views.common import BaseLoggedInView
 from airgun.views.common import SatTab
 from airgun.views.common import SatTable
+from airgun.views.common import SearchableViewMixinPF4
 from airgun.widgets import SatTableWithUnevenStructure
-from airgun.widgets import Search
 
 
-class CustomSearch(Search):
-    search_field = TextInput(id='downshift-0-input')
-    search_button = Button('Search')
-
-
-class ModuleStreamView(BaseLoggedInView):
+class ModuleStreamView(BaseLoggedInView, SearchableViewMixinPF4):
     """Main Module_Streams view"""
 
     title = Text("//h2[contains(., 'Module Streams')]")
     table = SatTable('.//table', column_widgets={'Name': Text("./a")})
-
-    search_box = CustomSearch()
-
-    def search(self, query):
-        """Perform search using search box on the page and return table
-        contents.
-
-        :param str query: search query to type into search field. E.g.
-            ``name = "bar"``.
-        :return: list of dicts representing table rows
-        :rtype: list
-        """
-        self.search_box.search(query)
-        return self.table.read()
 
     @property
     def is_displayed(self):

--- a/airgun/views/organization.py
+++ b/airgun/views/organization.py
@@ -7,14 +7,14 @@ from widgetastic_patternfly import BreadCrumb
 
 from airgun.views.common import BaseLoggedInView
 from airgun.views.common import SatVerticalTab
-from airgun.views.common import SearchableViewMixin
+from airgun.views.common import SearchableViewMixinPF4
 from airgun.widgets import ActionsDropdown
 from airgun.widgets import CustomParameter
 from airgun.widgets import FilteredDropdown
 from airgun.widgets import MultiSelect
 
 
-class OrganizationsView(BaseLoggedInView, SearchableViewMixin):
+class OrganizationsView(BaseLoggedInView, SearchableViewMixinPF4):
     title = Text("//h1[normalize-space(.)='Organizations']")
     new = Text("//a[contains(@href, '/organizations/new')]")
     table = Table(

--- a/airgun/views/os.py
+++ b/airgun/views/os.py
@@ -6,7 +6,7 @@ from widgetastic_patternfly import BreadCrumb
 
 from airgun.views.common import BaseLoggedInView
 from airgun.views.common import SatTab
-from airgun.views.common import SearchableViewMixin
+from airgun.views.common import SearchableViewMixinPF4
 from airgun.widgets import ActionsDropdown
 from airgun.widgets import CustomParameter
 from airgun.widgets import FilteredDropdown
@@ -69,7 +69,7 @@ class TemplatesList(View):
             result[title].fill(select_value)
 
 
-class OperatingSystemsView(BaseLoggedInView, SearchableViewMixin):
+class OperatingSystemsView(BaseLoggedInView, SearchableViewMixinPF4):
     title = Text("//h1[normalize-space(.)='Operating Systems']")
     new = Text("//a[contains(@href, '/operatingsystems/new')]")
     table = Table(

--- a/airgun/views/oscapcontent.py
+++ b/airgun/views/oscapcontent.py
@@ -6,13 +6,13 @@ from widgetastic_patternfly import BreadCrumb
 
 from airgun.views.common import BaseLoggedInView
 from airgun.views.common import SatTab
-from airgun.views.common import SearchableViewMixin
+from airgun.views.common import SearchableViewMixinPF4
 from airgun.widgets import ActionsDropdown
 from airgun.widgets import MultiSelect
 from airgun.widgets import SatTable
 
 
-class SCAPContentsView(BaseLoggedInView, SearchableViewMixin):
+class SCAPContentsView(BaseLoggedInView, SearchableViewMixinPF4):
     title = Text("//h1[normalize-space(.)='SCAP Content']")
     new = Text("//a[contains(@href, 'scap_contents/new')]")
     table = SatTable(

--- a/airgun/views/partitiontable.py
+++ b/airgun/views/partitiontable.py
@@ -9,7 +9,7 @@ from widgetastic_patternfly import Button
 
 from airgun.views.common import BaseLoggedInView
 from airgun.views.common import SatTab
-from airgun.views.common import SearchableViewMixin
+from airgun.views.common import SearchableViewMixinPF4
 from airgun.views.common import TemplateInputItem
 from airgun.widgets import ACEEditor
 from airgun.widgets import ActionsDropdown
@@ -18,7 +18,7 @@ from airgun.widgets import MultiSelect
 from airgun.widgets import RemovableWidgetsItemsListView
 
 
-class PartitionTablesView(BaseLoggedInView, SearchableViewMixin):
+class PartitionTablesView(BaseLoggedInView, SearchableViewMixinPF4):
 
     title = Text("//h1[text()='Partition Tables']")
     new = Button("Create Partition Table")

--- a/airgun/views/provisioning_template.py
+++ b/airgun/views/provisioning_template.py
@@ -9,7 +9,7 @@ from widgetastic_patternfly import Button
 
 from airgun.views.common import BaseLoggedInView
 from airgun.views.common import SatTab
-from airgun.views.common import SearchableViewMixin
+from airgun.views.common import SearchableViewMixinPF4
 from airgun.views.common import TemplateEditor
 from airgun.views.common import TemplateInputItem
 from airgun.widgets import ActionsDropdown
@@ -26,7 +26,7 @@ class TemplateHostEnvironmentAssociation(GenericRemovableWidgetItem):
     host_group = Select(locator=".//select[contains(@name, '[hostgroup_id]')]")
 
 
-class ProvisioningTemplatesView(BaseLoggedInView, SearchableViewMixin):
+class ProvisioningTemplatesView(BaseLoggedInView, SearchableViewMixinPF4):
     title = Text("//h1[normalize-space(.)='Provisioning Templates']")
     new = Button("Create Template")
     build_pxe_default = Button("Build PXE Default")

--- a/airgun/views/report_template.py
+++ b/airgun/views/report_template.py
@@ -8,7 +8,7 @@ from widgetastic_patternfly import Button
 
 from airgun.views.common import BaseLoggedInView
 from airgun.views.common import SatTab
-from airgun.views.common import SearchableViewMixin
+from airgun.views.common import SearchableViewMixinPF4
 from airgun.views.common import TemplateEditor
 from airgun.views.common import TemplateInputItem
 from airgun.widgets import ActionsDropdown
@@ -18,7 +18,7 @@ from airgun.widgets import RemovableWidgetsItemsListView
 from airgun.widgets import TextInputsGroup
 
 
-class ReportTemplatesView(BaseLoggedInView, SearchableViewMixin):
+class ReportTemplatesView(BaseLoggedInView, SearchableViewMixinPF4):
     title = Text("//h1[normalize-space(.)='Report Templates']")
     new = Button("Create Template")
     table = Table(

--- a/airgun/views/role.py
+++ b/airgun/views/role.py
@@ -3,13 +3,13 @@ from widgetastic.widget import TextInput
 from widgetastic_patternfly import BreadCrumb
 
 from airgun.views.common import BaseLoggedInView
-from airgun.views.common import SearchableViewMixin
+from airgun.views.common import SearchableViewMixinPF4
 from airgun.widgets import ActionsDropdown
 from airgun.widgets import MultiSelect
 from airgun.widgets import SatTable
 
 
-class RolesView(BaseLoggedInView, SearchableViewMixin):
+class RolesView(BaseLoggedInView, SearchableViewMixinPF4):
     title = Text("//h1[normalize-space(.)='Roles']")
     new = Text("//a[contains(@href, '/roles/new')]")
     table = SatTable(

--- a/airgun/views/settings.py
+++ b/airgun/views/settings.py
@@ -5,11 +5,11 @@ from widgetastic_patternfly import Button
 
 from airgun.views.common import BaseLoggedInView
 from airgun.views.common import SatTab
-from airgun.views.common import SearchableViewMixin
+from airgun.views.common import SearchableViewMixinPF4
 from airgun.widgets import PopOverWidget
 
 
-class SettingsView(BaseLoggedInView, SearchableViewMixin):
+class SettingsView(BaseLoggedInView, SearchableViewMixinPF4):
     title = Text("//h1[normalize-space(.)='Settings']")
     table = Table(
         './/table',

--- a/airgun/views/task.py
+++ b/airgun/views/task.py
@@ -7,7 +7,7 @@ from widgetastic_patternfly4 import Pagination
 
 from airgun.views.common import BaseLoggedInView
 from airgun.views.common import SatTab
-from airgun.views.common import SearchableViewMixin
+from airgun.views.common import SearchableViewMixinPF4
 from airgun.widgets import ActionsDropdown
 from airgun.widgets import PieChart
 from airgun.widgets import ProgressBar
@@ -26,7 +26,7 @@ class TaskReadOnlyEntryError(ReadOnlyEntry):
     BASE_LOCATOR = "//span[contains(., '{}')]//parent::div" "/following-sibling::pre"
 
 
-class TasksView(BaseLoggedInView, SearchableViewMixin):
+class TasksView(BaseLoggedInView, SearchableViewMixinPF4):
     title = Text("//h1[normalize-space(.)='Tasks']")
     focus = ActionsDropdown("//div[./button[@id='tasks-dashboard-time-period-dropdown']]")
     table = SatTable(

--- a/airgun/views/user.py
+++ b/airgun/views/user.py
@@ -7,12 +7,12 @@ from widgetastic_patternfly import BreadCrumb
 
 from airgun.views.common import BaseLoggedInView
 from airgun.views.common import SatTab
-from airgun.views.common import SearchableViewMixin
+from airgun.views.common import SearchableViewMixinPF4
 from airgun.widgets import FilteredDropdown
 from airgun.widgets import MultiSelect
 
 
-class UsersView(BaseLoggedInView, SearchableViewMixin):
+class UsersView(BaseLoggedInView, SearchableViewMixinPF4):
     title = Text("//h1[normalize-space(.)='Users']")
     new = Text("//a[contains(@href, '/users/new')]")
     table = Table(

--- a/airgun/views/usergroup.py
+++ b/airgun/views/usergroup.py
@@ -8,12 +8,12 @@ from widgetastic_patternfly4 import Button as P4Button
 
 from airgun.views.common import BaseLoggedInView
 from airgun.views.common import SatTab
-from airgun.views.common import SearchableViewMixin
+from airgun.views.common import SearchableViewMixinPF4
 from airgun.widgets import FilteredDropdown
 from airgun.widgets import MultiSelect
 
 
-class UserGroupsView(BaseLoggedInView, SearchableViewMixin):
+class UserGroupsView(BaseLoggedInView, SearchableViewMixinPF4):
     title = Text("//h1[normalize-space(.)='User Groups']")
     new_on_blank_page = P4Button('Create User group')
     new = Text("//a[contains(@href, '/usergroups/new')]")

--- a/airgun/widgets.py
+++ b/airgun/widgets.py
@@ -751,14 +751,10 @@ class Search(Widget):
 class PF4Search(Search):
     """PF4 Searchbar for table filtering"""
 
-    ROOT = '//div[@role="combobox" or @aria-haspopup="listbox"]'
-    search_field = TextInput(
-        locator=(
-            ".//input[@type='text' or @id='downshift-0-input' or"
-            " contains(@class, 'pf-m-search') or data-ouia-component-type='PF4/TextInput']"
-        )
-    )
-    clear_button = Button(locator=".//button[contains(@class,'search-clear')]")
+    ROOT = '//div[@class="foreman-search-bar"]'
+    search_field = TextInput(locator=(".//input[@aria-label='Search input']"))
+    search_button = Text(locator=(".//button[@aria-label='Search']"))
+    clear_button = Button(locator=(".//input[@aria-label='Reset search']"))
 
     def clear(self):
         """Clears search field value and re-trigger search to remove all
@@ -772,6 +768,8 @@ class PF4Search(Search):
     def search(self, value):
         self.clear()
         self.fill(value)
+        if self.search_button.is_displayed:
+            self.search_button.click()
 
 
 class SatVerticalNavigation(VerticalNavigation):


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/airgun/pull/913

This PR updates views to use the common `SearchableViewMixinPF4` which uses the new `PF4Search` widget. Should help simplify the Search locators across different views.

**Changed files:**
- `airgun/`
	- `widgets.py`
- `airgun/views/`
	- `common.py`
	- `ansible_variable.py`
	- `architecture.py`
	- `audit.py`
	- `bookmark.py`
	- `cloud_insights.py`
	- `computeprofile.py`
	- `domain.py`
	- `hardware_model.py`
	- `host.py`
	- `hostgroup.py`
	- `job_template.py`
	- `location.py`
	- `media.py`
	- `modulestream.py`
	- `organization.py`
	- `os.py`
	- `oscapcontent.py`
	- `partitiontable.py`
	- `provisioning_template.py`
	- `report_template.py`
	- `role.py`
	- `settings.py`
	- `task.py`
	- `user.py`
	- `usergroup.py`