### PR TITLE
[master]: Changes for 6.16.z new branch

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -16,7 +16,6 @@ updates:
       - "6.15.z"
       - "6.14.z"
       - "6.13.z"
-      - "6.12.z"
 
   # Maintain dependencies for our GitHub Actions
   - package-ecosystem: "github-actions"
@@ -30,4 +29,3 @@ updates:
       - "6.15.z"
       - "6.14.z"
       - "6.13.z"
-      - "6.12.z"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,6 +10,7 @@ updates:
     schedule:
       interval: "daily"
     labels:
+      - '6.16.z'
       - "CherryPick"
       - "dependencies"
       - "6.15.z"
@@ -23,6 +24,7 @@ updates:
     schedule:
       interval: "daily"
     labels:
+      - '6.16.z'
       - "CherryPick"
       - "dependencies"
       - "6.15.z"


### PR DESCRIPTION

  ### Problem Statement
  New 6.16.z downstream and master points to stream that is 6.17
  ### Solution
  - Dependabot.yaml cherrypicks to 6.16.z
