### PR TITLE
Manual Cherrypick All Hosts UI to 6.15.z

### DIFF
--- a/airgun/entities/all_hosts.py
+++ b/airgun/entities/all_hosts.py
@@ -22,12 +22,17 @@ class AllHostsEntity(BaseEntity):
         """Delete host through table dropdown"""
         view = self.navigate_to(self, 'All')
         self.browser.plugin.ensure_page_safe(timeout='5s')
-        view.table.wait_displayed()
+        view.wait_displayed()
         view.search(host_name)
         view.table[0][2].widget.item_select('Delete')
         delete_modal = HostDeleteDialog(self.browser)
         if delete_modal.is_displayed:
             delete_modal.confirm_delete.click()
+        view = self.navigate_to(self, 'All')
+        self.browser.plugin.ensure_page_safe(timeout='5s')
+        view.wait_displayed()
+        view.search(host_name)
+        return view.no_results
 
     def bulk_delete_all(self):
         """Delete multiple hosts through bulk action dropdown"""
@@ -40,6 +45,10 @@ class AllHostsEntity(BaseEntity):
         if delete_modal.is_displayed:
             delete_modal.confirm_checkbox.fill(True)
             delete_modal.confirm_delete.click()
+        view = self.navigate_to(self, 'All')
+        self.browser.plugin.ensure_page_safe(timeout='5s')
+        view.wait_displayed()
+        return view.no_results
 
 
 @navigator.register(AllHostsEntity, 'All')

--- a/airgun/entities/all_hosts.py
+++ b/airgun/entities/all_hosts.py
@@ -1,0 +1,53 @@
+from airgun.entities.base import BaseEntity
+from airgun.navigation import NavigateStep, navigator
+from airgun.utils import retry_navigation
+from airgun.views.all_hosts import (
+    AllHostsTableView,
+    BulkHostDeleteDialog,
+    HostDeleteDialog,
+)
+
+
+class AllHostsEntity(BaseEntity):
+    endpoint_path = '/new/hosts'
+
+    def search(self, host_name):
+        """Search for specific Host"""
+        view = self.navigate_to(self, 'All')
+        self.browser.plugin.ensure_page_safe(timeout='5s')
+        view.wait_displayed()
+        return view.search(host_name)
+
+    def delete(self, host_name):
+        """Delete host through table dropdown"""
+        view = self.navigate_to(self, 'All')
+        self.browser.plugin.ensure_page_safe(timeout='5s')
+        view.table.wait_displayed()
+        view.search(host_name)
+        view.table[0][2].widget.item_select('Delete')
+        delete_modal = HostDeleteDialog(self.browser)
+        if delete_modal.is_displayed:
+            delete_modal.confirm_delete.click()
+
+    def bulk_delete_all(self):
+        """Delete multiple hosts through bulk action dropdown"""
+        view = self.navigate_to(self, 'All')
+        self.browser.plugin.ensure_page_safe(timeout='5s')
+        view.wait_displayed()
+        view.select_all.fill(True)
+        view.bulk_actions.item_select('Delete')
+        delete_modal = BulkHostDeleteDialog(self.browser)
+        if delete_modal.is_displayed:
+            delete_modal.confirm_checkbox.fill(True)
+            delete_modal.confirm_delete.click()
+
+
+@navigator.register(AllHostsEntity, 'All')
+class ShowAllHostsScreen(NavigateStep):
+    """Navigate to All Hosts screen."""
+
+    VIEW = AllHostsTableView
+
+    @retry_navigation
+    def step(self, *args, **kwargs):
+        self.view.menu.select('Hosts', 'All Hosts')

--- a/airgun/entities/all_hosts.py
+++ b/airgun/entities/all_hosts.py
@@ -1,3 +1,5 @@
+from widgetastic.exceptions import NoSuchElementException
+
 from airgun.entities.base import BaseEntity
 from airgun.navigation import NavigateStep, navigator
 from airgun.utils import retry_navigation
@@ -28,6 +30,8 @@ class AllHostsEntity(BaseEntity):
         delete_modal = HostDeleteDialog(self.browser)
         if delete_modal.is_displayed:
             delete_modal.confirm_delete.click()
