### PR TITLE
contenthost legacy ui get virtual host support

### DIFF
--- a/airgun/views/contenthost.py
+++ b/airgun/views/contenthost.py
@@ -142,6 +142,7 @@ class ContentHostDetailsView(BaseLoggedInView):
         description = EditableEntry(name='Description')
         type = ReadOnlyEntry(name='Type')
         virtual_guests = ReadOnlyEntry(name='Virtual Guests')
+        virtual_host = ReadOnlyEntry(name='Virtual Host')
         registered_through = ReadOnlyEntry(name='Registered Through')
         # Subscriptions
         subscription_status = ReadOnlyEntry(name='Subscription Status')


### PR DESCRIPTION
contenthost legacy ui get virtual host support

This PR influence the PR https://github.com/SatelliteQE/robottelo/pull/15064

Cases Run:  PASS
```
(robottelo_vv_master) [root@dell-per740-68-vm-05 robottelo]# pytest ./tests/foreman/virtwho/ui/test_esx_sca.py -k test_positive_deploy_configure_by_id_script --disable-pytest-warnings -q
..                                                                                                                                                                                                          [100%]
2 passed, 34 deselected, 29 warnings in 539.09s (0:08:59)
2024-05-21 00:27:04 - robottelo - WARNING - missing grid_url or session_id. unable to clean video files.

```