### PR TITLE
Manifest expiration date appearance of header and message

### DIFF
--- a/airgun/entities/subscription.py
+++ b/airgun/entities/subscription.py
@@ -140,12 +140,10 @@ class SubscriptionEntity(BaseEntity):
         return manifest_expiration_date
 
     def is_subscription_manifest_header_message_display(self):
-        """Is header & message present in manage manifest modal box or not"""
-        result = False
+        """Checks header and massage present in the manage manifest modal"""
         view = self.navigate_to(self, 'Manage Manifest')
         view.wait_animation_end()
-        if view.manifest.alert_message.is_displayed:
-            result = True
+        result = view.manifest.alert_message.is_displayed
         # close opened modal dialogs views
         manage_view = ManageManifestView(self.browser)
         if manage_view.is_displayed:

--- a/airgun/entities/subscription.py
+++ b/airgun/entities/subscription.py
@@ -139,6 +139,19 @@ class SubscriptionEntity(BaseEntity):
             manage_view.close_button.click()
         return manifest_expiration_date
 
+    def is_subscription_manifest_header_message_display(self):
+        """Is header & message present in manage manifest modal box or not"""
+        result = False
+        view = self.navigate_to(self, 'Manage Manifest')
+        view.wait_animation_end()
+        if view.manifest.alert_message.is_displayed:
+            result = True
+        # close opened modal dialogs views
+        manage_view = ManageManifestView(self.browser)
+        if manage_view.is_displayed:
+            manage_view.close_button.click()
+        return result
+
     def add(self, entity_name, quantity=1):
         """Attach new subscriptions
         :param entity_name: Name of subscription to attach


### PR DESCRIPTION
### Problem 
- Considering newly implemented 6.16.0 feature/RFE "Notification when manifest is going to expire" and reported bug "Manifest expiration date (year) shows older for all manifest" it is neccessary to check manifest expiration message is disappearing when manifest upload very first time into organization.
- It was left behind because related https://github.com/SatelliteQE/airgun/pull/1385 merged very early phase of testing.
- During phoenix qe team discussion, we have decided to open new robottelo PR and airgun PR to validate manifest expiration header message functionality before updating settings value (expire_soon_days)
### Solution
Implemented function will return True or False base on availability of header message on manage manifest modal box.
### Related PR
Robottelo https://github.com/SatelliteQE/robottelo/pull/15500