### PR TITLE
Fixes in repo discovery and search

### DIFF
--- a/airgun/views/product.py
+++ b/airgun/views/product.py
@@ -159,7 +159,7 @@ class ProductRepoDiscoveryView(BaseLoggedInView, SearchableViewMixin):
 
     @View.nested
     class discovered_repos(View):
-        discover_action = Text("//button[@type='submit']")
+        discover_action = Text("//button[@type='submit' and contains(., 'Discover')]")
         cancel_discovery = Text("//button[@ng-click='cancelDiscovery()']")
         repos = CreateDiscoveredReposView()
 

--- a/airgun/views/repository.py
+++ b/airgun/views/repository.py
@@ -12,7 +12,6 @@ from widgetastic_patternfly import BreadCrumb
 from airgun.views.common import (
     BaseLoggedInView,
     SearchableViewMixin,
-    SearchableViewMixinPF4,
 )
 from airgun.widgets import (
     ActionsDropdown,
@@ -26,7 +25,7 @@ from airgun.widgets import (
 )
 
 
-class RepositoriesView(BaseLoggedInView, SearchableViewMixinPF4):
+class RepositoriesView(BaseLoggedInView, SearchableViewMixin):
     breadcrumb = BreadCrumb()
     new = Text("//button[contains(@href, '/repositories/new')]")
     sync = Text("//button[contains(@ng-click, 'syncSelectedRepositories')]")


### PR DESCRIPTION
While fixing some HTTP Proxy UI failures I discovered that in 6.15 and stream/6.16 the `Discover` button is not hit since it collides with the vertical nav menu search. Narrowing down the locator helps.

Also, `session.repository.search(product_name, repo_name)` now returns `None` since #1200 was merged. It does not feel like a PF4 searchbox in 6.15 and stream 

![image](https://github.com/SatelliteQE/airgun/assets/46570670/93d4a764-cd31-4d9f-acec-428ae68a9957)

Turning it back helped locally.
