### PR TITLE
[6.14.z] Add support for File page in Content section of UI

### DIFF
--- a/airgun/entities/file.py
+++ b/airgun/entities/file.py
@@ -1,0 +1,51 @@
+from airgun.entities.base import BaseEntity
+from airgun.navigation import NavigateStep, navigator
+from airgun.utils import retry_navigation
+from airgun.views.file import FileDetailsView, FilesView
+
+
+class FilesEntity(BaseEntity):
+    endpoint_path = '/files'
+
+    def search(self, query):
+        view = self.navigate_to(self, 'All')
+        return view.search(query)
+
+    def read(self, entity_name, widget_names=None):
+        view = self.navigate_to(self, 'Details', entity_name=entity_name)
+        return view.read(widget_names=widget_names)
+
+    def read_cv_table(self, entity_name):
+        view = self.navigate_to(self, 'Details', entity_name=entity_name)
+        return view.content_views.cvtable.read()
+
+
+@navigator.register(FilesEntity, 'All')
+class ShowAllFiles(NavigateStep):
+    """navigate to Files Page"""
+
+    VIEW = FilesView
+
+    @retry_navigation
+    def step(self, *args, **kwargs):
+        self.view.menu.select('Content', 'Content Types', 'Files')
+
+
+@navigator.register(FilesEntity, 'Details')
+class ShowPackageDetails(NavigateStep):
+    """Navigate to File Details page by clicking on file name"""
+
+    VIEW = FileDetailsView
+
+    def prerequisite(self, *args, **kwargs):
+        return self.navigate_to(self.obj, 'All')
+
+    def step(self, *args, **kwargs):
+        entity_name = kwargs.get('entity_name')
+        self.parent.search(f'name = {entity_name}')
+        self.parent.table.row(name=entity_name)['Name'].widget.click()
+
+    def am_i_here(self, *args, **kwargs):
+        entity_name = kwargs.get('entity_name')
+        self.view.file_name = entity_name
+        return self.view.is_displayed and self.view.breadcrumb.locations[1] == entity_name

--- a/airgun/session.py
+++ b/airgun/session.py
@@ -35,6 +35,7 @@ from airgun.entities.discoveryrule import DiscoveryRuleEntity
 from airgun.entities.domain import DomainEntity
 from airgun.entities.eol_banner import EOLBannerEntity
 from airgun.entities.errata import ErrataEntity
+from airgun.entities.file import FilesEntity
 from airgun.entities.filter import FilterEntity
 from airgun.entities.hardware_model import HardwareModelEntity
 from airgun.entities.host import HostEntity
@@ -447,6 +448,11 @@ class Session:
     def filter(self):
         """Instance of Filter entity."""
         return self._open(FilterEntity)
+
+    @cached_property
+    def file(self):
+        """Instance of Files entity."""
+        return self._open(FilesEntity)
 
     @cached_property
     def hardwaremodel(self):

--- a/airgun/views/file.py
+++ b/airgun/views/file.py
@@ -1,0 +1,54 @@
+from widgetastic.widget import Text, View
+from widgetastic_patternfly import BreadCrumb
+
+from airgun.views.common import (
+    BaseLoggedInView,
+    ReadOnlyEntry,
+    SatTab,
+    SatTable,
+)
+from airgun.widgets import Search
+
+
+class FilesView(BaseLoggedInView):
+    """Main Files view"""
+
+    title = Text("//h1[contains(., 'Files')]")
+    table = SatTable('.//table', column_widgets={'Name': Text("./a"), 'Path': Text("./a")})
+
+    search_box = Search()
+
+    def search(self, query):
+        self.search_box.search(query)
+        return self.table.read()
+
+    @property
+    def is_displayed(self):
+        return self.browser.wait_for_element(self.title, exception=False) is not None
+
+
+class FileDetailsView(BaseLoggedInView):
+    breadcrumb = BreadCrumb()
+
+    @property
+    def is_displayed(self):
+        breadcrumb_loaded = self.browser.wait_for_element(self.breadcrumb, exception=False)
+
+        return breadcrumb_loaded and self.breadcrumb.locations[0] == 'Files'
+
+    @View.nested
+    class details(SatTab):
+        path = ReadOnlyEntry(name='Checksum')
+        checksum = ReadOnlyEntry(name='Path')
+
+    @View.nested
+    class content_views(SatTab):
+        TAB_NAME = 'Content Views'
+        cvtable = SatTable(
+            './/table',
+            column_widgets={
+                'Name': Text("./a"),
+                'Environment': Text("./a"),
+                'Version': Text("./a"),
+            },
+        )


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/airgun/pull/1426

Adds Views/Entities for the Content -> Content Types -> File screen. 

Supporting this robottelo PR: 