### PR TITLE
[6.13.z] browser teardown fix at session exit

### DIFF
--- a/airgun/session.py
+++ b/airgun/session.py
@@ -229,7 +229,7 @@ class Session:
             not risen not to shadow real session result.
         """
         if self.browser is None:
-            # browser was never started, don't do anything
+            # browser hasn't been started or was already closed, don't do anything
             return
         LOGGER.info('Stopping UI session %r for user %r', self.name, self._user)
         passed = True if exc_type is None else False
@@ -239,7 +239,7 @@ class Session:
         except Exception as err:  # - TODO: fix bare except
             LOGGER.exception(err)
         finally:
-            self._factory.finalize(passed)
+            self.browser = self._factory.finalize(passed)
 
     def _open(self, entity):
         """Initializes requested entity. If this is first time session


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/airgun/pull/1413

Cherrypick of PR: https://github.com/SatelliteQE/airgun/pull/1390

### Problem Statement

When nesting `airgun.session.Session` in multiple context managers (like robottelo `session` fixture does),
the `__exit__` method, which handles browser teardown, is called mutliple times as well.

This causes that the second and further attempt to call `webdriver.quit()` will fail,
because the browser was already closed.


### Solution

Execute the browser teardown only once.


### Related Issues

Needed for https://github.com/SatelliteQE/robottelo/pull/15050
