### PR TITLE
[6.14.z] Locator updated in is_supported() method...

### DIFF
--- a/airgun/entities/provisioning_template.py
+++ b/airgun/entities/provisioning_template.py
@@ -75,7 +75,7 @@ class ProvisioningTemplateEntity(BaseEntity):
         try:
             return "Supported by Red Hat" in view.table.row(name=entity_name)[
                 'Name'
-            ].widget.browser.element('./img').get_attribute('title')
+            ].widget.browser.element('./parent::td/img').get_attribute('title')
         except NoSuchElementException:
             return False
 


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/airgun/pull/1499

- I have updated the locator in the provisioning_template, and the PR is https://github.com/SatelliteQE/airgun/pull/1494/files. 

- Due to these changes, one of the test cases encountered issues with the assertion. To resolve this, I updated the locator in the is_supported() method, which is part of the Airgun entity. The assertion is now working correctly, addressing the failure that occurred as a result of my changes.

