### PR TITLE
Remove katello-agent from entities and views

### DIFF
--- a/airgun/entities/hostcollection.py
+++ b/airgun/entities/hostcollection.py
@@ -70,7 +70,7 @@ class HostCollectionEntity(BaseEntity):
         content_type='Package',
         packages=None,
         action='install',
-        action_via='via Katello Agent',
+        action_via='via remote execution',
         job_values=None,
     ):
         """Manage host collection packages.
@@ -83,8 +83,7 @@ class HostCollectionEntity(BaseEntity):
         :param str action: The action to apply. Available options: install,
             update, update_all, delete.
         :param str action_via: Via which mean to apply action. Available
-            options: "via Katello Agent", "via remote execution",
-            "via remote execution - customize first"
+            options: "via remote execution", "via remote execution - customize first"
         :param dict job_values: Remote Execution Job custom form values.
             When action_via is: "via remote execution - customize first",
             the new remote execution job form is opened and we can set custom
@@ -102,8 +101,6 @@ class HostCollectionEntity(BaseEntity):
         view.apply_action(action, action_via=action_via)
         view.flash.assert_no_error()
         view.flash.dismiss()
-        if action_via == 'via Katello Agent':
-            view.done.click()
         if action_via == 'via remote execution - customize first':
             # After this step the user is redirected to remote execution job
             # create view.
@@ -111,19 +108,18 @@ class HostCollectionEntity(BaseEntity):
             job_create_view.fill(job_values)
             job_create_view.submit.click()
 
-        if action_via in ('via remote execution', 'via remote execution - customize first'):
-            # After this step the user is redirected to job status view.
-            job_status_view = JobInvocationStatusView(view.browser)
-            wait_for(
-                lambda: (
-                    job_status_view.overview.job_status.read() != 'Pending'
-                    and job_status_view.overview.job_status_progress.read() == '100%'
-                ),
-                timeout=300,
-                delay=10,
-                logger=view.logger,
-            )
-            return job_status_view.overview.read()
+        # After this step the user is redirected to job status view.
+        job_status_view = JobInvocationStatusView(view.browser)
+        wait_for(
+            lambda: (
+                job_status_view.overview.job_status.read() != 'Pending'
+                and job_status_view.overview.job_status_progress.read() == '100%'
+            ),
+            timeout=300,
+            delay=10,
+            logger=view.logger,
+        )
+        return job_status_view.overview.read()
 
     def search_applicable_hosts(self, entity_name, errata_id):
         """Check for search URI in Host Collection errata view.
@@ -141,21 +137,19 @@ class HostCollectionEntity(BaseEntity):
         return uri
 
     def install_errata(
-        self, entity_name, errata_id, install_via='via Katello agent', job_values=None
+        self, entity_name, errata_id, install_via='via remote execution', job_values=None
     ):
         """Install host collection errata
 
         :param str entity_name:  The host collection name.
         :param str errata_id: the errata id to install.
         :param str install_via: Via which mean to install errata. Available
-            options: "via Katello Agent", "via remote execution",
-            "via remote execution - customize first"
+            options: "via remote execution", "via remote execution - customize first"
         :param dict job_values: Remote Execution Job custom form values.
             When install_via is: "via remote execution - customize first",
             the new remote execution job form is opened and we can set custom
             values.
-        :return: Task details view values when install "via kattelo agent" else
-            returns job status view values.
+        :return: Job status view values.
         """
         if job_values is None:
             job_values = {}
@@ -176,23 +170,18 @@ class HostCollectionEntity(BaseEntity):
             job_create_view.fill(job_values)
             job_create_view.submit.click()
 
-        if install_via == 'via Katello agent':
-            task_view = HostCollectionActionTaskDetailsView(view.browser)
-            task_view.progressbar.wait_for_result()
-            return task_view.read()
-        else:
-            # After this step the user is redirected to job status view.
-            job_status_view = JobInvocationStatusView(view.browser)
-            wait_for(
-                lambda: (
-                    job_status_view.overview.job_status.read() != 'Pending'
-                    and job_status_view.overview.job_status_progress.read() == '100%'
-                ),
-                timeout=300,
-                delay=10,
-                logger=view.logger,
-            )
-            return job_status_view.overview.read()
+        # After this step the user is redirected to job status view.
+        job_status_view = JobInvocationStatusView(view.browser)
+        wait_for(
+            lambda: (
+                job_status_view.overview.job_status.read() != 'Pending'
+                and job_status_view.overview.job_status_progress.read() == '100%'
+            ),
+            timeout=300,
+            delay=10,
+            logger=view.logger,
+        )
+        return job_status_view.overview.read()
 
     def manage_module_streams(
         self,

--- a/airgun/views/contenthost.py
+++ b/airgun/views/contenthost.py
@@ -38,8 +38,7 @@ from airgun.widgets import (
 
 
 class StatusIcon(GenericLocatorWidget):
-    """Small icon indicating subscription or katello-agent status. Can be
-    colored in either green, yellow or red.
+    """Small icon indicating subscription status. Can be colored in either green, yellow or red.
 
     Example html representation::
 
@@ -142,7 +141,6 @@ class ContentHostDetailsView(BaseLoggedInView):
         bios_uuid = ReadOnlyEntry(name='BIOS UUID')
         description = EditableEntry(name='Description')
         type = ReadOnlyEntry(name='Type')
-        katello_agent = ReadOnlyEntry(name='Katello Agent')
         virtual_guests = ReadOnlyEntry(name='Virtual Guests')
         registered_through = ReadOnlyEntry(name='Registered Through')
         # Subscriptions

--- a/airgun/views/hostcollection.py
+++ b/airgun/views/hostcollection.py
@@ -188,7 +188,7 @@ class HostCollectionManagePackagesView(BaseLoggedInView):
             )
         return action_button
 
-    def apply_action(self, name, action_via='via Katello Agent'):
+    def apply_action(self, name, action_via='via remote execution'):
         """Apply an action by name using action via if indicated"""
         action_button = self.get_action_button(name)
         action_button.fill(action_via)


### PR DESCRIPTION
Katello agent was deprecated and is being removed from 6.15, the functionality will be replaced by REX.
This PR removes references from entities and views.