### PR TITLE
[6.14.z] Fix bad table row locator

### DIFF
--- a/airgun/views/activationkey.py
+++ b/airgun/views/activationkey.py
@@ -25,7 +25,7 @@ class ActivationKeysView(BaseLoggedInView, SearchableViewMixin):
 
     title = Text("//h2[contains(., 'Activation Keys')]")
     new = Text("//button[contains(@href, '/activation_keys/new')]")
-    table = Table('.//table', column_widgets={'Name': Text('./a')})
+    table = Table('.//table', column_widgets={'Name': Text('.//a')})
 
     @property
     def is_displayed(self):


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/airgun/pull/997

This looks like a troll fix, but it should get the 'test_positive_end_to_end_crud' passing.