+        else:
+            raise NoSuchElementException("Delete Modal was not displayed.")
         view = self.navigate_to(self, 'All')
         self.browser.plugin.ensure_page_safe(timeout='5s')
         view.wait_displayed()

--- a/airgun/session.py
+++ b/airgun/session.py
@@ -11,6 +11,7 @@ from airgun import settings
 from airgun.browser import AirgunBrowser, SeleniumBrowserFactory
 from airgun.entities.acs import AcsEntity
 from airgun.entities.activationkey import ActivationKeyEntity
+from airgun.entities.all_hosts import AllHostsEntity
 from airgun.entities.ansible_role import AnsibleRolesEntity
 from airgun.entities.ansible_variable import AnsibleVariablesEntity
 from airgun.entities.architecture import ArchitectureEntity
@@ -324,6 +325,11 @@ class Session:
     def activationkey(self):
         """Instance of Activation Key entity."""
         return self._open(ActivationKeyEntity)
+
+    @cached_property
+    def all_hosts(self):
+        """Instance of All Hosts entity."""
+        return self._open(AllHostsEntity)
 
     @cached_property
     def ansibleroles(self):

--- a/airgun/views/all_hosts.py
+++ b/airgun/views/all_hosts.py
@@ -35,8 +35,14 @@ class HostDeleteDialog(View):
 
     ROOT = './/div[@data-ouia-component-id="delete-modal"]'
 
+    title = Text("//span[normalize-space(.)='Confirm Deletion']")
+
     confirm_delete = Button(locator='.//button[@data-ouia-component-id="confirm-delete"]')
     cancel_delete = Button('cancel-delete')
+
+    @property
+    def is_displayed(self):
+        return self.browser.wait_for_element(self.title, exception=False) is not None
 
 
 class BulkHostDeleteDialog(View):
@@ -44,7 +50,12 @@ class BulkHostDeleteDialog(View):
 
     ROOT = './/div[@data-ouia-component-id="bulk-delete-hosts-modal"]'
 
+    title = Text("//span[normalize-space(.)='Delete hosts?']")
     confirm_checkbox = Checkbox('dire-warning-checkbox')
 
     confirm_delete = Button('btn-modal-confirm')
     cancel_delete = Button('btn-modal-cancel')
+
+    @property
+    def is_displayed(self):
+        return self.browser.wait_for_element(self.title, exception=False) is not None

--- a/airgun/views/all_hosts.py
+++ b/airgun/views/all_hosts.py
@@ -1,0 +1,50 @@
+from widgetastic.widget import Checkbox, Text, View
+from widgetastic_patternfly4 import Button, Dropdown
+from widgetastic_patternfly4.ouia import (
+    PatternflyTable,
+)
+
+from airgun.views.common import (
+    BaseLoggedInView,
+    SearchableViewMixinPF4,
+)
+
+
+class AllHostsTableView(BaseLoggedInView, SearchableViewMixinPF4):
+    title = Text("//h1[normalize-space(.)='Hosts']")
+    select_all = Checkbox(
+        locator='.//input[@data-ouia-component-id="select-all-checkbox-dropdown-toggle-checkbox"]'
+    )
+    bulk_actions = Dropdown(locator='.//div[@data-ouia-component-id="action-buttons-dropdown"]')
+    table = PatternflyTable(
+        component_id='table',
+        column_widgets={
+            0: Checkbox(locator='.//input[@type="checkbox"]'),
+            'Name': Text('./a'),
+            2: Dropdown(locator='.//div[contains(@class, "pf-c-dropdown")]'),
+        },
+    )
+
+    @property
+    def is_displayed(self):
+        return self.browser.wait_for_element(self.title, exception=False) is not None
+
+
+class HostDeleteDialog(View):
+    """Confirmation dialog for deleting host"""
+
+    ROOT = './/div[@data-ouia-component-id="delete-modal"]'
+
+    confirm_delete = Button(locator='.//button[@data-ouia-component-id="confirm-delete"]')
+    cancel_delete = Button('cancel-delete')
+
+
+class BulkHostDeleteDialog(View):
+    """Confirmation dialog for bulk deleting hosts or hosts with compute resources"""
+
+    ROOT = './/div[@data-ouia-component-id="bulk-delete-hosts-modal"]'
+
+    confirm_checkbox = Checkbox('dire-warning-checkbox')
+
+    confirm_delete = Button('btn-modal-confirm')
+    cancel_delete = Button('btn-modal-cancel')

