### PR TITLE
Fix clean button locator in PF4 search.

### DIFF
--- a/airgun/widgets.py
+++ b/airgun/widgets.py
@@ -754,7 +754,7 @@ class PF4Search(Search):
     ROOT = '//div[@class="foreman-search-bar"]'
     search_field = TextInput(locator=(".//input[@aria-label='Search input']"))
     search_button = Text(locator=(".//button[@aria-label='Search']"))
-    clear_button = Button(locator=(".//input[@aria-label='Reset search']"))
+    clear_button = Text(locator=(".//button[@aria-label='Reset search']"))
 
     def clear(self):
         """Clears search field value and re-trigger search to remove all


### PR DESCRIPTION
As it was, we were getting an error when searching for the element, getting False for is_displayed. Consequently, the clear button was not clicked and a generic browser clear was called instead. The text disappeared for a bit and then it got re-filled to the search field.
It caused failures in tests such as
tests/foreman/ui/test_dashboard.py::test_positive_task_status
Changing type and locator fixes the issue.