### PR TITLE
[6.14.z] edit host view wait until displayed

### DIFF
--- a/airgun/entities/host.py
+++ b/airgun/entities/host.py
@@ -464,6 +464,7 @@ class EditHost(NavigateStep):
         entity_name = kwargs.get('entity_name')
         self.parent.search(entity_name)
         self.parent.table.row(name=entity_name)['Actions'].widget.fill('Edit')
+        self.view.wait_displayed()
 
 
 @navigator.register(HostEntity, 'Select Action')


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/airgun/pull/1362

`EditHost` navigation step now waits for the view to be displayed.

This is needed for an edge case, when editing a host with empty values, i.e.,
`host.update(client.hostname, {})`,
is too fast and the view is not yet fully loaded.
