### PR TITLE
Updated the correct context runner for Airgun

### DIFF
--- a/.github/workflows/auto_cherry_pick_merge.yaml
+++ b/.github/workflows/auto_cherry_pick_merge.yaml
@@ -52,8 +52,8 @@ jobs:
         id: outcome
         uses: omkarkhatavkar/wait-for-status-checks@main
         with:
-          ref: ${{ github.head_ref }}
-          context: 'Robottelo-Runner'
+          ref: ${{ github.event.pull_request.head.sha }}
+          context: 'Airgun-Runner'
           wait-interval: 60
           count: 100
 


### PR DESCRIPTION
The context of PRT was not correct, now after passing context it will work as expected.  I also found that the statuses api is not working with branch name which is `head_ref` so applying the head commit sha to make thing work. 

https://docs.github.com/en/rest/commits/statuses?apiVersion=2022-11-28#list-commit-statuses-for-a-reference--parameters  