### PR TITLE
[6.14.z] [pre-commit.ci] pre-commit autoupdate

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,16 +5,16 @@ ci:
 
 repos:
 - repo: https://github.com/psf/black
-  rev: 23.3.0
+  rev: 23.10.1
   hooks:
   - id: black
 - repo: https://github.com/astral-sh/ruff-pre-commit
-  rev: v0.0.277
+  rev: v0.1.3
   hooks:
     - id: ruff
       args: [--fix, --exit-non-zero-on-fix]
 - repo: https://github.com/pre-commit/pre-commit-hooks
-  rev: v4.2.0
+  rev: v4.5.0
   hooks:
   - id: check-yaml
   - id: debug-statements

--- a/airgun/session.py
+++ b/airgun/session.py
@@ -234,7 +234,7 @@ class Session:
         try:
             if not passed:
                 self.take_screenshot()
-        except Exception as err:  # noqa: BLE001 - TODO: fix bare except
+        except Exception as err:  # - TODO: fix bare except
             LOGGER.exception(err)
         finally:
             self._factory.finalize(passed)


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/airgun/pull/1017

<!--pre-commit.ci start-->
updates:
- [github.com/psf/black: 23.3.0 → 23.10.1](https://github.com/psf/black/compare/23.3.0...23.10.1)
- [github.com/astral-sh/ruff-pre-commit: v0.0.277 → v0.1.3](https://github.com/astral-sh/ruff-pre-commit/compare/v0.0.277...v0.1.3)
- [github.com/pre-commit/pre-commit-hooks: v4.2.0 → v4.5.0](https://github.com/pre-commit/pre-commit-hooks/compare/v4.2.0...v4.5.0)
<!--pre-commit.ci end-->