### PR TITLE
Update get_register_command to reflect new mandatory fields

### DIFF
--- a/airgun/entities/host.py
+++ b/airgun/entities/host.py
@@ -46,13 +46,19 @@ class HostEntity(BaseEntity):
         host_view.flash.assert_no_error()
         host_view.flash.dismiss()
 
-    def get_register_command(self, values, full_read=None):
+    def get_register_command(self, values=None, full_read=None):
         """Get curl command generated on Register Host page"""
         view = self.navigate_to(self, 'Register')
-        view.fill(values)
-        self.browser.click(view.generate_command)
-        self.browser.plugin.ensure_page_safe()
-        view.registration_command.wait_displayed()
+        if values is not None:
+            view.fill(values)
+        if view.general.activation_keys.read():
+            self.browser.click(view.generate_command)
+            self.browser.plugin.ensure_page_safe()
+            view.registration_command.wait_displayed()
+        else:
+            view.general.new_activation_key_link.wait_displayed()
+            if view.generate_command.disabled:
+                raise DisabledWidgetError('Generate registration command button is disabled')
         if full_read:
             return view.read()
         return view.registration_command.read()

--- a/airgun/views/host.py
+++ b/airgun/views/host.py
@@ -497,6 +497,7 @@ class HostCreateView(BaseLoggedInView):
 
 
 class HostRegisterView(BaseLoggedInView):
+    title = Text("//h1[normalize-space(.)='Register Host']")
     generate_command = PF4Button('registration_generate_btn')
     cancel = PF4Button('registration-cancel-button')
     registration_command = TextInput(locator="//input[@aria-label='Copyable input']")
@@ -519,6 +520,7 @@ class HostRegisterView(BaseLoggedInView):
         insecure = Checkbox(id='reg_insecure')
         activation_keys = BaseMultiSelect('activation-keys-field')
         activation_key_helper = Text("//div[@id='activation_keys_field-helper']")
+        new_activation_key_link = Link('//a[normalize-space(.)="Create new activation key"]')
 
     @View.nested
     class advanced(Tab):
@@ -544,7 +546,7 @@ class HostRegisterView(BaseLoggedInView):
 
     @property
     def is_displayed(self):
-        return self.browser.wait_for_element(self.general.operating_system, exception=False)
+        return self.browser.wait_for_element(self.title, exception=False)
 
     def before_fill(self, values):
         """Fill some of the parameters in the widgets with values.
@@ -566,12 +568,6 @@ class HostRegisterView(BaseLoggedInView):
                     logger=self.logger,
                 )
                 self.general.__getattribute__(field).fill(field_value)
-        wait_for(
-            lambda: self.general.linux_host_init_link.is_displayed,
-            timeout=30,
-            delay=2,
-            logger=self.logger,
-        )
 
 
 class RecommendationWidget(GenericLocatorWidget):


### PR DESCRIPTION
**Description**
- Update get_register_command to reflect new mandatory fields i.e ActivationKey, which was previously operating systems.
- Make get_register_command work when no values are passed, required for default values validation and few negative tests.
- Add locator for new_activation_key_link, which appears when no AK available in organization, and when there's single AK in organization, AK will be auto-selected in 6.15+