### PR TITLE
[6.12.z] fixing make-docs issue with some update in code

### DIFF
--- a/airgun/entities/subscription.py
+++ b/airgun/entities/subscription.py
@@ -48,9 +48,9 @@ class SubscriptionEntity(BaseEntity):
     @property
     def has_manifest(self):
         """Is there manifest present in current organization?
-        :return: boolean value indicating whether manifest is present
-        May be None if user can't verify reliably if manifest is
-        uploaded or not due to missing permissions
+
+        :return: boolean value indicating whether manifest is present May be None if user can't verify
+            reliably if manifest is uploaded or not due to missing permissions
         """
         try:
             view = self.navigate_to(self, 'Manage Manifest')

--- a/airgun/helpers/base.py
+++ b/airgun/helpers/base.py
@@ -1,22 +1,15 @@
-from typing import TYPE_CHECKING
-
-if TYPE_CHECKING:
-    pass
-
-
 class BaseEntityHelper:
     def __init__(self, entity):
-        # type: (BaseEntity) -> None
         self._entity = entity
 
     @property
     def entity(self):
+        """Returns the entity associated with this helper."""
         return self._entity
 
     def read_filled_view(
         self, navigation_name, navigation_kwargs=None, values=None, read_widget_names=None
     ):
-        # type: (str, Dict, Dict[str, Any], List[str]) -> Dict[str, Any]
         """Navigate to a form using 'navigation_name' and with parameters from 'navigation_kwargs',
         fill the form with values and then read values for widgets from 'read_widget_names' list if
         supplied otherwise read all widgets values.
@@ -32,10 +25,8 @@ class BaseEntityHelper:
             )
 
         """
-        if navigation_kwargs is None:
-            navigation_kwargs = {}
-        if values is None:
-            values = {}
+        navigation_kwargs = navigation_kwargs or {}
+        values = values or {}
         view = self.entity.navigate_to(self.entity, name=navigation_name, **navigation_kwargs)
         view.fill(values)
         return view.read(widget_names=read_widget_names)

--- a/airgun/widgets.py
+++ b/airgun/widgets.py
@@ -2368,8 +2368,9 @@ class AuthSourceAggregateCard(AggregateStatusCard):
 
     @property
     def count(self):
-        """Count of sources
-        :return int: None if no count element is found, otherwise count of sources in the card
+        """Count of sources.
+
+        :return int or None: None if no count element is found, otherwise count of sources in the card.
         """
         try:
             return int(self.browser.text(self.browser.element(self.COUNT)))


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/airgun/pull/1391

This pull request addresses an issue encountered when generating documentation using Sphinx in the Airgun project. The problem arose due to incompatible type annotations causing errors during the documentation build process.

To resolve this issue, the following changes were made:

- Updated the docstring of the affected module to provide clearer and more descriptive documentation.
- Removed type annotations from the codebase to ensure compatibility 

These changes ensure that the documentation build process (make -docs) in Airgun proceeds smoothly without encountering errors related to type annotations.