### PR TITLE
[6.14.z] Fix navigation: All Hosts>Manage Columns

### DIFF
--- a/airgun/views/host.py
+++ b/airgun/views/host.py
@@ -200,7 +200,7 @@ class HostInterface(View):
 
 class HostsView(BaseLoggedInView, SearchableViewMixinPF4):
     title = Text("//h1[normalize-space(.)='Hosts']")
-    manage_columns = PF4Button("OUIA-Generated-Button-link-1")
+    manage_columns = PF4Button('manage-columns-button')
     export = Text(".//a[contains(@class, 'btn')][contains(@href, 'hosts.csv')]")
     new = Text(".//div[@id='rails-app-content']//a[contains(normalize-space(.),'Create Host')]")
     register = PF4Button('OUIA-Generated-Button-secondary-2')


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/airgun/pull/1051
Failed to auto-cherrypick.
### Purpose
Fix UI navigation, for not finding `'Manage Columns'` button by existing locator,

### Related Issues: 
--- Reproduced locally and in recent CI runs (Stream, 6.15, 6.14) ---
```
from: tests/foreman/ui/test_host.py :: test_positive_manage_table_columns(ln203):
E   session.host.manage_table_columns(columns)

navmazing_null - ERROR - NAVIGATE: Got an error Message: Could not find an element 
     Locator(by='xpath', locator='.//*[contains(@data-ouia-component-type,"PF4/Button") and @data-ouia-component-id="OUIA-Generated-Button-link-1"]');
navmazing.NavigationTriesExceeded: Navigation failed to reach [ManageColumns] in the specificed tries
```