### PR TITLE
[master]: Changes for 6.16.z new branch

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,6 +11,7 @@ updates:
       interval: "daily"
     labels:
       - '6.16.z'
+      - '6.16.z'
       - "CherryPick"
       - "dependencies"
       - "6.15.z"
@@ -23,6 +24,7 @@ updates:
     schedule:
       interval: "daily"
     labels:
+      - '6.16.z'
       - '6.16.z'
       - "CherryPick"
       - "dependencies"


### PR DESCRIPTION

  ### Problem Statement
  New 6.16.z downstream and master points to stream that is 6.17
  ### Solution
  - Dependabot.yaml cherrypicks to 6.16.z
