### PR TITLE
[6.15.z] Add pagination for ansible_roles in HostGroupEditView

### DIFF
--- a/airgun/views/hostgroup.py
+++ b/airgun/views/hostgroup.py
@@ -159,3 +159,4 @@ class HostGroupEditView(HostGroupCreateView):
         no_of_available_role = Text('//span[@class="pf-c-options-menu__toggle-text"]//b[2]')
         resources = MultiSelectNoFilter(id='ansible_roles')
         submit = Text('//input[@name="commit"]')
+        pagination = PF4Pagination()


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/airgun/pull/1455

Ansible test was failing due to `no widget name Pagination` error while editing the hostgroup, hence adding pagination for ansible_roles in HostGroupEditView