### PR TITLE
Fix hardware model delete functionality (6.15.z)

### DIFF
--- a/airgun/entities/hardware_model.py
+++ b/airgun/entities/hardware_model.py
@@ -46,7 +46,7 @@ class HardwareModelEntity(BaseEntity):
         """
         view = self.navigate_to(self, 'All')
         view.search(entity_name)
-        view.table.row(name=entity_name)['Actions'].widget.click()
+        view.table.row(name=entity_name)[4].widget.item_select("Delete")
         view.delete_dialog.confirm()
         if err_message:
             view.flash.assert_message(f"Danger alert: {err_message}")

--- a/airgun/views/hardware_model.py
+++ b/airgun/views/hardware_model.py
@@ -1,11 +1,12 @@
 from widgetastic.widget import Text, TextInput
-from widgetastic_patternfly import BreadCrumb, Button
+from widgetastic_patternfly import BreadCrumb
+from widgetastic_patternfly4 import Dropdown
 
 from airgun.views.common import BaseLoggedInView, SearchableViewMixinPF4
-from airgun.widgets import ConfirmationDialog, SatTable
+from airgun.widgets import Pf4ConfirmationDialog, SatTable
 
 
-class DeleteHardwareModelDialog(ConfirmationDialog):
+class DeleteHardwareModelDialog(Pf4ConfirmationDialog):
     confirm_dialog = Text(".//button[contains(normalize-space(.),'Delete')]")
     cancel_dialog = Text(".//button[normalize-space(.)='Cancel']")
 
@@ -18,7 +19,7 @@ class HardwareModelsView(BaseLoggedInView, SearchableViewMixinPF4):
         './/table',
         column_widgets={
             'Name': Text('.//a'),
-            'Actions': Button('Delete'),
+            4: Dropdown(),
         },
     )
 


### PR DESCRIPTION
For foreman 3.9 (6.15.z) the 'Actions' header string was removed (see picture):

![hardware_models](https://github.com/SatelliteQE/airgun/assets/2125774/95085cc3-7f21-440f-afbb-4951e327c51c)

The delete action is now accessible via an svg.

This should fix https://github.com/SatelliteQE/robottelo/blob/master/tests/foreman/ui/test_hardwaremodel.py
