### PR TITLE
Revert removal of taxonomy from host module

### DIFF
--- a/airgun/views/host.py
+++ b/airgun/views/host.py
@@ -789,6 +789,7 @@ class HostsTaxonomyMismatchRadioGroup(GenericLocatorWidget):
         </form>
     """
 
+    taxonomy = None
     fix_mismatch = Text("//input[contains(@id, 'optimistic_import_yes')]")
     fail_on_mismatch = Text("//input[contains(@id, 'optimistic_import_no')]")
     buttons_text = {


### PR DESCRIPTION
Reverted removal of taxonomy in views.host.py. 
The issue with CI check failing because of bug in sphinx-autoapi which was fixed in v3.2.1