### PR TITLE
[6.12.z] added the ui_sesion_id attribute for video-session

### DIFF
--- a/airgun/session.py
+++ b/airgun/session.py
@@ -192,6 +192,7 @@ class Session:
         self._login = login
         self.navigator = None
         self.browser = None
+        self.ui_session_id = None
 
     def __call__(self, user=None, password=None, session_cookie=None, url=None, login=None):
         """Stores provided values. This allows tests to provide additional
@@ -271,6 +272,7 @@ class Session:
             selenium_browser = self._factory.get_browser()
             self.browser = AirgunBrowser(selenium_browser, self)
             LOGGER.info(f'Setting initial URL to {url}')
+            self.ui_session_id = selenium_browser.session_id
 
             self.browser.url = url
 


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/airgun/pull/1038

#### PR Description
Added the `ui_session_id` attribute for the holding video session id, later can be used in robottelo for video rp-logging  

#### Depedant PR 
https://github.com/SatelliteQE/robottelo/pull/13055  