### PR TITLE
[6.14.z] subscription page failure fix

### DIFF
--- a/airgun/entities/subscription.py
+++ b/airgun/entities/subscription.py
@@ -36,8 +36,8 @@ class SubscriptionEntity(BaseEntity):
             timeout=timeout,
             logger=view.progressbar.logger,
         )
-        view.flash.assert_no_error(ignore_messages=ignore_error_messages)
         view.flash.dismiss()
+        view.flash.assert_no_error(ignore_messages=ignore_error_messages)
         wait_for(
             lambda: self.has_manifest == has_manifest,
             handle_exception=True,
@@ -172,6 +172,11 @@ class SubscriptionEntity(BaseEntity):
         view.delete_button.click()
         view.confirm_deletion.confirm()
         self._wait_for_process_to_finish('Delete Upstream Subscription', has_manifest=True)
+
+    def read_subscriptions(self):
+        """Return subscriptions table"""
+        view = self.navigate_to(self, 'All')
+        return view.table.read()
 
 
 class SubscriptionNavigationStep(NavigateStep):


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/airgun/pull/992

Airgun support added because `tests>foreman>ui>test_subscription.py::test_positive_end_to_end` was failing due to flash message, Also uploaded manifest has sca enabled for orgnization and because of that test couldn't read subscription status from dashboard page, So added support to read subscription table.
Note: These are dependable changes for `test_subscription.py::test_positive_end_to_end` to get execute successfully. Dependant [PR #12781](https://github.com/SatelliteQE/robottelo/pull/12781)