### PR TITLE
[6.12.z] [pre-commit.ci] pre-commit autoupdate

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,11 +5,11 @@ ci:
 
 repos:
 - repo: https://github.com/psf/black
-  rev: 23.10.1
+  rev: 23.11.0
   hooks:
   - id: black
 - repo: https://github.com/astral-sh/ruff-pre-commit
-  rev: v0.1.3
+  rev: v0.1.5
   hooks:
     - id: ruff
       args: [--fix, --exit-non-zero-on-fix]


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/airgun/pull/1028

<!--pre-commit.ci start-->
updates:
- [github.com/psf/black: 23.10.1 → 23.11.0](https://github.com/psf/black/compare/23.10.1...23.11.0)
- [github.com/astral-sh/ruff-pre-commit: v0.1.3 → v0.1.5](https://github.com/astral-sh/ruff-pre-commit/compare/v0.1.3...v0.1.5)
<!--pre-commit.ci end-->