### PR TITLE
[6.15.z] Add fetching of all errata entries from new host page, fix search of errata on legacy chost page

### DIFF
--- a/airgun/entities/contenthost.py
+++ b/airgun/entities/contenthost.py
@@ -159,14 +159,18 @@ class ContentHostEntity(BaseEntity):
         return view.read()
 
     def search_errata(self, entity_name, errata_id, environment=None):
-        """Search for specific errata applicable for content host.
+        """Search for specific errata applicable to content host.
+        Check the legacy Contenthost page -> Details -> Errata tab.
 
         :param str entity_name: the content hosts name.
         :param str errata_id: errata id or title, e.g. 'RHEA-2012:0055'
         :param str optional environment: lifecycle environment to filter by.
         """
-        view = self.navigate_to(self, 'Edit', entity_name=entity_name)
+        view = self.navigate_to(self, 'LegacyDetails', entity_name=entity_name)
+        view.wait_displayed()
         view.errata.search(errata_id, lce=environment)
+        view.errata.table.wait_displayed()
+        self.browser.plugin.ensure_page_safe()
         return view.errata.table.read()
 
     def read_errata_details(self, entity_name, errata_id, environment=None):

--- a/airgun/entities/host_new.py
+++ b/airgun/entities/host_new.py
@@ -292,6 +292,46 @@ class NewHostEntity(HostEntity):
         view.flash.assert_no_error()
         view.flash.dismiss()
 
+    def get_errata_table(
+        self,
+        entity_name,
+        installable=None,
+        severity=None,
+        search=None,
+        type=None,
+    ):
+        """Return the table of all errata entries, from Errata tab on selected host.
+        param: entity_name str: hostname to search for errata table
+
+        Optional: Filter by passing args (string):
+            param: installable str: filter errata by installability ('Yes' or 'No').
+            param: severity str: filter errata by severity.
+            param: search str: pass a search query to the searchbar, prior to reading.
+            param: type str: filter errata search by type.
+
+        note: all of the optional params being None, will result in no filtering.
+        """
+        view = self.navigate_to(self, 'NewDetails', entity_name=entity_name)
+        view.wait_displayed()
+        view.content.errata.select()
+        # optional: filter by params that are not None
+        if installable is not None:
+            assert installable == 'Yes' or 'No', (
+                'installable_filter expected None or str, "Yes" or "No".'
+                f' Got: {installable}, ({type(installable)}).'
+            )
+            view.content.errata.installable_filter.fill(installable)
+        if type is not None:
+            view.content.errata.type_filter.fill(type)
+        if severity is not None:
+            view.content.errata.severity_filter.fill(severity)
+        if search is not None:
+            view.content.errata.searchbar.fill(search)
+        # displayed the table with or without filters
+        view.content.errata.table.wait_displayed()
+        self.browser.plugin.ensure_page_safe()
+        return view.content.errata.table.read()
+
     def get_errata_by_type(self, entity_name, type):
         """List errata based on type and return table"""
         view = self.navigate_to(self, 'NewDetails', entity_name=entity_name)


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/airgun/pull/1374

- Update `search_errata` on contenthost, to correctly navigate to 'LegacyDetails' for chost.
- `get_errata_table`: Add support to New Host > content > errata tab:
    Return all errata entries displayed in the table.
    can search and filter by optional params, otherwise display all errata present on host.