### PR TITLE
Navigation menu search: use proper PF4 button widget

### DIFF
--- a/airgun/widgets.py
+++ b/airgun/widgets.py
@@ -26,8 +26,13 @@ from widgetastic_patternfly import (
     Kebab,
     VerticalNavigation,
 )
-from widgetastic_patternfly4 import Pagination as PF4Pagination
-from widgetastic_patternfly4.ouia import BaseSelect, Button as PF4Button, Dropdown, Menu
+from widgetastic_patternfly4 import Button as PF4Button, Pagination as PF4Pagination
+from widgetastic_patternfly4.ouia import (
+    BaseSelect,
+    Button as OUIAButton,
+    Dropdown,
+    Menu,
+)
 from widgetastic_patternfly4.progress import Progress as PF4Progress
 
 from airgun.exceptions import DisabledWidgetError, ReadOnlyWidgetError
@@ -855,8 +860,8 @@ class PF4NavSearch(PF4Search):
 
     ROOT = '//div[@id="navigation-search"]'
     search_field = TextInput(locator=(".//input[@aria-label='Search input']"))
-    search_button = Button(locator=(".//button[@aria-label='Search']"))
-    clear_button = Button(locator=(".//button[@aria-label='Reset']"))
+    search_button = PF4Button(locator=(".//button[@aria-label='Search']"))
+    clear_button = PF4Button(locator=(".//button[@aria-label='Reset']"))
     items = PF4NavSearchMenu("navigation-search-menu")
     results_timeout = search_clear_timeout = 2
 
@@ -1362,9 +1367,9 @@ class Pf4ConfirmationDialog(ConfirmationDialog):
     right corner."""
 
     ROOT = '//div[@id="app-confirm-modal" or @data-ouia-component-type="PF4/ModalContent"]'
-    confirm_dialog = PF4Button('btn-modal-confirm')
-    cancel_dialog = PF4Button('btn-modal-cancel')
-    discard_dialog = PF4Button('app-confirm-modal-ModalBoxCloseButton')
+    confirm_dialog = OUIAButton('btn-modal-confirm')
+    cancel_dialog = OUIAButton('btn-modal-cancel')
+    discard_dialog = OUIAButton('app-confirm-modal-ModalBoxCloseButton')
 
 
 class LCESelector(GenericLocatorWidget):
@@ -2691,7 +2696,7 @@ class EditModal(View):
     """Class representing the Edit modal header"""
 
     title = Text('.//h1')
-    close_button = PF4Button('acs-edit-details-modal-ModalBoxCloseButton')
+    close_button = OUIAButton('acs-edit-details-modal-ModalBoxCloseButton')
 
     error_message = Text('//div[contains(@aria-label, "Danger Alert")]')
 


### PR DESCRIPTION
Vertical menu search buttons should use the correct PF4 button widgets.
This fixes the search clearing issue, when a search text value pops back
after clearing the search input via browser.clear()

The original PF4Button import alias was renamed to OUIAButton.
