### PR TITLE
6.14.z changes - increse timeout for read subscription

### DIFF
--- a/airgun/entities/subscription.py
+++ b/airgun/entities/subscription.py
@@ -176,7 +176,7 @@ class SubscriptionEntity(BaseEntity):
     def read_subscriptions(self):
         """Return subscriptions table"""
         view = self.navigate_to(self, 'All')
-        view.wait_displayed(timeout=10, delay=1)
+        view.wait_displayed(timeout=60, delay=10)
         return view.table.read()
 
 

--- a/airgun/views/subscription.py
+++ b/airgun/views/subscription.py
@@ -137,12 +137,13 @@ class SubscriptionListView(BaseLoggedInView, SubscriptionSearchableViewMixin):
     columns_filter_checkboxes = SubscriptionColumnsFilter(
         ".//form[div[contains(@class, 'filter')]]/div/i"
     )
+    table_loading = Text("//h5[normalize-space(.)='Loading']")
 
     @property
     def is_displayed(self):
         return (
-            self.browser.wait_for_element('div#subscriptions-table', timeout=10, exception=False)
-            is not None
+            self.browser.wait_for_element(self.table_loading, exception=False) is None
+            and self.browser.wait_for_element(self.table, exception=False) is not None
         )
 
     def is_searchable(self):


### PR DESCRIPTION
Sub-task of **6.14.z Airgun PR https://github.com/SatelliteQE/airgun/pull/1412** *

**Problem**
PRT is failing for 6.14.z CP PR https://github.com/SatelliteQE/robottelo/pull/15276 (Original 6.15.z robottelo PR https://github.com/SatelliteQE/robottelo/pull/15237)

**Actual issue**
Subscription table is not loading within existing 10s of timeout

**Solution**
Increasing timeout value would help to fix this issue

**Related PR**
6.15.z Airgun PR https://github.com/SatelliteQE/airgun/pull/1405
**6.14.z Airgun PR https://github.com/SatelliteQE/airgun/pull/1412** *


**PRT Comment**
```
trigger: test-robottelo
pytest: tests/foreman/ui/test_subscription.py -k 'test_positive_access_with_non_admin_user_with_manifest'
robottelo: 15276
```