### PR TITLE
add Host statues modal support

### DIFF
--- a/airgun/entities/host_new.py
+++ b/airgun/entities/host_new.py
@@ -10,6 +10,7 @@ from airgun.views.host_new import (
     EnableTracerView,
     InstallPackagesView,
     ManageHostCollectionModal,
+    ManageHostStatusesView,
     ModuleStreamDialog,
     NewHostDetailsView,
     ParameterDeleteDialog,
@@ -43,6 +44,19 @@ class NewHostEntity(HostEntity):
         # Run this read twice to navigate to the page and load it before reading
         view.read(widget_names=widget_names)
         return view.read(widget_names=widget_names)
+
+    def get_host_statuses(self, entity_name):
+        """Read host statuses from Host Details page
+
+        Args:
+            entity_name: Name of the host
+        """
+        view = self.navigate_to(self, 'NewDetails', entity_name=entity_name)
+        view.wait_displayed()
+        self.browser.plugin.ensure_page_safe()
+        view.overview.host_status.manage_all_statuses.click()
+        view = ManageHostStatusesView(self.browser)
+        return view.read()
 
     def edit_system_purpose(
         self, entity_name, role=None, sla=None, usage=None, release_ver=None, add_ons=None

--- a/airgun/entities/host_new.py
+++ b/airgun/entities/host_new.py
@@ -56,7 +56,9 @@ class NewHostEntity(HostEntity):
         self.browser.plugin.ensure_page_safe()
         view.overview.host_status.manage_all_statuses.click()
         view = ManageHostStatusesView(self.browser)
-        return view.read()
+        values = view.read()
+        view.close_modal.click()
+        return values
 
     def edit_system_purpose(
         self, entity_name, role=None, sla=None, usage=None, release_ver=None, add_ons=None

--- a/airgun/views/host_new.py
+++ b/airgun/views/host_new.py
@@ -800,13 +800,13 @@ class ManageHostStatusesView(View):
 
     ROOT = './/div[@data-ouia-component-id="statuses-modal"]'
 
-    host_statuses_table = Table(
-        locator='.//table[contains(@class, "pf-c-table")]',
+    host_statuses_table = PatternflyTable(
+        component_id='statuses-table',
         column_widgets={
-            'name': Text('.//td[1]'),
-            'status': Text('.//td[2]'),
-            'reported_at': Text('.//td[3]'),
-            '3': Button(locator='.//td[4]'),
+            'Name': Text('.//td[1]'),
+            'Status': Text('.//td[2]'),
+            'Reported at': Text('.//td[3]'),
+            3: Button(locator='.//td[4]'),
         },
     )
 

--- a/airgun/views/host_new.py
+++ b/airgun/views/host_new.py
@@ -795,6 +795,26 @@ class EditSystemPurposeView(View):
     cancel = OUIAButton('cancel-syspurpose')
 
 
+class ManageHostStatusesView(View):
+    """Manage host statuses modal"""
+
+    ROOT = './/div[@data-ouia-component-id="statuses-modal"]'
+
+    host_statuses_table = Table(
+        locator='.//table[contains(@class, "pf-c-table")]',
+        column_widgets={
+            'name': Text('.//td[1]'),
+            'status': Text('.//td[2]'),
+            'reported_at': Text('.//td[3]'),
+            '3': Button(locator='.//td[4]'),
+        },
+    )
+
+    def read(self):
+        # Parses into a dictionary of {name: {status, reported_at}}
+        return {value.pop('Name'): value for value in self.host_statuses_table.read()}
+
+
 class EditAnsibleRolesView(View):
     """Edit Ansible Roles Modal"""
 

--- a/airgun/views/host_new.py
+++ b/airgun/views/host_new.py
@@ -799,14 +799,14 @@ class ManageHostStatusesView(View):
     """Manage host statuses modal"""
 
     ROOT = './/div[@data-ouia-component-id="statuses-modal"]'
-
+    close_modal = Button(locator='.//button[@aria-label="Close"]')
     host_statuses_table = PatternflyTable(
         component_id='statuses-table',
         column_widgets={
-            'Name': Text('.//td[1]'),
-            'Status': Text('.//td[2]'),
-            'Reported at': Text('.//td[3]'),
-            3: Button(locator='.//td[4]'),
+            'Name': Text('.//td[contains(@data-label, "Name")]'),
+            'Status': Text('.//td[contains(@data-label, "Status")]'),
+            'Reported at': Text('.//td[contains(@data-label, "Reported at")]'),
+            3: Button(locator='.//td[contains(@class, "action")]'),
         },
     )
 


### PR DESCRIPTION
Adds support for reading the `Manage host statuses` modal in the new Host page.
Calling `session.host_new.get_host_statuses(entity_name)` returns a dictionary of the values:

```
{
'Execution': {'Status': 'Last execution failed', 'Reported at': '8 minutes ago', 3: ''},
'Configuration': {'Status': 'N/A', 'Reported at': 'N/A', 3: ''}, 
'Build': {'Status': 'N/A', 'Reported at': 'N/A', 3: ''}, 
...
}
```

I will update https://github.com/SatelliteQE/robottelo/blob/master/tests/foreman/ui/test_rhcloud_insights.py to use this instead of the old page, then PRT can be ran, see here https://github.com/SatelliteQE/robottelo/pull/12582