### PR TITLE
addition of auto-branching process as part of github action

### DIFF
--- a/.github/workflows/auto_branching.yml
+++ b/.github/workflows/auto_branching.yml
@@ -1,0 +1,212 @@
+### The auto-branching workflow triggered through a dispatch request from the CI
+name: auto-branching
+
+# Run on workflow dispatch from CI
+on:
+  workflow_dispatch:
+    inputs:
+      target_branch:
+        type: string
+        description: branch to be created from the master
+      stream_version:
+        type: string
+        description: new stream version of satellite
+
+jobs:
+  check-group-membership:
+    runs-on: ubuntu-latest
+    outputs:
+      member: ${{steps.check_membership.outputs.member}}
+
+    steps:
+      - name: Check if the user is a member of repository-admins group
+        id: check_membership
+        run: |
+          # Use GitHub API to check if the user triggering the workflow is a member of satellite-admin group
+          MEMBER=$(curl -s -H "Authorization: token ${{ secrets._REPO_ADMIN_TOKEN }}" \
+              "https://api.github.com/orgs/satelliteQE/teams/repository-admins/memberships/${{ github.actor }}")
+          if [[ $(echo "$MEMBER" | jq -r '.state') == "active" ]]; then
+            echo "User is a member of satellite-admin group."
+            echo "member=true" >> $GITHUB_OUTPUT
+          else
+            echo "User is not a member of satellite-admin group."
+            echo "member=false" >> $GITHUB_OUTPUT
+            exit 1
+          fi
+
+
+  auto-branching-new-downstream-release:
+    name: ${{ github.event.inputs.target_branch }} - raise PR with changes
+    runs-on: ubuntu-latest
+    needs: check-group-membership
+    if: ${{ needs.check-group-membership.outputs.member == 'true' }}
+
+    steps:
+      - name: Checkout Robottelo
+        uses: actions/checkout@v4
+
+      - name: Create the ${{ github.event.inputs.target_branch }} branch
+        id: create-branch
+        uses: peterjgrainger/action-create-branch@v2.2.0
+        env:
+          GITHUB_TOKEN: ${{ secrets._REPO_ADMIN_TOKEN }}
+        with:
+          branch: ${{ github.event.inputs.target_branch }}
+
+      - name: Create label for the ${{ github.event.inputs.target_branch }} branch
+        id: create-label
+        run: |
+          curl -X POST \
+            -H "Authorization: token ${{ secrets._REPO_ADMIN_TOKEN }}" \
+            -H "Accept: application/vnd.github.v3+json" \
+            https://api.github.com/repos/${{ github.repository }}/labels \
+            -d "{\"name\":\"${{ github.event.inputs.target_branch }}\",\"color\":\"fbca04\"}"
+
+      - name: Switch to ${{ github.event.inputs.target_branch }} branch
+        run: git checkout -b "${{ github.event.inputs.target_branch }}"
+
+      - name: Checkout from ${{ github.event.inputs.target_branch }} branch for auto-branching changes
+        id: checkout-to-auto-branch
+        run: |
+            branch_name="auto-branching-${{ github.event.inputs.target_branch }}-$(date '+%s')"
+            git checkout -b "$branch_name"
+            echo "branch_name=$branch_name" >> $GITHUB_OUTPUT
+
+      - name: Update target branch label in dependabot yml file
+        id: update-dependabot
+        run: |
+            # Read the dependabot.yml file
+            FILE_PATH="./.github/dependabot.yml"
+            TARGET_BRANCH="${{ github.event.inputs.target_branch }}"
+            # Append the target branch label to the labels node
+            awk -v target="'$TARGET_BRANCH'" '/^ *labels:/ {$0 = $0 "\n      - " target} 1' "$FILE_PATH" > temp.yml && mv temp.yml "$FILE_PATH"
+
+      - name: Remove the dispatch release GHA
+        id: remove-dispatch-release-gha
+        run: |
+            rm -rf ./.github/workflows/dispatch_release.yml
+            rm -rf ./.github/workflows/auto_branching.yml
+
+      - name: git status
+        run: git status
+
+      - name: git diff
+        run: git diff
+
+      - name: Commit changes
+        run: |
+          git config --local user.email "action@github.com"
+          git config --local user.name "GitHub Action"
+          git add ./.github/*
+          git commit -m "Changes for new ${{ github.event.inputs.target_branch }} branch"
+          git remote -vvv
+          git push origin ${{steps.checkout-to-auto-branch.outputs.branch_name}}
+      - name: Create pull request
+        id: create_pr
+        run: |
+          title="[${{ github.event.inputs.target_branch }}]: Changes for ${{ github.event.inputs.target_branch }} new branch"
+          body="
+            ### Problem Statement
+            New ${{ github.event.inputs.target_branch }} branch
+            ### Solution
+            - Dependabot labels are updated for new branch
+            - Removed dispatch release GHA from ${{ github.event.inputs.target_branch }} as we are releasing only master changes
+          "
+          pr_number=$(gh pr create --title "$title" --body "$body" --base "${{ github.event.inputs.target_branch }}" | awk -F'/' '{print $NF}')
+          echo "$pr_number"
+          echo "pr_number=$pr_number" >> $GITHUB_OUTPUT
+        env:
+          GITHUB_TOKEN: ${{ secrets._REPO_ADMIN_TOKEN }}
+
+      - name: Add the prt comment for running the sanity tests
+        id: add-parent-prt-comment
+        uses: thollander/actions-comment-pull-request@v2
+        with:
+          message: |
+            trigger: test-robottelo
+          pr_number: ${{ steps.create_pr.outputs.pr_number }}
+          GITHUB_TOKEN: ${{ secrets._REPO_ADMIN_TOKEN }}
+      
+      - name: add the no-cherrypick label
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets._REPO_ADMIN_TOKEN }}
+          script: |
+            github.rest.issues.addLabels({
+              issue_number: ${{ steps.create_pr.outputs.pr_number }},
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              labels: ["No-CherryPick"]
+            })
+
+  auto-branching-master:
+    name: master - raise PR with changes
+    runs-on: ubuntu-latest
+    needs: check-group-membership
+    if: ${{ needs.check-group-membership.outputs.member == 'true' }}
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Update target branch label in dependabot yml file
+        id: update-dependabot
+        run: |
+          # Read the dependabot.yml file
+          FILE_PATH="./.github/dependabot.yml"
+          TARGET_BRANCH="${{ github.event.inputs.target_branch }}"
+          # Append the target branch label to the labels node
+          awk -v target="'$TARGET_BRANCH'" '/^ *labels:/ {$0 = $0 "\n      - " target} 1' "$FILE_PATH" > temp.yml && mv temp.yml "$FILE_PATH"
+
+      - name: git status
+        run: git status
+
+      - name: git diff
+        run: git diff
+
+      - name: Commit changes
+        run: |
+          git config --local user.email "Satellite-QE.satqe.com"
+          git config --local user.name "Satellite-QE"
+          branch_name="auto-branching-${{ github.event.inputs.target_branch }}-$(date '+%s')"
+          git checkout -b "$branch_name"
+          git add ./.github/*
+          git commit -m "Changes for ${{ github.event.inputs.target_branch }} new branch"
+          git push origin "$branch_name"
+
+      - name: Create pull request
+        id: create_pr
+        run: |
+          title="[master]: Changes for ${{ github.event.inputs.target_branch }} new branch"
+          body="
+            ### Problem Statement
+            New ${{ github.event.inputs.target_branch }} downstream and master points to stream that is ${{ github.event.inputs.stream_version }}
+            ### Solution
+            - Dependabot.yaml cherrypicks to ${{ github.event.inputs.target_branch }}
+          "
+          pr_number=$(gh pr create --title "$title" --body "$body" --base "master" | awk -F'/' '{print $NF}')
+          echo "$pr_number"
+          echo "pr_number=$pr_number" >> $GITHUB_OUTPUT
+        env:
+          GITHUB_TOKEN: ${{ secrets._REPO_ADMIN_TOKEN }}
+
+      - name: Add the prt comment for running the sanity tests
+        id: add-parent-prt-comment
+        uses: thollander/actions-comment-pull-request@v2
+        with:
+          message: |
+            trigger: test-robottelo
+          pr_number: ${{ steps.create_pr.outputs.pr_number }}
+          GITHUB_TOKEN: ${{ secrets._REPO_ADMIN_TOKEN }}
+
+
+      - name: add the no-cherrypick label
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets._REPO_ADMIN_TOKEN }}
+          script: |
+            github.rest.issues.addLabels({
+              issue_number: ${{ steps.create_pr.outputs.pr_number }},
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              labels: ["No-CherryPick"]
+            })


### PR DESCRIPTION
### Problem Statement
Currently the branching process is manual and it requires to review the files needs to be updated. Also requires attention in details as there are many files changes with respect to multiple branches as well. We need to have some automated solution that will help in the solve this.    

### Solution
Introducing the Github Action that will help to solve this issue. It will contains the steps that needs to run every time when we needs branching. These are predefined steps and getting documented help to not to miss the some changes   

### Test Result 
I have tested on my own fork and here it is the result, (yet to test it ) 

**- work_flow trigger:** 
   - https://github.com/omkarkhatavkar/airgun/actions/runs/8322496425

**- non-master branch workflow and PR:**
    -   https://github.com/omkarkhatavkar/airgun/pull/6
    
**- master branch workflow and PR:** 
    -  https://github.com/omkarkhatavkar/airgun/pull/5
   

<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->