### PR TITLE
[6.13.z] Bump actions/checkout from 2 to 4

### DIFF
--- a/.github/workflows/auto_cherry_pick.yml
+++ b/.github/workflows/auto_cherry_pick.yml
@@ -40,7 +40,7 @@ jobs:
 
     steps:
       ## Airgun Repo Checkout
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         if: ${{ startsWith(matrix.label, '6.') && matrix.label != github.base_ref }}
         with:
           fetch-depth: 0

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -17,7 +17,7 @@ jobs:
         python-version: ['3.10', '3.11']
     steps:
       - name: Checkout Airgun
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Set Up Python-${{ matrix.python-version }}
         uses: actions/setup-python@v5


### PR DESCRIPTION
Failed cherry-pick of https://github.com/SatelliteQE/airgun/pull/1153
Fixes https://github.com/SatelliteQE/airgun/issues/1157

Bumps [actions/checkout](https://github.com/actions/checkout) from 2 to 4.
- [Release notes](https://github.com/actions/checkout/releases)
- [Changelog](https://github.com/actions/checkout/blob/main/CHANGELOG.md)
- [Commits](https://github.com/actions/checkout/compare/v2...v4)

---
updated-dependencies:
- dependency-name: actions/checkout dependency-type: direct:production update-type: version-update:semver-major ...