### PR TITLE
[6.13.z] [pre-commit.ci] pre-commit autoupdate

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,11 +5,11 @@ ci:
 
 repos:
 - repo: https://github.com/psf/black
-  rev: 24.4.2
+  rev: 24.8.0
   hooks:
   - id: black
 - repo: https://github.com/astral-sh/ruff-pre-commit
-  rev: v0.4.9
+  rev: v0.5.7
   hooks:
     - id: ruff
       args: [--fix, --exit-non-zero-on-fix]


### PR DESCRIPTION
updates:
- [github.com/psf/black: 24.4.2 → 24.8.0](https://github.com/psf/black/compare/24.4.2...24.8.0)
- [github.com/astral-sh/ruff-pre-commit: v0.4.9 → v0.5.7](https://github.com/astral-sh/ruff-pre-commit/compare/v0.4.9...v0.5.7)

(cherry picked from commit 22a0ed6491fd8c34197422c76470193de0e0405a)