### PR TITLE
[6.15.z] host_new>content>errata tab pagination

### DIFF
--- a/airgun/entities/host_new.py
+++ b/airgun/entities/host_new.py
@@ -299,17 +299,41 @@ class NewHostEntity(HostEntity):
         view.content.errata.table.wait_displayed()
         return view.read(widget_names="content.errata.table")
 
-    def apply_erratas(self, entity_name, search):
-        """Apply errata on selected host based on errata_id"""
+    def apply_erratas(self, entity_name, search=None):
+        """Apply available errata on selected host based on searchbar result.
+
+        param: search (string): search value to filter results.
+        example: search="errata_id == {ERRATA_ID}"
+        default: None; all available errata are returned and installed.
+        """
         view = self.navigate_to(self, 'NewDetails', entity_name=entity_name)
         view.wait_displayed()
-        view.content.errata.searchbar.fill(search)
+        if search is None:
+            # Return all errata, clear the searchbar
+            view.content.errata.searchbar.clear()
+        else:
+            # Return only errata by search
+            view.content.errata.searchbar.fill(search)
         # wait for filter to apply
+        view.content.errata.wait_displayed()
         self.browser.plugin.ensure_page_safe()
         view.content.errata.select_all.click()
         view.content.errata.apply.fill('Apply')
         view.flash.assert_no_error()
         view.flash.dismiss()
+        # clear the searchbar so any input will not persist
+        view.content.errata.searchbar.clear()
+        view.content.errata.wait_displayed()
+        self.browser.plugin.ensure_page_safe()
+
+    def get_errata_pagination(self, entity_name):
+        """Get pagination info from Errata tab on selected host."""
+        view = self.navigate_to(self, 'NewDetails', entity_name=entity_name)
+        view.wait_displayed()
+        view.content.errata.select()
+        view.content.errata.wait_displayed()
+        self.browser.plugin.ensure_page_safe()
+        return view.content.errata.pagination
 
     def get_module_streams(self, entity_name, search):
         """Filter module streams"""

--- a/airgun/views/host_new.py
+++ b/airgun/views/host_new.py
@@ -393,7 +393,9 @@ class NewHostDetailsView(BaseLoggedInView):
                     8: Dropdown(locator='./div'),
                 },
             )
-            pagination = PF4Pagination()
+            pagination = PF4Pagination(
+                "//div[@class = 'pf-c-pagination pf-m-bottom tfm-pagination']"
+            )
 
         @View.nested
         class module_streams(Tab):

--- a/airgun/widgets.py
+++ b/airgun/widgets.py
@@ -2645,7 +2645,26 @@ class InventoryBootstrapSwitch(Widget):
 
 
 class SearchInput(TextInput):
+    """Searchbar's contained input text, and buttons"""
+
+    search_field = TextInput(locator=('//input[@aria-label="Search input"]'))
+    clear_button = Text(locator=('//button[@aria-label="Reset search"]'))
+
+    def clear(self):
+        """Clear search input by clicking the clear_button.
+        Return: True if button was present, and clicking it caused it to disappear.
+        False otherwise.
+        """
+        changed = False
+        if self.clear_button.is_displayed:
+            self.clear_button.click()
+            # after clicking clear button, it should disappear
+            if not self.clear_button.is_displayed:
+                changed = True
+        return changed
+
     def fill(self, value, enter_timeout=1, after_enter_timeout=3):
+        """Fill the search input with supplied value"""
         changed = super().fill(value)
         if changed:
             # workaround for BZ #2140636


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/airgun/pull/1152

### Purpose
- supports [robottelo #13767](https://github.com/SatelliteQE/robottelo/pull/13767)
- Add new host UI support for reading errata tab pagination.
- method could be extended to any content>{tab with pagination} in New Host UI page once working.

### Solution
-Added new method `clear()` to `SearchInput` class (aigun/widgets.py)
-usage in the airgun view like so`view.content.errata.searchbar.clear()`
-Now using this in `apply_erratas()` method (entities/host_new.py), to clear the searchbar of any possible value present, when no search passed to` apply_erratas()`, meaning show and apply all errata with a blank searchbar.
-We also `clear` the searchbar in `apply_erratas()` after installing, that way any search value passed does not persist in the searchbar.
### ~Issue~, Resolved
- ~When reading info from PF4Pagination object in [views/host_new.py@362](https://github.com/SatelliteQE/airgun/blob/06ea1937089659ad1e27007f73b18cd297c6bf88/airgun/views/host_new.py#L362C7-L362C7), we get an empty dictionary with no information. _**Solved**_~
- ~**When the method `apply_erratas(entity, search)` is run,** it will leave the searchbar filled, and keep it filled until the view is reset.~
-  ~Workaround: Before accessing `view.content.errata.pagination`, we pass ' ' to searchbar, to display all available errata unfiltered. In case the searchbar was left occupied by a method run previously. I have been looking for a better way or built in method to clear the searchbar /unfilter, before geting pagination.~