### PR TITLE
[6.15.z] virtwho config edit name message check update

### DIFF
--- a/airgun/entities/virtwho_configure.py
+++ b/airgun/entities/virtwho_configure.py
@@ -64,7 +64,10 @@ class VirtwhoConfigureEntity(BaseEntity):
         values = self._reset_values(values)
         view.fill(values)
         view.submit.click()
-        view.flash.assert_message(f"Success alert: Successfully updated {name}.")
+        if 'name' in values:
+            view.flash.assert_message(f"Success alert: Successfully updated {values['name']}.")
+        else:
+            view.flash.assert_message(f"Success alert: Successfully updated {name}.")
         view.flash.assert_no_error()
         view.flash.dismiss()
 


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/airgun/pull/1096

When update the virt-who config name to another name, the edit message has been updated to check the new virt-who config, but the previous code still check the old non-exist virt-who config.

Cases :PASS
```
(robottelo_vv) [virtwho@dell-per740-68-vm-04 robottelo]$ pytest ./tests/foreman/virtwho/ui/test_esx.py  -k test_positive_virtwho_manager_role --disable-pytest-warnings -q
.                                                                                                                                                                                                           [100%]
1 passed, 33 deselected, 15 warnings in 307.44s (0:05:07)
2023-12-20 03:10:48 - robottelo - WARNING - missing grid_url or session_id. unable to clean video files.

```