### PR TITLE
ignore all hidden columns in SatTable widget

### DIFF
--- a/airgun/widgets.py
+++ b/airgun/widgets.py
@@ -1881,6 +1881,8 @@ class SatTable(Table):
     If the table is empty, there might be only one column with an appropriate message in the table
     body, or it may have no columns or rows at all. This subclass handles both possibilities.
 
+    It also ignores all hidden columns, which some tables might contain, like the Hosts table.
+
     Example html representation::
 
         <table bst-table="table" ...>
@@ -1906,6 +1908,10 @@ class SatTable(Table):
         .//table
 
     """
+
+    HEADERS = "./thead/tr/th[not(@hidden)]|./tr/th[not(@hidden)]|./thead/tr/td[not(@hidden)]"
+    COLUMN_RESOLVER_PATH = "/td[not(@hidden)]"
+    COLUMN_AT_POSITION = "./td[not(@hidden)][{0}]"
 
     no_rows_message = (
         ".//td/span[contains(@data-block, 'no-rows-message') or "


### PR DESCRIPTION
### Problem Statement

The Hosts table HTML contains multiple duplicate columns that are hidden, like *Name, Model, Operating system*, etc.
On the eye, the rendered result looks and behaves correctly,
however these hidden columns are causing the widget `airgun.widgets.SatTable` to behave not fully correctly.

This flaw started to fully manifest by merging PR https://github.com/SatelliteQE/airgun/pull/1453
where the `SatTable` widget interacted with the hidden columns instead of the visible ones (and sometimes vice versa).


### Solution

The `SatTable` widget is modified to ignore all hidden headers and columns in the table.
