### PR TITLE
[6.12.z] brought back task pagination

### DIFF
--- a/airgun/views/task.py
+++ b/airgun/views/task.py
@@ -1,6 +1,7 @@
 from wait_for import wait_for
 from widgetastic.widget import Table, Text, View
 from widgetastic_patternfly import BreadCrumb
+from widgetastic_patternfly4 import Pagination as PF4Pagination
 
 from airgun.views.common import BaseLoggedInView, SatTab, SearchableViewMixinPF4
 from airgun.widgets import (
@@ -32,6 +33,8 @@ class TasksView(BaseLoggedInView, SearchableViewMixinPF4):
             'Action': Text('./a'),
         },
     )
+
+    pagination = PF4Pagination()
 
     @property
     def is_displayed(self):


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/airgun/pull/1204

Seems it was accidentally removed in https://github.com/SatelliteQE/airgun/pull/947

Result with changes:

```
 pytest tests/foreman/ui/test_dashboard.py -k task_status
=============================================== test session starts ===============================================

collected 5 items / 4 deselected / 1 selected                                                                     

tests/foreman/ui/test_dashboard.py .


```