### PR TITLE
[6.15.z] Improve stability of before_fill function

### DIFF
--- a/airgun/views/host.py
+++ b/airgun/views/host.py
@@ -1,4 +1,5 @@
 import re
+import time
 
 from wait_for import wait_for
 from widgetastic.utils import ParametrizedLocator
@@ -569,6 +570,7 @@ class HostRegisterView(BaseLoggedInView):
                     logger=self.logger,
                 )
                 self.general.__getattribute__(field).fill(field_value)
+                time.sleep(1)
 
 
 class RecommendationWidget(GenericLocatorWidget):


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/airgun/pull/1266

Adding this sleep ensures, that before_fill behaves correctly and detects disabled components correctly.