### PR TITLE
[6.15.z] Fix get_downloads_list which is causing save_downloaded_file to fail

### DIFF
--- a/airgun/browser.py
+++ b/airgun/browser.py
@@ -6,7 +6,6 @@ from contextlib import contextmanager
 from datetime import datetime
 import logging
 import os
-import time
 import urllib
 from urllib.parse import unquote
 
@@ -344,19 +343,12 @@ class AirgunBrowser(Browser):
         downloads_uri = 'chrome://downloads'
         if not self.url.startswith(downloads_uri):
             self.url = downloads_uri
-        time.sleep(3)
         script = (
-            'return downloads.Manager.get().items_'
-            '.filter(e => e.state === "COMPLETE")'
-            '.map(e => e.file_url || e.fileUrl);'
+            'return document.querySelector("downloads-manager")'
+            '.shadowRoot.querySelector("#downloadsList")'
+            '.items.filter(e => e.state == "2")'
+            '.map(e => e.filePath || e.file_path || e.fileUrl || e.file_url);'
         )
-        if self.browser_type == 'chrome':
-            script = (
-                'return document.querySelector("downloads-manager")'
-                '.shadowRoot.querySelector("#downloadsList")'
-                '.items.filter(e => e.state === "COMPLETE")'
-                '.map(e => e.filePath || e.file_path || e.fileUrl || e.file_url);'
-            )
         return self.execute_script(script)
 
     def get_file_content(self, uri):


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/airgun/pull/1098

Fix get_downloads_list which is causing save_downloaded_file to fail. Fixed issue and removed some unnecessary code.

```
tests/foreman/ui/test_rhcloud_inventory.py:209: in test_rh_cloud_inventory_settings
    report_path = session.cloudinventory.download_report(org.name)
../../lib64/python3.11/site-packages/airgun/entities/cloud_inventory.py:43: in download_report
    return self.browser.save_downloaded_file()
../../lib64/python3.11/site-packages/airgun/browser.py:430: in save_downloaded_file
    file_uri = files[0]
E   IndexError: list index out of range
``` 