### PR TITLE
redhat_repositories search box & button xpath, add wait_for in search

### DIFF
--- a/airgun/entities/redhat_repository.py
+++ b/airgun/entities/redhat_repository.py
@@ -18,6 +18,7 @@ class RedHatRepositoryEntity(BaseEntity):
             eg: RPM, OSTree ...
         """
         view = self.navigate_to(self, 'All')
+        wait_for(lambda: view.search_box.is_displayed, timeout=10, delay=1)
         return view.search(value, category=category, types=types)
 
     def read(self, entity_name=None, category='Available', recommended_repo=None):

--- a/airgun/views/redhat_repository.py
+++ b/airgun/views/redhat_repository.py
@@ -208,8 +208,12 @@ class RedHatRepositoriesView(BaseLoggedInView):
 
     title = Text("//h1[contains(., 'Red Hat Repositories')]")
     search_category = RepositorySearchCategory(".//div[button[@id='search-list-select']]")
-    search_box = TextInput(locator=".//input[@aria-label='Search input']")
-    search_button = Text(".//button[@aria-label='Search']")
+    search_box = TextInput(
+        locator='//*[@id="redhatRepositoriesPage"]//following::input[@aria-label="Search input"]'
+    )
+    search_button = Text(
+        '//*[@id="redhatRepositoriesPage"]//following::button[@aria-label="Search"]'
+    )
     search_types = RepositorySearchTypes(".//div[button[@data-id='formControlsSelectMultiple']]")
     search_clear = Text(".//span[@class = 'fa fa-times']")
     recommended_repos = Text(".//div[contains(@class, 'bootstrap-switch wrapper')]")


### PR DESCRIPTION
**Problem:** `Search box` and `search button` for `Content > Red Hat Repositories` page were not found, rather script was selecting left pannel search box. Apart from this, test was not waiting for page to load before searching on `Red Hat Repositories` page.

**Solution:** The updated `XPaths` and added `wait_for` method before searching any rh repositories.

**Note:** 
Correspondig Robottelo PR https://github.com/SatelliteQE/robottelo/pull/14673