### PR TITLE
[6.13.z] adding the test name as metadata for searching in grid sessions

### DIFF
--- a/airgun/browser.py
+++ b/airgun/browser.py
@@ -170,6 +170,10 @@ class SeleniumBrowserFactory:
 
         Note: should not be called directly, use :meth:`get_browser` instead.
         """
+        if self.test_name:
+            self.web_kaifuku.webdriver_options.desired_capabilities.update(
+                {'se:test_name': self.test_name}
+            )
         manager = BrowserManager.from_conf(self.web_kaifuku)
         self._webdriver = manager.start()
         self._set_session_cookie()


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/airgun/pull/964

![image](https://github.com/SatelliteQE/airgun/assets/3190629/01c5c42c-de41-4a7b-b77b-4d39b9fbd914)
