### PR TITLE
Update the Container Image Tags page view

### DIFF
--- a/airgun/views/containerimagetag.py
+++ b/airgun/views/containerimagetag.py
@@ -36,12 +36,31 @@ class ContainerImageTagDetailsView(TaskDetailsView):
     @View.nested
     class details(SatTab):
         product = ReadOnlyEntry(name='Product')
-        repository = ReadOnlyEntry(name='Repository')
+        schema = ReadOnlyEntry(name='Schema Version')
+        manifest_type = ReadOnlyEntry(name='Manifest Type')
+        digest = ReadOnlyEntry(name='Digest')
 
     @View.nested
     class lce(SatTab):
         TAB_NAME = 'Lifecycle Environments'
         table = SatTable(
             './/table',
-            column_widgets={'Environment': Text('./a'), 'Content View Version': Text('./a')},
+            column_widgets={
+                'Environment': Text('./a'),
+                'Content View Version': Text('./a'),
+                'Published At': Text('./a'),
+            },
+        )
+
+    @View.nested
+    class repos(SatTab):
+        TAB_NAME = 'Repositories'
+        table = SatTable(
+            './/table',
+            column_widgets={
+                'Name': Text('./a'),
+                'Product': Text('./a'),
+                'Content View': Text('./a'),
+                'Last Sync': Text('./a'),
+            },
         )


### PR DESCRIPTION
In 6.14 and later the structure of the `Container Image Tags` page has been changed - repository was removed from the `Details` tab and a new `Repositories` tab was added.

For reference: https://github.com/Katello/katello/pull/10533

This PR updates the view accordingly.