### PR TITLE
Rework is_displayed logic for contenthost

### DIFF
--- a/airgun/entities/contenthost.py
+++ b/airgun/entities/contenthost.py
@@ -39,7 +39,8 @@ class ContentHostEntity(BaseEntity):
     def read(self, entity_name, widget_names=None):
         """Read content host details, optionally read only the widgets in widget_names."""
         view = self.navigate_to(self, 'Edit', entity_name=entity_name)
-        view.is_displayed
+        view.wait_displayed()
+        self.browser.plugin.ensure_page_safe()
         return view.read(widget_names=widget_names)
 
     def read_legacy_ui(self, entity_name, widget_names=None):


### PR DESCRIPTION
Labels: master, 6.15.z  

See also: https://github.com/SatelliteQE/airgun/pull/1281#issuecomment-2019926059

relevant test:
tests/foreman/ui/test_repository.py::test_positive_create_as_non_admin_user