### PR TITLE
Adapt to additional div in taxonomy mismatch locator

### DIFF
--- a/airgun/views/host.py
+++ b/airgun/views/host.py
@@ -743,7 +743,7 @@ class HostsTaxonomyMismatchRadioGroup(GenericLocatorWidget):
 
     def __init__(self, parent, **kwargs):
         self.taxonomy = kwargs.pop('taxonomy')
-        super().__init__(parent, "//div[@class='modal-body']//div[@id='content']/form", **kwargs)
+        super().__init__(parent, "//div[@class='modal-body']//div[@id='content']//form", **kwargs)
 
     def _is_checked(self, widget):
         """Returns whether the widget is checked"""


### PR DESCRIPTION
An additional div was added in [foreman 3.9](https://github.com/theforeman/foreman/blame/84f33a3322be21da99d6ce3a8c33803f68ba5000/app/views/layouts/_application_content.html.erb#L11) (6.15.z)

So the form locator has to be adapted.

before
```
 <div class="modal-body">
    <div id="content">
        <form class="form-horizontal well">
```

after
```
 <div class="modal-body">
    <div id="content">
      <div class="pf-c-page__main-section pf-m-light rails-table-toolbar">
        <form class="form-horizontal well">
```