### PR TITLE
[6.16] Adjust all hosts to use menu, add support for Build Management

### DIFF
--- a/airgun/entities/all_hosts.py
+++ b/airgun/entities/all_hosts.py
@@ -6,6 +6,7 @@ from airgun.utils import retry_navigation
 from airgun.views.all_hosts import (
     AllHostsManageColumnsView,
     AllHostsTableView,
+    BuildManagementDialog,
     BulkHostDeleteDialog,
     HostDeleteDialog,
 )
@@ -61,6 +62,23 @@ class AllHostsEntity(BaseEntity):
         self.browser.plugin.ensure_page_safe(timeout='5s')
         view.wait_displayed()
         return view.no_results
+
+    def build_management(self, reboot=False, rebuild=False):
+        """Build or rebuild hosts through build management popup"""
+        view = self.navigate_to(self, 'All')
+        self.browser.plugin.ensure_page_safe(timeout='5s')
+        view.wait_displayed()
+        view.select_all.fill(True)
+        view.bulk_actions.item_select('Build management')
+        build_management_modal = BuildManagementDialog(self.browser)
+        if build_management_modal.is_displayed:
+            if reboot:
+                build_management_modal.reboot_now.fill(True)
+            if rebuild:
+                build_management_modal.rebuild_provisioning_only.fill(True)
+            build_management_modal.confirm.click()
+        self.browser.wait_for_element(view.alert_message, exception=False)
+        return view.alert_message.read()
 
     def manage_table_columns(self, values: dict):
         """

--- a/airgun/views/all_hosts.py
+++ b/airgun/views/all_hosts.py
@@ -1,5 +1,5 @@
 from widgetastic.widget import Checkbox, Text, View
-from widgetastic_patternfly4 import Button, Dropdown
+from widgetastic_patternfly4 import Button, Dropdown, Menu, Radio
 from widgetastic_patternfly4.ouia import (
     PatternflyTable,
 )
@@ -11,12 +11,18 @@ from airgun.views.common import (
 from airgun.views.host_new import ManageColumnsView, PF4CheckboxTreeView
 
 
+class AllHostsMenu(Menu):
+    IS_ALWAYS_OPEN = False
+    BUTTON_LOCATOR = ".//button[contains(@class, 'pf-c-menu-toggle')]"
+    ROOT = f"{BUTTON_LOCATOR}/.."
+
+
 class AllHostsTableView(BaseLoggedInView, SearchableViewMixinPF4):
     title = Text("//h1[normalize-space(.)='Hosts']")
     select_all = Checkbox(
         locator='.//input[@data-ouia-component-id="select-all-checkbox-dropdown-toggle-checkbox"]'
     )
-    bulk_actions = Dropdown(locator='.//div[@data-ouia-component-id="action-buttons-dropdown"]')
+    bulk_actions = AllHostsMenu()
     table_loading = Text("//h5[normalize-space(.)='Loading']")
     no_results = Text("//h5[normalize-space(.)='No Results']")
     manage_columns = Button("Manage columns")
@@ -28,6 +34,7 @@ class AllHostsTableView(BaseLoggedInView, SearchableViewMixinPF4):
             2: Dropdown(locator='.//div[contains(@class, "pf-c-dropdown")]'),
         },
     )
+    alert_message = Text('.//div[@aria-label="Success Alert" or @aria-label="Danger Alert"]')
 
     @property
     def is_displayed(self):
@@ -46,6 +53,27 @@ class HostDeleteDialog(View):
 
     confirm_delete = Button(locator='//button[normalize-space(.)="Delete"]')
     cancel_delete = Button(locator='//button[normalize-space(.)="Cancel"]')
+
+    @property
+    def is_displayed(self):
+        return self.browser.wait_for_element(self.title, exception=False) is not None
+
+
+class BuildManagementDialog(View):
+    """Dialog for Build Management"""
+
+    ROOT = './/div[@data-ouia-component-id="bulk-build-hosts-modal"]'
+
+    title = Text(".//h1[normalize-space(.)='Build management']")
+
+    build = Radio(locator='.//input[@data-ouia-component-id="build-host-radio"]')
+    reboot_now = Checkbox(locator='.//input[@data-ouia-component-id="build-reboot-checkbox"]')
+    rebuild_provisioning_only = Checkbox(
+        locator='.//input[@data-ouia-component-id="rebuild-host-radio"]'
+    )
+
+    confirm = Button(locator='//button[normalize-space(.)="Confirm"]')
+    cancel = Button(locator='//button[normalize-space(.)="Cancel"]')
 
     @property
     def is_displayed(self):


### PR DESCRIPTION
Adds support for Build Management in All Hosts page, as well as updates the dropdown to a Menu, matching recent changes from the dev side.

Note: Not all of these changes appear to have made it into stream, so there will likely need to be more work with this component. 