### PR TITLE
[6.14.z] added the ui_sesion_id attribute for video-session

### DIFF
--- a/airgun/session.py
+++ b/airgun/session.py
@@ -193,6 +193,7 @@ class Session:
         self._login = login
         self.navigator = None
         self.browser = None
+        self.ui_session_id = None
 
     def __call__(self, user=None, password=None, session_cookie=None, url=None, login=None):
         """Stores provided values. This allows tests to provide additional
@@ -273,6 +274,7 @@ class Session:
             self.browser = AirgunBrowser(selenium_browser, self)
             LOGGER.info(f'Session Id For {self.name}: {selenium_browser.session_id}')
             LOGGER.info(f'Setting initial URL to {url}')
+            self.ui_session_id = selenium_browser.session_id
 
             self.browser.url = url
 


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/airgun/pull/1038

#### PR Description
Added the `ui_session_id` attribute for the holding video session id, later can be used in robottelo for video rp-logging  

#### Depedant PR 
https://github.com/SatelliteQE/robottelo/pull/13055  