### PR TITLE
removed (.) which fails to navigate to host

### DIFF
--- a/airgun/views/host.py
+++ b/airgun/views/host.py
@@ -226,7 +226,7 @@ class HostsView(BaseLoggedInView, SearchableViewMixinPF4):
         column_widgets={
             0: Checkbox(locator=".//input[@class='host_select_boxes']"),
             'Name': Text(
-                ".//a[contains(@href, '/new/hosts/') and not(contains(@href, 'Insights'))]"
+                "//a[contains(@href, '/new/hosts/') and not(contains(@href, 'Insights'))]"
             ),
             'Recommendations': Text("./a"),
             'Actions': ActionsDropdown("./div[contains(@class, 'btn-group')]"),


### PR DESCRIPTION
A dot (.) was added before the locator, causing the host not to navigate on the UI page and resulting in a JavaScript error. I removed this dot (.), and now the navigation to the given host works correctly.

Dependent PR - https://github.com/SatelliteQE/robottelo/pull/15489