### PR TITLE
module stream xpaths updates

### DIFF
--- a/airgun/views/modulestream.py
+++ b/airgun/views/modulestream.py
@@ -13,7 +13,7 @@ from airgun.widgets import SatTableWithUnevenStructure
 class ModuleStreamView(BaseLoggedInView, SearchableViewMixinPF4):
     """Main Module_Streams view"""
 
-    title = Text("//h2[contains(., 'Module Streams')]")
+    title = Text("//h1[contains(., 'Module Streams')]")
     table = SatTable('.//table', column_widgets={'Name': Text("./a")})
 
     @property
@@ -25,7 +25,7 @@ class ModuleStreamView(BaseLoggedInView, SearchableViewMixinPF4):
 class ModuleStreamsDetailsView(BaseLoggedInView):
     breadcrumb = BreadCrumb()
 
-    title = Text("//a(., 'Module Streams')]")
+    title = Text(".//a[(@href='/module_streams/') and contains(.,'Module Streams')]")
     details_tab = Text("//a[@id='module-stream-tabs-container-tab-1']")
 
     @property


### PR DESCRIPTION
## Problem
Selenium was throwing error for xpath from `ModuleStreamView` and `ModuleStreamDetailsView` classes when webdriver trying to access header breadcrumb and module stream details tab.

## Error
> selenium.common.exceptions.NoSuchElementException: Message: Could not find an element Locator(by='xpath', locator="//h2[contains(., 'Module Streams')]"); For documentation on this error, please visit: https://www.selenium.dev/documentation/webdriver/troubleshooting/errors#no-such-element-exception

## Solution
Updated xpath will solve this error

## Related PR
Robottelo PR: https://github.com/SatelliteQE/robottelo/pull/15586