### PR TITLE
[6.14.z] 6.15.z-fix subscription search box xpath

### DIFF
--- a/airgun/entities/subscription.py
+++ b/airgun/entities/subscription.py
@@ -176,6 +176,7 @@ class SubscriptionEntity(BaseEntity):
     def read_subscriptions(self):
         """Return subscriptions table"""
         view = self.navigate_to(self, 'All')
+        view.wait_displayed(timeout=10, delay=1)
         return view.table.read()
 
 

--- a/airgun/views/subscription.py
+++ b/airgun/views/subscription.py
@@ -23,7 +23,9 @@ from airgun.widgets import (
 # Search field and button on Subscriptions page uses different locators,
 # so subclass it and use it in our custom SearchableViewMixin
 class SubscriptionSearch(Search):
-    search_field = TextInput(locator=(".//input[starts-with(@id, 'downshift-')]"))
+    search_field = TextInput(
+        locator=('//input[@aria-label="Search input" and @placeholder="Search"]')
+    )
     search_button = Button('Search')
 
 


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/airgun/pull/1405

**Problem**
Content - Subscription page search box xpath unable to locate due to wrong xpath

**Solution**
This updated xpath will work as expected.

**Note**
Robottelo changes from the PR [[Link]](https://github.com/SatelliteQE/robottelo/pull/15237) are not dependant these changes as I have updated some part of test case ( `test_positive_access_with_non_admin_user_with_manifest`) which won't search for any Subscription