### PR TITLE
[6.15.z] Navigation search: input clear fix

### DIFF
--- a/airgun/widgets.py
+++ b/airgun/widgets.py
@@ -31,7 +31,7 @@ from widgetastic_patternfly4.ouia import (
     BaseSelect,
     Button as OUIAButton,
     Dropdown,
-    Menu,    
+    Menu,
 )
 from widgetastic_patternfly4.progress import Progress as PF4Progress
 

--- a/airgun/widgets.py
+++ b/airgun/widgets.py
@@ -31,7 +31,7 @@ from widgetastic_patternfly4.ouia import (
     BaseSelect,
     Button as OUIAButton,
     Dropdown,
-    Menu
+    Menu,    
 )
 from widgetastic_patternfly4.progress import Progress as PF4Progress
 

--- a/airgun/widgets.py
+++ b/airgun/widgets.py
@@ -27,7 +27,12 @@ from widgetastic_patternfly import (
     VerticalNavigation,
 )
 from widgetastic_patternfly4 import Button as PF4Button, Pagination as PF4Pagination
-from widgetastic_patternfly4.ouia import BaseSelect, Button as OUIAButton, Dropdown, Menu
+from widgetastic_patternfly4.ouia import (
+    BaseSelect,
+    Button as OUIAButton,
+    Dropdown,
+    Menu
+)
 from widgetastic_patternfly4.progress import Progress as PF4Progress
 
 from airgun.exceptions import DisabledWidgetError, ReadOnlyWidgetError

--- a/airgun/widgets.py
+++ b/airgun/widgets.py
@@ -26,8 +26,8 @@ from widgetastic_patternfly import (
     Kebab,
     VerticalNavigation,
 )
-from widgetastic_patternfly4 import Pagination as PF4Pagination
-from widgetastic_patternfly4.ouia import BaseSelect, Button as PF4Button, Dropdown, Menu
+from widgetastic_patternfly4 import Button as PF4Button, Pagination as PF4Pagination
+from widgetastic_patternfly4.ouia import BaseSelect, Button as OUIAButton, Dropdown, Menu
 from widgetastic_patternfly4.progress import Progress as PF4Progress
 
 from airgun.exceptions import DisabledWidgetError, ReadOnlyWidgetError
@@ -853,8 +853,8 @@ class PF4NavSearch(PF4Search):
 
     ROOT = '//div[@id="navigation-search"]'
     search_field = TextInput(locator=(".//input[@aria-label='Search input']"))
-    search_button = Button(locator=(".//button[@aria-label='Search']"))
-    clear_button = Button(locator=(".//button[@aria-label='Reset']"))
+    search_button = PF4Button(locator=(".//button[@aria-label='Search']"))
+    clear_button = PF4Button(locator=(".//button[@aria-label='Reset']"))
     items = PF4NavSearchMenu("navigation-search-menu")
     results_timeout = search_clear_timeout = 2
 
@@ -1360,9 +1360,9 @@ class Pf4ConfirmationDialog(ConfirmationDialog):
     right corner."""
 
     ROOT = '//div[@id="app-confirm-modal" or @data-ouia-component-type="PF4/ModalContent"]'
-    confirm_dialog = PF4Button('btn-modal-confirm')
-    cancel_dialog = PF4Button('btn-modal-cancel')
-    discard_dialog = PF4Button('app-confirm-modal-ModalBoxCloseButton')
+    confirm_dialog = OUIAButton('btn-modal-confirm')
+    cancel_dialog = OUIAButton('btn-modal-cancel')
+    discard_dialog = OUIAButton('app-confirm-modal-ModalBoxCloseButton')
 
 
 class LCESelector(GenericLocatorWidget):
@@ -2689,7 +2689,7 @@ class EditModal(View):
     """Class representing the Edit modal header"""
 
     title = Text('.//h1')
-    close_button = PF4Button('acs-edit-details-modal-ModalBoxCloseButton')
+    close_button = OUIAButton('acs-edit-details-modal-ModalBoxCloseButton')
 
     error_message = Text('//div[contains(@aria-label, "Danger Alert")]')
 


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/airgun/pull/1233

More sophisticated approach for clearing the search input.

Sometimes the previous value still remained in the search input,
even when `clear()` was called several times in a row.

This was probably a timing issue when running on a rel. fast browser machine.
