### PR TITLE
[6.15.z] Errata install, and legacy chost methods

### DIFF
--- a/airgun/entities/contenthost.py
+++ b/airgun/entities/contenthost.py
@@ -119,7 +119,7 @@ class ContentHostEntity(BaseEntity):
 
     def search_package(self, entity_name, package_name):
         """Search for specific package installed in content host"""
-        view = self.navigate_to(self, 'Edit', entity_name=entity_name)
+        view = self.navigate_to(self, 'LegacyDetails', entity_name=entity_name)
         view.packages_installed.search(package_name)
         return view.packages_installed.table.read()
 
@@ -137,13 +137,14 @@ class ContentHostEntity(BaseEntity):
         """Install errata on a content host
 
         :param name: content host name to apply errata on
-        :param errata_id: errata id or title, e.g. 'RHEA-2012:0055'
+        :param errata_id: str: errata id or title, e.g. 'RHEA-2012:0055'
+            or pass "All" to select all available errata available for host,
         :param str install_via: via which mean to install errata. Available
             options: "katello", "rex", "rex_customize"
 
         :return: Returns a dict containing task status details
         """
-        view = self.navigate_to(self, 'Edit', entity_name=entity_name)
+        view = self.navigate_to(self, 'LegacyDetails', entity_name=entity_name)
         if errata_id == "All":
             view.errata.select_all.fill(True)
         else:

--- a/airgun/entities/errata.py
+++ b/airgun/entities/errata.py
@@ -5,9 +5,9 @@ from airgun.utils import retry_navigation
 from airgun.views.errata import (
     ErrataDetailsView,
     ErrataInstallationConfirmationView,
-    ErrataTaskDetailsView,
     ErratumView,
 )
+from airgun.views.job_invocation import JobInvocationStatusView
 
 
 class ErrataEntity(BaseEntity):
@@ -59,11 +59,16 @@ class ErrataEntity(BaseEntity):
             view.content_hosts.environment_filter.fill(environment)
         return view.read(widget_names=widget_names)
 
-    def install(self, entity_name, host_name):
+    def install(self, entity_name, host_names, environment=None):
         """Install errata on content host.
 
         :param str entity_name: errata id or title
-        :param str host_name: content host name to apply errata on
+        :param str host_names: content host name to apply errata on.
+            pass a single str hostname,
+            or pass 'All' for any available hosts,
+            or pass a list of str hostnames.
+        :param str environment: name of lifecycle environment to scope errata.
+            default: None
         """
         view = self.navigate_to(
             self,
@@ -73,13 +78,31 @@ class ErrataEntity(BaseEntity):
             installable=False,
             repo=None,
         )
-        view.content_hosts.search(host_name)
-        view.content_hosts.table.row(name=host_name)[0].fill(True)
+        if environment:
+            view.content_hosts.environment_filter.fill(environment)
+        view.content_hosts.wait_displayed()
+
+        if host_names == 'All':
+            # select_all on table, check if single or multiple hosts
+            view.content_hosts.select_all.fill(True)
+        elif isinstance(host_names, list):
+            # find and select hostnames in table from list
+            for hostname in host_names:
+                view.content_hosts.table.row(name=hostname)[0].fill(True)
+        else:
+            # search and select the single passed hostname
+            view.content_hosts.search(host_names)
+            view.content_hosts.wait_displayed()
+            view.content_hosts.table.row(name=host_names)[0].fill(True)
+        view.content_hosts.wait_displayed()
         view.content_hosts.apply.click()
+        # brought to confirmation page
         view = ErrataInstallationConfirmationView(view.browser)
+        view.wait_displayed()
         view.confirm.click()
-        view = ErrataTaskDetailsView(view.browser)
-        view.progressbar.wait_for_result()
+        # wait for redirect to task details page
+        view = JobInvocationStatusView(view.browser)
+        view.wait_for_result(delay=0.01, timeout=1200)
         return view.read()
 
     def search_content_hosts(self, entity_name, value, environment=None):

--- a/airgun/entities/host_new.py
+++ b/airgun/entities/host_new.py
@@ -326,6 +326,7 @@ class NewHostEntity(HostEntity):
         """Filter installed packages on host"""
         view = self.navigate_to(self, 'NewDetails', entity_name=entity_name)
         view.content.packages.select()
+        view.content.packages.table.wait_displayed()
         view.content.packages.searchbar.fill(search)
         # wait for filter to apply
         self.browser.plugin.ensure_page_safe()

--- a/airgun/views/errata.py
+++ b/airgun/views/errata.py
@@ -80,6 +80,7 @@ class ErrataDetailsView(BaseLoggedInView):
         TAB_NAME = 'Content Hosts'
         environment_filter = SatSelect(".//select[@ng-model='environmentFilter']")
         searchbox = Search()
+        select_all = Checkbox(locator=".//input[@type='checkbox'][@ng-change='allSelected()']")
         apply = Text(".//button[@ng-click='goToNextStep()']")
         table = SatTable(
             locator=".//table",
@@ -188,7 +189,7 @@ class ApplyErrataView(BaseLoggedInView):
 
 class ErrataInstallationConfirmationView(BaseLoggedInView):
     cancel = Text(".//button[@ng-click='transitionBack()']")
-    confirm = Text(".//button[@type='submit']")
+    confirm = Text(".//span[text()='Confirm']")
 
 
 class ErrataTaskDetailsView(TaskDetailsView):

--- a/airgun/views/host_new.py
+++ b/airgun/views/host_new.py
@@ -350,7 +350,9 @@ class NewHostDetailsView(BaseLoggedInView):
             ROOT = './/div[@id="packages-tab"]'
 
             select_all = Checkbox(locator='.//div[@id="selection-checkbox"]/div/label')
-            searchbar = SearchInput(locator='.//input[contains(@class, "pf-m-search")]')
+            searchbar = SearchInput(
+                locator='.//input[contains(@class, "pf-c-text-input-group__text-input")]'
+            )
             status_filter = Dropdown(locator='.//div[@aria-label="select Status container"]/div')
             upgrade = Pf4ActionsDropdown(locator='.//div[div/button[normalize-space(.)="Upgrade"]]')
             dropdown = Dropdown(locator='.//div[button[@aria-label="bulk_actions"]]')


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/airgun/pull/1387

Supports robottelo [#15483](https://github.com/SatelliteQE/robottelo/pull/15483) << 6.15.z CP of original PR
- Add option to install errata to multiple/all hosts listed, in ContentTypes > Errata > details > ContentHosts tab
- Fix legacy chost errata install and package search methods, to use `LegacyDetails` page
- Some locators updated