### PR TITLE
[6.13.z] Host Details Locator Cleanup

### DIFF
--- a/airgun/views/host_new.py
+++ b/airgun/views/host_new.py
@@ -220,13 +220,7 @@ class NewHostDetailsView(BaseLoggedInView):
                 './/button[@data-ouia-component-id="syspurpose-edit-button"]'
             )
 
-            role = Text('.//dd[contains(@class, "pf-c-description-list__description")][1]')
-            sla = Text('.//dd[contains(@class, "pf-c-description-list__description")][2]')
-            usage_type = Text('.//dd[contains(@class, "pf-c-description-list__description")][3]')
-            release_version = Text(
-                './/dd[contains(@class, "pf-c-description-list__description")][4]'
-            )
-            addons = Text('.//dd[contains(@class, "pf-c-description-list__description")][5]')
+            details = HostDetailsCard()
 
     @View.nested
     class details(Tab):
@@ -248,60 +242,32 @@ class NewHostDetailsView(BaseLoggedInView):
                 './/a[contains(@data-ouia-component-id, "OUIA-Generated-Button-link-1")]'
             )
             os = Text('.//a[contains(@data-ouia-component-id, "OUIA-Generated-Button-link-2")]')
-            boot_time = Text('.//div[contains(@class, "pf-c-description-list__group")][3]/dd/div')
-            kernel_release = Text(
-                './/div[contains(@class, "pf-c-description-list__group")][4]/dd/div'
-            )
+
+            details = HostDetailsCard()
 
         @View.nested
         class provisioning(Card):
             ROOT = './/article[.//div[text()="Provisioning"]]'
 
-            build_duration = Text(
-                './/div[contains(@class, "pf-c-description-list__group")][1]/dd/div'
-            )
-            token = Text('.//div[contains(@class, "pf-c-description-list__group")][2]/dd/div')
-            pxe_loader = Text('.//div[contains(@class, "pf-c-description-list__group")][3]/dd/div')
+            details = HostDetailsCard()
 
         @View.nested
         class bios(Card):
             ROOT = './/article[.//div[text()="BIOS"]]'
 
-            vendor = Text('.//div[contains(@class, "pf-c-description-list__group")][1]/dd/div')
-            version = Text('.//div[contains(@class, "pf-c-description-list__group")][2]/dd/div')
-            release_date = Text(
-                './/div[contains(@class, "pf-c-description-list__group")][3]/dd/div'
-            )
+            details = HostDetailsCard()
 
         @View.nested
         class registration_details(Card):
             ROOT = './/article[.//div[text()="Registration details"]]'
 
-            registered_on = Text(
-                './/div[contains(@class, "pf-c-description-list__group")][1]/dd/div'
-            )
-            registration_type = Text(
-                './/div[contains(@class, "pf-c-description-list__group")][2]/ul/h4'
-            )
-            activation_key_name = Text(
-                './/div[contains(@class, "pf-c-description-list__group")][2]//a'
-            )
-            registered_through = Text(
-                './/div[contains(@class, "pf-c-description-list__group")][3]/dd/div'
-            )
+            details = HostDetailsCard()
 
         @View.nested
         class hw_properties(Card):
             ROOT = './/article[.//div[text()="HW properties"]]'
 
-            model = Text('.//div[contains(@class, "pf-c-description-list__group")][1]//dd')
-            number_of_cpus = Text('.//div[contains(@class, "pf-c-description-list__group")][2]//dd')
-            sockets = Text('.//div[contains(@class, "pf-c-description-list__group")][3]//dd')
-            cores_per_socket = Text(
-                './/div[contains(@class, "pf-c-description-list__group")][4]//dd'
-            )
-            ram = Text('.//div[contains(@class, "pf-c-description-list__group")][5]//dd')
-            storage = Text('.//div[contains(@class, "pf-c-description-list__group")][6]//h4')
+            details = HostDetailsCard()
 
         @View.nested
         class provisioning_templates(Card):


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/airgun/pull/1015

Replace individual locators with HostDetailsCard widget, and remove unnecessary and unused entity methods.

These cards can easily be accessed through the get_details method instead. 

Probably also worth stating that these cards aren't currently under test, and this PR doesn't remedy that, it just cleans up the locators and entities that were written when the new Host Details UI was made originally.