### PR TITLE
[6.14.z] adding the PRT result and labels on github comment

### DIFF
--- a/.github/workflows/prt_labels.yml
+++ b/.github/workflows/prt_labels.yml
@@ -1,0 +1,44 @@
+name: Remove the PRT label, for the new commit
+
+on:
+  pull_request:
+    types: ["opened", "synchronize"]
+
+jobs:
+    prt_labels:
+      name: remove the PRT label, if it is a new commit
+      runs-on: ubuntu-latest
+      steps:
+        - name: Fetch the PRT status
+          id: prt
+          uses: omkarkhatavkar/wait-for-status-checks@main
+          with:
+            ref: ${{ github.head_ref }}
+            context: 'Robottelo-Runner'
+            wait-interval: 2
+            count: 5
+
+        - name: remove the PRT Passed/Failed label, for new commit
+          if: always() && ${{steps.prt.outputs.result}} == 'not_found'
+          uses: actions/github-script@v7
+          with:
+            github-token: ${{ secrets.CHERRYPICK_PAT }}
+            script: |
+              const prNumber = '${{ github.event.number }}';
+              const issue = await github.rest.issues.get({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: prNumber,
+              });
+              const labelsToRemove = ['PRT-Failed', 'PRT-Passed'];
+              const labelsToRemoveFiltered = labelsToRemove.filter(label => issue.data.labels.some(({ name }) => name === label));
+              if (labelsToRemoveFiltered.length > 0) {
+                await Promise.all(labelsToRemoveFiltered.map(async label => {
+                  await github.rest.issues.removeLabel({
+                    issue_number: prNumber,
+                    owner: context.repo.owner,
+                    repo: context.repo.repo,
+                    name: label
+                  });
+                }));
+              }

--- a/.github/workflows/prt_result.yml
+++ b/.github/workflows/prt_result.yml
@@ -1,0 +1,84 @@
+### The prt result workflow triggered through dispatch request from CI
+name: post-prt-result
+
+# Run on workflow dispatch from CI
+on:
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        type: string
+        description: pr number for PRT run
+      build_number:
+        type: string
+        description: build number for PRT run
+      pytest_result:
+        type: string
+        description: pytest summary result line
+      build_status:
+        type: string
+        description: status of jenkins build e.g. success, unstable or error
+      prt_comment:
+        type: string
+        description: prt pytest comment triggered the PRT checks
+
+
+jobs:
+  post-the-prt-result:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Add last PRT result into the github comment
+        id: add-prt-comment
+        if: ${{ always() && github.event.inputs.pytest_result != '' }}
+        uses: thollander/actions-comment-pull-request@v2
+        with:
+          message: |
+            **PRT Result**
+            ```
+            Build Number: ${{ github.event.inputs.build_number }}
+            Build Status: ${{ github.event.inputs.build_status }}
+            PRT Comment: ${{ github.event.inputs.prt_comment }}
+            Test Result : ${{ github.event.inputs.pytest_result }}
+            ```
+          pr_number: ${{ github.event.inputs.pr_number }}
+          GITHUB_TOKEN: ${{ secrets.CHERRYPICK_PAT }}
+
+      - name: Add the PRT passed/failed labels
+        id: prt-status
+        if: ${{ always() && github.event.inputs.build_status != '' }}
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.CHERRYPICK_PAT }}
+          script: |
+            const prNumber = ${{ github.event.inputs.pr_number }};
+            const buildStatus = "${{ github.event.inputs.build_status }}";
+            const labelToAdd = buildStatus === "SUCCESS" ? "PRT-Passed" : "PRT-Failed";
+            github.rest.issues.addLabels({
+              issue_number: prNumber,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              labels: [labelToAdd]
+            });
+      - name: Remove failed label on test pass or vice-versa
+        if: ${{ always() && github.event.inputs.build_status != '' }}
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.CHERRYPICK_PAT }}
+          script: |
+            const prNumber = ${{ github.event.inputs.pr_number }};
+            const issue = await github.rest.issues.get({
+              owner: context.issue.owner,
+              repo: context.issue.repo,
+              issue_number: prNumber,
+            });
+            const buildStatus = "${{ github.event.inputs.build_status }}";
+            const labelToRemove = buildStatus === "SUCCESS" ? "PRT-Failed" : "PRT-Passed";
+            const labelExists = issue.data.labels.some(({ name }) => name === labelToRemove);
+            if (labelExists) {
+              github.rest.issues.removeLabel({
+                issue_number: prNumber,
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                name: [labelToRemove]
+              });
+            }


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/airgun/pull/1239

### Details 
https://github.com/SatelliteQE/robottelo/pull/13979
https://github.com/SatelliteQE/robottelo/pull/14093

### Problem Statement
1. Currently, the labels PRT-Passed and PRT-Failed are added based on the results of the Pull Request Testing (PRT). However, when contributors update the pull request with new commits, these labels might remain, leading to potential confusion. There is a need to automatically remove these labels when new commits are added to the pull request.
2. Currently, the PRT result gets clean after a new commit and there is no way for PR to know what happened with the result. PRT passed/failed labels also need to be added automatically this helps in reviewing the PR quickly and merging them

### Solution

1. Add the dispatch workflow that takes care of this thing from the Jenkins CI update the GitHub comment with all details and apply the filter.
2. To address this issue, we propose implementing a solution using GitHub Actions (GHA). The solution involves periodically checking the GitHub status API to monitor for new commits on the pull request. Upon detecting a new commit, the workflow will automatically remove the PRT-Passed and PRT-Failed labels from the pull request. This ensures that the labels accurately reflect the current status of the pull request, reducing confusion and maintaining clarity for reviewers and contributors.


### Test Result 
https://github.com/omkarkhatavkar/robottelo/actions/runs/7916581527/job/21610780591?pr=216