### PR TITLE
cleaning the video recording after test pass

### DIFF
--- a/airgun/browser.py
+++ b/airgun/browser.py
@@ -87,9 +87,9 @@ class SeleniumBrowserFactory:
         :raises: ValueError: If wrong ``provider`` or ``browser`` specified.
         """
         if self.provider == 'selenium':
-            return self._get_selenium_browser()
+            return self._get_selenium_browser(), None
         elif self.provider == 'remote':
-            return self._get_remote_browser()
+            return self._get_remote_browser(), self.web_kaifuku.webdriver_options.command_executor
         else:
             raise ValueError(
                 f'"{self.provider}" browser is not supported. '

--- a/setup.py
+++ b/setup.py
@@ -26,6 +26,7 @@ setup(
         'widgetastic.core',
         'widgetastic.patternfly',
         'widgetastic.patternfly4',
+        'broker[docker]',
     ],
     packages=find_packages(exclude=['tests*']),
     package_data={'': ['LICENSE']},


### PR DESCRIPTION
```
/Users/okhatavk/satellite/robottelo/env/bin/python /Applications/PyCharm CE.app/Contents/plugins/python-ce/helpers/pycharm/_jb_pytest_runner.py --path /Users/okhatavk/satellite/robottelo/tests/foreman/ui/test_settings.py -- -k test_negative_validate_foreman_url_error_message 
Testing started at 5:03 pm ...
Launching pytest with arguments -k test_negative_validate_foreman_url_error_message /Users/okhatavk/satellite/robottelo/tests/foreman/ui/test_settings.py --no-header --no-summary -q in /Users/okhatavk/satellite/robottelo

============================= test session starts ==============================
collecting ... collected 16 items / 14 deselected / 2 selected

tests/foreman/ui/test_settings.py::test_negative_validate_foreman_url_error_message[foreman_url] 
tests/foreman/ui/test_settings.py::test_negative_validate_foreman_url_error_message[entries_per_page] 

========== 2 passed, 14 deselected, 10 warnings in 357.73s (0:05:57) ===========
2023-09-27 17:03:28 - robottelo.collection - INFO - Processing test items to add testimony token markers
PASSED [ 50%]PASSED [100%]
Process finished with exit code 0

```