### PR TITLE
Remove date dependent screenshot path

### DIFF
--- a/airgun/session.py
+++ b/airgun/session.py
@@ -301,10 +301,8 @@ class Session:
         session happens.
         """
         now = datetime.now()
-        path = os.path.join(
-            settings.selenium.screenshots_path,
-            now.strftime('%Y-%m-%d'),
-        )
+        path = settings.selenium.screenshots_path
+
         if not os.path.exists(path):
             os.makedirs(path)
         path = os.path.join(


### PR DESCRIPTION
* Do not implicitly overwrite `settings.selenium.screenshots_path`
* Date is already set in the filename
* Reduce datetime dependency

See also https://github.com/SatelliteQE/airgun/issues/989