### PR TITLE
Adding new functionality for multi repo override

### DIFF
--- a/airgun/entities/host_new.py
+++ b/airgun/entities/host_new.py
@@ -355,6 +355,17 @@ class NewHostEntity(HostEntity):
         view.flash.assert_no_error()
         view.flash.dismiss()
 
+    def override_multiple_repo_sets(self, entity_name, repo_set, repo_type, action):
+        """Change override for multiple repository sets without using the Select All method"""
+        view = self.navigate_to(self, 'NewDetails', entity_name=entity_name)
+        view.wait_displayed()
+        self.browser.plugin.ensure_page_safe()
+        view.content.repository_sets.searchbar.fill(repo_set)
+        view.content.repository_sets.table[0][0].widget.click()
+        view.content.repository_sets.dropdown.item_select(action)
+        view.flash.assert_no_error()
+        view.flash.dismiss()
+
     def bulk_override_repo_sets(self, entity_name, repo_type, action):
         """Change override for repository set"""
         view = self.navigate_to(self, 'NewDetails', entity_name=entity_name)


### PR DESCRIPTION
This new addition is for SAT-22193

A customer scenario came up where we need to individually check each repository and then use the new override functionality for all repos selected. We cannot use the "select all" method to reporoduce. 

Robottelo:https://github.com/SatelliteQE/robottelo/pull/13596