### PR TITLE
[6.14.z] Rework of virt card

### DIFF
--- a/airgun/entities/host_new.py
+++ b/airgun/entities/host_new.py
@@ -478,7 +478,7 @@ class NewHostEntity(HostEntity):
 
     def get_virtualization(self, entity_name):
         view = self.navigate_to(self, 'NewDetails', entity_name=entity_name)
-        view.wait_displayed()
+        view.details.virtualization.wait_displayed()
         self.browser.plugin.ensure_page_safe()
         return view.details.virtualization.read()
 

--- a/airgun/views/host_new.py
+++ b/airgun/views/host_new.py
@@ -338,29 +338,7 @@ class NewHostDetailsView(BaseLoggedInView):
         class virtualization(Card):
             ROOT = './/article[contains(@data-ouia-component-id, "card-template-Virtualization")]'
 
-            datacenter = Text('.//div[contains(@class, "pf-c-description-list__group")][1]//dd')
-            cluster = Text('.//div[contains(@class, "pf-c-description-list__group")][2]//dd')
-            memory = Text('.//div[contains(@class, "pf-c-description-list__group")][3]//dd')
-            public_ip_address = Text(
-                './/div[contains(@class, "pf-c-description-list__group")][4]//dd'
-            )
-            mac_address = Text('.//div[contains(@class, "pf-c-description-list__group")][5]//dd')
-            cpus = Text('.//div[contains(@class, "pf-c-description-list__group")][6]//dd')
-            cores_per_socket = Text(
-                './/div[contains(@class, "pf-c-description-list__group")][7]//dd'
-            )
-            firmware = Text('.//div[contains(@class, "pf-c-description-list__group")][8]//dd')
-            hypervisor = Text('.//div[contains(@class, "pf-c-description-list__group")][9]//dd')
-            connection_state = Text(
-                './/div[contains(@class, "pf-c-description-list__group")][10]//dd'
-            )
-            overall_status = Text(
-                './/div[contains(@class, "pf-c-description-list__group")][11]//dd'
-            )
-            annotation_notes = Text(
-                './/div[contains(@class, "pf-c-description-list__group")][12]//dd'
-            )
-            running_on = Text('.//div[contains(@class, "pf-c-description-list__group")][13]//dd')
+            details = HostDetailsCard()
 
     @View.nested
     class content(Tab):


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/airgun/pull/933

Adding a small clause here to allow pages that don't have a title attribute to continue using search. Only one I know of for sure that's this way, are the vm_import tests within computeresources, but there might be others. 

This seems like a no op for most pages, and allows others to continue to use search. 