### PR TITLE
Manage columns support for All Hosts

### DIFF
--- a/airgun/entities/all_hosts.py
+++ b/airgun/entities/all_hosts.py
@@ -4,6 +4,7 @@ from airgun.entities.base import BaseEntity
 from airgun.navigation import NavigateStep, navigator
 from airgun.utils import retry_navigation
 from airgun.views.all_hosts import (
+    AllHostsManageColumnsView,
     AllHostsTableView,
     BulkHostDeleteDialog,
     HostDeleteDialog,
@@ -19,6 +20,13 @@ class AllHostsEntity(BaseEntity):
         self.browser.plugin.ensure_page_safe(timeout='5s')
         view.wait_displayed()
         return view.search(host_name)
+
+    def read_table(self):
+        """Read All Hosts table"""
+        view = self.navigate_to(self, 'All')
+        self.browser.plugin.ensure_page_safe(timeout='5s')
+        view.wait_displayed()
+        return view.table.read()
 
     def delete(self, host_name):
         """Delete host through table dropdown"""
@@ -54,6 +62,28 @@ class AllHostsEntity(BaseEntity):
         view.wait_displayed()
         return view.no_results
 
+    def manage_table_columns(self, values: dict):
+        """
+        Select which columns should be displayed in the hosts table.
+
+        :param dict values: items of 'column name: value' pairs
+            Example: {'IPv4': True, 'Power': False, 'Model': True}
+        """
+        view = self.navigate_to(self, 'ManageColumns')
+        view.fill(values)
+        view.submit()
+
+    def get_displayed_table_headers(self):
+        """
+        Return displayed columns in the hosts table.
+
+        :return list: header names of the hosts table
+        """
+        view = self.navigate_to(self, 'All')
+        self.browser.plugin.ensure_page_safe(timeout='5s')
+        view.wait_displayed()
+        return view.table.headers
+
 
 @navigator.register(AllHostsEntity, 'All')
 class ShowAllHostsScreen(NavigateStep):
@@ -64,3 +94,17 @@ class ShowAllHostsScreen(NavigateStep):
     @retry_navigation
     def step(self, *args, **kwargs):
         self.view.menu.select('Hosts', 'All Hosts')
+
+
+@navigator.register(AllHostsEntity, 'ManageColumns')
+class HostsManageColumns(NavigateStep):
+    """Navigate to the Manage columns dialog"""
+
+    VIEW = AllHostsManageColumnsView
+
+    def prerequisite(self, *args, **kwargs):
+        return self.navigate_to(self.obj, 'All')
+
+    def step(self, *args, **kwargs):
+        """Open the Manage columns dialog"""
+        self.parent.manage_columns.click()

--- a/airgun/views/all_hosts.py
+++ b/airgun/views/all_hosts.py
@@ -8,6 +8,7 @@ from airgun.views.common import (
     BaseLoggedInView,
     SearchableViewMixinPF4,
 )
+from airgun.views.host_new import ManageColumnsView, PF4CheckboxTreeView
 
 
 class AllHostsTableView(BaseLoggedInView, SearchableViewMixinPF4):
@@ -18,6 +19,7 @@ class AllHostsTableView(BaseLoggedInView, SearchableViewMixinPF4):
     bulk_actions = Dropdown(locator='.//div[@data-ouia-component-id="action-buttons-dropdown"]')
     table_loading = Text("//h5[normalize-space(.)='Loading']")
     no_results = Text("//h5[normalize-space(.)='No Results']")
+    manage_columns = Button("Manage columns")
     table = PatternflyTable(
         component_id='table',
         column_widgets={
@@ -64,3 +66,29 @@ class BulkHostDeleteDialog(View):
     @property
     def is_displayed(self):
         return self.browser.wait_for_element(self.title, exception=False) is not None
+
+
+class AllHostsCheckboxTreeView(PF4CheckboxTreeView):
+    """Small tweaks to work with All Hosts"""
+
+    CHECKBOX_LOCATOR = './/*[self::span|self::label][contains(@class, "pf-c-tree-view__node-text")]/preceding-sibling::span/input[@type="checkbox"]'
+
+
+class AllHostsManageColumnsView(ManageColumnsView):
+    """Manage columns modal from Hosts page, small tweaks to work with All Hosts"""
+
+    ROOT = './/div[@data-ouia-component-id="manage-columns-modal"]'
+
+    def read(self):
+        """
+        Get labels and values of all checkboxes in the dialog.
+
+        :return dict: mapping of `label: value` items
+        """
+        return self.checkbox_group.read()
+
+    def fill(self, values):
+        """
+        Overwritten to ignore the "Expand tree" functionality
+        """
+        self.checkbox_group.fill(values)


### PR DESCRIPTION
Adds support for All Hosts page Manage Columns functionality. Leverages heavily the work done for the similar functionality on the older Hosts page. 

Tested by: https://github.com/SatelliteQE/robottelo/pull/15383