### PR TITLE
[6.14.z] enabled the pre-commit CI and remove pre-commit GH action

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -30,9 +30,6 @@ jobs:
           pip install -U pip
           pip install -U -r requirements.txt -r requirements-optional.txt
 
-      - name: Pre Commit Checks
-        uses: pre-commit/action@v2.0.0
-
       - name: Analysis (git diff)
         if: failure()
         run: git diff

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,5 +1,8 @@
 # configuration for pre-commit git hooks
 
+ci:
+  autofix_prs: false  # disable autofixing PRs
+
 repos:
 - repo: https://github.com/psf/black
   rev: 23.3.0


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/airgun/pull/1016

Doing similar in Airgun what we did here in https://github.com/SatelliteQE/nailgun/pull/997 nailgun 