### PR TITLE
Bug 2158702:read virt-who config Edit view page info support

### DIFF
--- a/airgun/entities/virtwho_configure.py
+++ b/airgun/entities/virtwho_configure.py
@@ -76,6 +76,11 @@ class VirtwhoConfigureEntity(BaseEntity):
         view = self.navigate_to(self, 'Details', entity_name=entity_name)
         return view.read(widget_names=widget_names)
 
+    def read_edit(self, entity_name, widget_names=None):
+        """Read all values for existing virtwho configure entity for Edit View"""
+        view = self.navigate_to(self, 'Edit', entity_name=entity_name)
+        return view.read(widget_names=widget_names)
+
     def delete(self, value):
         """Delete specific virtwho configure"""
         view = self.navigate_to(self, 'All')


### PR DESCRIPTION
Coverage [Bug 2158702](https://bugzilla.redhat.com/show_bug.cgi?id=2158702), realize read virt-who config Edit view page info support
Test Cases: PASS
```
(robottelo_vv) [virtwho@dell-per740-68-vm-04 robottelo]$ pytest  ./tests/foreman/virtwho/ui/test_esx_sca.py -k test_positive_hypervisor_password_option --disable-pytest-warnings -q
2024-01-11 02:00:13 - robottelo - WARNING - Dynaconf validation failed, continuing for the sake of unit tests
    certs.cert_file is required in env main
=============================================================================================== test session starts ===============================================================================================

============================================================================ 1 passed, 35 deselected, 13 warnings in 169.65s (0:02:49) ============================================================================

```