### PR TITLE
Fix Job Template widget

### DIFF
--- a/airgun/entities/job_invocation.py
+++ b/airgun/entities/job_invocation.py
@@ -20,6 +20,10 @@ class JobInvocationEntity(BaseEntity):
     def run(self, values):
         """Run specific job"""
         view = self.navigate_to(self, 'Run')
+        # This is a temporary workaround because of SAT-27090
+        view.category_and_template.job_category.fill(values['category_and_template.job_category'])
+        values.pop('category_and_template.job_category')
+        view.category_and_template.job_template.click()
         view.fill(values)
         view.submit.expander.click()
         self.browser.wait_for_element(view.submit.submit, exception=False)

--- a/airgun/views/job_invocation.py
+++ b/airgun/views/job_invocation.py
@@ -30,8 +30,8 @@ class JobInvocationCreateView(BaseLoggedInView):
     @View.nested
     class category_and_template(WizardStepView):
         expander = Text(".//button[contains(.,'Category and template')]")
-        job_category = Select(locator='//div[*[@aria-label="Job category toggle"]]')
-        job_template = Select(locator='//div[div/*[@aria-label="Job template toggle"]]')
+        job_category = OUIASelect('job_category')
+        job_template = OUIASelect('job_template')
 
     @View.nested
     class target_hosts_and_inputs(WizardStepView):
@@ -71,6 +71,7 @@ class JobInvocationCreateView(BaseLoggedInView):
         time_span = TextInput(id='time-span')
         execution_order_alphabetical = Radio(id='execution-order-alphabetical')
         execution_order_randomized = Radio(id='execution-order-randomized')
+        ansible_collections_path = TextInput(id='collections_path')
 
     @View.nested
     class schedule(WizardStepView):


### PR DESCRIPTION
The job template widget on Monitor -> Jobs -> Run Job is Select type widget and has unnecessary input field to it. This makes selecting a value from Dropdown difficult. For temporary workaround, I have added a fix for it.
Bug: SAT-27090