### PR TITLE
pf4 bookmarks dropdown

### DIFF
--- a/airgun/views/capsule.py
+++ b/airgun/views/capsule.py
@@ -262,7 +262,6 @@ class CapsulesView(BaseLoggedInView, SearchableViewMixinPF4):
             'Actions': ActionsDropdown('./div[contains(@class, "btn-group")]'),
         },
     )
-
     pagination = Pagination()
 
     @property

--- a/airgun/views/computeresource.py
+++ b/airgun/views/computeresource.py
@@ -11,7 +11,12 @@ from widgetastic.widget import (
 )
 from widgetastic_patternfly import BreadCrumb
 
-from airgun.views.common import BaseLoggedInView, SatTab, SearchableViewMixin
+from airgun.views.common import (
+    BaseLoggedInView,
+    SatTab,
+    SearchableViewMixin,
+    SearchableViewMixinPF4,
+)
 from airgun.views.host import HostCreateView
 from airgun.widgets import (
     ActionsDropdown,
@@ -24,7 +29,7 @@ from airgun.widgets import (
 )
 
 
-class ComputeResourcesView(BaseLoggedInView, SearchableViewMixin):
+class ComputeResourcesView(BaseLoggedInView, SearchableViewMixinPF4):
     title = Text('//*[(self::h1 or self::h5) and normalize-space(.)="Compute Resources"]')
     new = Text('//a[normalize-space(.)="Create Compute Resource"]')
     table = SatTable(

--- a/airgun/views/dashboard.py
+++ b/airgun/views/dashboard.py
@@ -1,7 +1,7 @@
 from widgetastic.widget import Table, Text, View, Widget
 
-from airgun.views.common import BaseLoggedInView, SatTable
-from airgun.widgets import ActionsDropdown, PieChart, Search
+from airgun.views.common import BaseLoggedInView, SatTable, SearchableViewMixinPF4
+from airgun.widgets import ActionsDropdown, PieChart
 
 
 class ItemValueList(Widget):
@@ -71,11 +71,10 @@ class AutoRefresh(Widget):
             self.browser.element(self.AUTO_REFRESH).click()
 
 
-class DashboardView(BaseLoggedInView):
+class DashboardView(BaseLoggedInView, SearchableViewMixinPF4):
     title = Text("//h1[normalize-space(.)='Overview']")
     manage = ActionsDropdown("//div[@class='btn-group']")
     refresh = AutoRefresh()
-    searchbox = Search()
 
     @property
     def is_displayed(self):

--- a/airgun/views/discoveryrule.py
+++ b/airgun/views/discoveryrule.py
@@ -2,7 +2,7 @@ from widgetastic.widget import Checkbox, Text, TextInput, View
 from widgetastic_patternfly import BreadCrumb
 from widgetastic_patternfly4 import Button as PF4Button
 
-from airgun.views.common import BaseLoggedInView, SatTab
+from airgun.views.common import BaseLoggedInView, SatTab, SearchableViewMixinPF4
 from airgun.widgets import (
     ActionsDropdown,
     AutoCompleteTextInput,
@@ -12,7 +12,7 @@ from airgun.widgets import (
 )
 
 
-class DiscoveryRulesView(BaseLoggedInView):
+class DiscoveryRulesView(BaseLoggedInView, SearchableViewMixinPF4):
     title = Text("//h1[normalize-space(.)='Discovery Rules']")
     new = Text("//a[contains(@href, '/discovery_rules/new')]")
     new_on_blank_page = PF4Button('Create Rule')

--- a/airgun/views/package.py
+++ b/airgun/views/package.py
@@ -1,7 +1,12 @@
 from widgetastic.widget import Checkbox, Select, Text, View
 from widgetastic_patternfly import BreadCrumb
 
-from airgun.views.common import BaseLoggedInView, ReadOnlyEntry, SatTab, SatTable
+from airgun.views.common import (
+    BaseLoggedInView,
+    ReadOnlyEntry,
+    SatTab,
+    SatTable,
+)
 from airgun.widgets import ItemsListReadOnly, Search
 
 

--- a/airgun/views/repository.py
+++ b/airgun/views/repository.py
@@ -9,7 +9,11 @@ from widgetastic.widget import (
 )
 from widgetastic_patternfly import BreadCrumb
 
-from airgun.views.common import BaseLoggedInView, SearchableViewMixin
+from airgun.views.common import (
+    BaseLoggedInView,
+    SearchableViewMixin,
+    SearchableViewMixinPF4,
+)
 from airgun.widgets import (
     ActionsDropdown,
     ConfirmationDialog,
@@ -22,7 +26,7 @@ from airgun.widgets import (
 )
 
 
-class RepositoriesView(BaseLoggedInView, SearchableViewMixin):
+class RepositoriesView(BaseLoggedInView, SearchableViewMixinPF4):
     breadcrumb = BreadCrumb()
     new = Text("//button[contains(@href, '/repositories/new')]")
     sync = Text("//button[contains(@ng-click, 'syncSelectedRepositories')]")

--- a/airgun/views/subnet.py
+++ b/airgun/views/subnet.py
@@ -1,11 +1,16 @@
 from widgetastic.widget import Table, Text, TextInput, View
 from widgetastic_patternfly import BreadCrumb
 
-from airgun.views.common import BaseLoggedInView, SatTab, SearchableViewMixin
-from airgun.widgets import CustomParameter, FilteredDropdown, MultiSelect, RadioGroup
+from airgun.views.common import BaseLoggedInView, SatTab, SearchableViewMixinPF4
+from airgun.widgets import (
+    CustomParameter,
+    FilteredDropdown,
+    MultiSelect,
+    RadioGroup,
+)
 
 
-class SubnetsView(BaseLoggedInView, SearchableViewMixin):
+class SubnetsView(BaseLoggedInView, SearchableViewMixinPF4):
     title = Text('//*[(self::h1 or self::h5) and normalize-space(.)="Subnets"]')
     new = Text('//a[normalize-space(.)="Create Subnet"]')
     table = Table(

--- a/airgun/widgets.py
+++ b/airgun/widgets.py
@@ -629,7 +629,7 @@ class ActionsDropdown(GenericLocatorWidget):
         "contains(@ng-click, 'toggleDropdown')][contains(@class, 'btn')]"
         "[*[self::span or self::i][contains(@class, 'caret')]]"
     )
-    pf4_drop_down = Dropdown('OUIA-Generated-Dropdown-2')
+    pf4_drop_down = Text("//div[contains(@data-ouia-component-id, 'bookmarks-dropdown')]")
     button = Text(
         ".//*[self::button or self::span][contains(@class, 'btn') or "
         "contains(@aria-label, 'search button')]"
@@ -818,6 +818,8 @@ class PF4Search(Search):
     search_field = TextInput(locator=(".//input[@aria-label='Search input']"))
     search_button = Text(locator=(".//button[@aria-label='Search']"))
     clear_button = Text(locator=(".//button[@aria-label='Reset search']"))
+
+    actions = ActionsDropdown("//div[contains(@data-ouia-component-id, 'bookmarks-dropdown')]")
 
     def clear(self):
         """Clears search field value and re-trigger search to remove all


### PR DESCRIPTION
This change fixes around 90 tests in the bookmark component. The locator for bookmarks dropdown was not accurate for pf4 searchboxes, plus views were not updated to use pf4 search. The remaining legacy searchboxes continue to work.

Test result for component with pf4 searcbox:
```
 pytest tests/foreman/ui/test_bookmarks.py -k  test_positive_end_to_end[Architecture]
=============================================== test session starts ===============================================                                                               

tests/foreman/ui/test_bookmarks.py .
```

Page with legacy searchbox:
```

pytest tests/foreman/ui/test_bookmarks.py -k  test_positive_end_to_end[product]
=============================================== test session starts ===============================================                                                               

tests/foreman/ui/test_bookmarks.py .
```