### PR TITLE
[6.15.z] adding and removing ansible role

### DIFF
--- a/airgun/entities/hostgroup.py
+++ b/airgun/entities/hostgroup.py
@@ -74,6 +74,33 @@ class HostGroupEntity(BaseEntity):
         wait_for(lambda: int(role_list[-1].text.split(". ")[0]), timeout=30)
         return int(role_list[-1].text.split(". ")[0])
 
+    def assign_role_to_hostgroup(self, entity_name, values):
+        """Assign Ansible role(s) to the host group based on user input
+        Args:
+            entity_name: Name of the host
+            values: Name of the ansible role
+        """
+        view = self.navigate_to(self, 'Edit', entity_name=entity_name)
+        view.fill(values)
+        view.submit.click()
+        view.flash.assert_no_error()
+        view.flash.dismiss()
+
+    def remove_hostgroup_role(self, entity_name, values):
+        """Remove Ansible role from the host group based on user input
+        Args:
+            entity_name: Name of the host
+            values: Name of the ansible role
+        """
+        view = self.navigate_to(self, 'Edit', entity_name=entity_name)
+        view.ansible_roles.resources.unassigned_values(values)
+        view.submit.click()
+
+    def read_role(self, entity_name, values):
+        """Return name of the assigned Ansible role(s) of the host group."""
+        view = self.navigate_to(self, 'Edit', entity_name=entity_name)
+        return view.ansible_roles.resources.read_assigned_values(values)
+
 
 @navigator.register(HostGroupEntity, 'All')
 class ShowAllHostGroups(NavigateStep):

--- a/airgun/views/hostgroup.py
+++ b/airgun/views/hostgroup.py
@@ -8,6 +8,7 @@ from airgun.widgets import (
     ConfigGroupMultiSelect,
     FilteredDropdown,
     MultiSelect,
+    MultiSelectNoFilter,
     PuppetClassesMultiSelect,
     RadioGroup,
 )
@@ -78,7 +79,7 @@ class HostGroupCreateView(BaseLoggedInView):
     @View.nested
     class ansible_roles(SatTab):
         TAB_NAME = 'Ansible Roles'
-        resources = MultiSelect(id='ms-hostgroup_ansible_role_ids')
+        resources = MultiSelectNoFilter(id='ansible_roles')
         pagination = PF4Pagination()
 
     @View.nested
@@ -156,4 +157,5 @@ class HostGroupEditView(HostGroupCreateView):
         assigned_role = '//div[@class="assigned-roles-container col-sm-6"]/div[2]/div'
         assigned_ansible_role = '//div[@class="assigned-roles-container col-sm-6"]/div[2]/div'
         no_of_available_role = Text('//span[@class="pf-c-options-menu__toggle-text"]//b[2]')
+        resources = MultiSelectNoFilter(id='ansible_roles')
         submit = Text('//input[@name="commit"]')

--- a/airgun/widgets.py
+++ b/airgun/widgets.py
@@ -501,6 +501,46 @@ class MultiSelect(GenericLocatorWidget):
         self.remove_all_button.click()
 
 
+class MultiSelectNoFilter(MultiSelect):
+    """This widget facilitates the movement of items between the unassigned and assigned lists. After providing values,
+    they will be stored in a list. Unassigned items contains the list which compare with the values,
+    if value is present it will assign the value or vise-versa."""
+
+    more_item = Text('//span[@class="pf-c-options-menu__toggle-button-icon"]')
+    select_pages = Text('//ul[@class="pf-c-options-menu__menu"]/li[6]/button')
+    available_role_template = '//div[@class="available-roles-container col-sm-6"]/div[2]/div'
+    assigned_role_template = '//div[@class="assigned-roles-container col-sm-6"]/div[2]/div'
+
+    def fill(self, values):
+        """This method facilitates assigning value(s) both during creation and after creation.
+        Compare this value list with the actual list of items present in the UI.
+        If the lists match, assign the items.
+        """
+        self.more_item.click()
+        self.select_pages.click()
+        available_list = self.browser.elements(self.available_role_template)
+        for data in available_list[1:]:
+            if data.text.split(". ")[1] in values:
+                data.click()
+        return True
+
+    def unassigned_values(self, values):
+        """This method facilitates the removal of items from the assigned list, effectively unassigned them."""
+        assigned_list = self.browser.elements(self.assigned_role_template)
+        for data in assigned_list:
+            if data.text.split(". ")[1] in values.values():
+                data.click()
+        return True
+
+    def read_assigned_values(self, values):
+        """Returns a list of assigned value(s)."""
+        assigned_list = self.browser.elements(self.assigned_role_template)
+        value = [
+            data.text.split(". ")[1] for data in assigned_list if data.text.split(". ")[1] in values
+        ]
+        return value
+
+
 class PF4MultiSelect(GenericLocatorWidget):
     """Typical two-pane multiselect widget. Allows to move items from
     list of ``unassigned`` entities to list of ``assigned`` ones and vice


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/airgun/pull/1424

Add and remove functionality for ansible roles in hostgroup
:steps:
1. Import all roles available by default.
2. Assign ansible role while create a hostgroup
3. Assign ansible role after create a hostgroup
4. Remove previously added ansible roles from the hostgroup

:expectedresults: The Ansible Role is successfully add and remove to the hostgroup.

Dependent PR: https://github.com/SatelliteQE/robottelo/pull/14672