### PR TITLE
Update Infrastructure-Virt-who Configurations navigator name

### DIFF
--- a/airgun/entities/virtwho_configure.py
+++ b/airgun/entities/virtwho_configure.py
@@ -100,7 +100,7 @@ class ShowAllVirtwhoConfigures(NavigateStep):
 
     @retry_navigation
     def step(self, *args, **kwargs):
-        self.view.menu.select('Infrastructure', 'Virt-who configurations')
+        self.view.menu.select('Infrastructure', 'Virt-who Configurations')
 
 
 @navigator.register(VirtwhoConfigureEntity, 'New')


### PR DESCRIPTION
As navigator name has been changed from  'Virt-who configurations' to  'Virt-who Configurations'. so update it to resolve NavSelectionNotFound: ('Infrastructure', 'Virt-who configurations') not found in navigation tree issue on Satellite6.16 stream.

Test Case: PASS
```
(robottelo_vv_master) [root@dell-per740-68-vm-05 robottelo]# pytest ./tests/foreman/virtwho/ui/test_hyperv_sca.py -k test_positive_hypervisor_id_option --disable-pytest-warnings -q
.                                                                                                                                                                                                           [100%]
1 passed, 2 deselected, 7 warnings in 390.24s (0:06:30)
```