### PR TITLE
Fix race condition in PF4 progressbar

### DIFF
--- a/airgun/widgets.py
+++ b/airgun/widgets.py
@@ -2233,6 +2233,14 @@ class ProgressBar(GenericLocatorWidget):
 class PF4ProgressBar(PF4Progress):
     locator = './/div[contains(@class, "pf-c-wizard__main-body")]'
 
+    @property
+    def is_completed(self):
+        """Boolean value whether progress bar is finished or not"""
+        try:
+            return self.current_progress == '100'
+        except NoSuchElementException:
+            return False
+
     def wait_for_result(self, timeout=600, delay=1):
         """Waits for progress bar to finish. By default checks whether progress
         bar is completed every second for 10 minutes.
@@ -2241,7 +2249,7 @@ class PF4ProgressBar(PF4Progress):
         """
         wait_for(lambda: self.is_displayed, timeout=30, delay=delay, logger=self.logger)
         wait_for(
-            lambda: not self.is_displayed or self.current_progress == '100',
+            lambda: not self.is_displayed or self.is_completed,
             timeout=timeout,
             delay=delay,
             logger=self.logger,


### PR DESCRIPTION
when the progress bar disappears between the
is_displayed query and the current_progress query
a NoSuchElement exception is raised