--- a/airgun/views/all_hosts.py
+++ b/airgun/views/all_hosts.py
@@ -16,6 +16,8 @@ class AllHostsTableView(BaseLoggedInView, SearchableViewMixinPF4):
         locator='.//input[@data-ouia-component-id="select-all-checkbox-dropdown-toggle-checkbox"]'
     )
     bulk_actions = Dropdown(locator='.//div[@data-ouia-component-id="action-buttons-dropdown"]')
+    table_loading = Text("//h5[normalize-space(.)='Loading']")
+    no_results = Text("//h5[normalize-space(.)='No Results']")
     table = PatternflyTable(
         component_id='table',
         column_widgets={
@@ -27,18 +29,21 @@ class AllHostsTableView(BaseLoggedInView, SearchableViewMixinPF4):
 
     @property
     def is_displayed(self):
-        return self.browser.wait_for_element(self.table, exception=False) is not None
+        return (
+            self.browser.wait_for_element(self.table_loading, exception=False) is None
+            and self.browser.wait_for_element(self.table, exception=False) is not None
+        )
 
 
 class HostDeleteDialog(View):
     """Confirmation dialog for deleting host"""
 
-    ROOT = './/div[@data-ouia-component-id="delete-modal"]'
+    ROOT = './/div[@data-ouia-component-id="app-confirm-modal"]'
 
-    title = Text("//span[normalize-space(.)='Confirm Deletion']")
+    title = Text("//span[normalize-space(.)='Delete host?']")
 
-    confirm_delete = Button(locator='.//button[@data-ouia-component-id="confirm-delete"]')
-    cancel_delete = Button('cancel-delete')
+    confirm_delete = Button(locator='//button[normalize-space(.)="Delete"]')
+    cancel_delete = Button(locator='//button[normalize-space(.)="Cancel"]')
 
     @property
     def is_displayed(self):
@@ -48,13 +53,13 @@ class HostDeleteDialog(View):
 class BulkHostDeleteDialog(View):
     """Confirmation dialog for bulk deleting hosts or hosts with compute resources"""
 
-    ROOT = './/div[@data-ouia-component-id="bulk-delete-hosts-modal"]'
+    ROOT = './/div[@id="bulk-delete-hosts-modal"]'
 
     title = Text("//span[normalize-space(.)='Delete hosts?']")
-    confirm_checkbox = Checkbox('dire-warning-checkbox')
+    confirm_checkbox = Checkbox(locator='.//input[@id="dire-warning-checkbox"]')
 
-    confirm_delete = Button('btn-modal-confirm')
-    cancel_delete = Button('btn-modal-cancel')
+    confirm_delete = Button(locator='//button[normalize-space(.)="Delete"]')
+    cancel_delete = Button(locator='//button[normalize-space(.)="Cancel"]')
 
     @property
     def is_displayed(self):

--- a/airgun/views/all_hosts.py
+++ b/airgun/views/all_hosts.py
@@ -27,7 +27,7 @@ class AllHostsTableView(BaseLoggedInView, SearchableViewMixinPF4):
 
     @property
     def is_displayed(self):
-        return self.browser.wait_for_element(self.title, exception=False) is not None
+        return self.browser.wait_for_element(self.table, exception=False) is not None
 
 
 class HostDeleteDialog(View):


### PR DESCRIPTION
This missed the cutover for 6.15.z, so this is a manual cherrypick to get these changes in. Supports another manual Cherrypick of the tests over to 6.15.z as well.

Original PR: https://github.com/SatelliteQE/airgun/pull/1039