### PR TITLE
[6.16.z] [6.16]Add support for CVE modal and PF4 version of LCE Selector

### DIFF
--- a/airgun/entities/all_hosts.py
+++ b/airgun/entities/all_hosts.py
@@ -9,6 +9,7 @@ from airgun.views.all_hosts import (
     BuildManagementDialog,
     BulkHostDeleteDialog,
     HostDeleteDialog,
+    ManageCVEModal,
     ManagePackagesModal,
 )
 from airgun.views.job_invocation import JobInvocationCreateView
@@ -81,6 +82,24 @@ class AllHostsEntity(BaseEntity):
             build_management_modal.confirm.click()
         self.browser.wait_for_element(view.alert_message, exception=False)
         return view.alert_message.read()
+
+    def manage_cve(self, lce=None, cv=None):
+        """Bulk reassign Content View Environments through the All Hosts page
+        args:
+            lce (str): Lifecycle Environment to swap the hosts to.
+            cv (str): CV within that LCE to assign the hosts to.
+        """
+        view = self.navigate_to(self, 'All')
+        self.browser.plugin.ensure_page_safe(timeout='5s')
+        view.wait_displayed()
+        view.select_all.fill(True)
+        view.bulk_actions_kebab.click()
+        self.browser.move_to_element(view.bulk_actions_menu.item_element('Manage content'))
+        view.bulk_actions.item_select('Content view environments')
+        view = ManageCVEModal(self.browser)
+        view.lce_selector.fill({lce: True})
+        view.content_source_select.item_select(cv)
+        view.save_btn.click()
 
     def manage_table_columns(self, values: dict):
         """

--- a/airgun/views/all_hosts.py
+++ b/airgun/views/all_hosts.py
@@ -1,5 +1,13 @@
-from widgetastic.widget import Checkbox, Text, View
-from widgetastic_patternfly4 import Button, Dropdown, Menu, Modal, Pagination, Radio
+from widgetastic.widget import Checkbox, ParametrizedView, Text, View
+from widgetastic_patternfly4 import (
+    Button,
+    Dropdown,
+    Menu,
+    Modal,
+    Pagination,
+    Radio,
+    Select,
+)
 from widgetastic_patternfly4.ouia import (
     Alert as OUIAAlert,
     PatternflyTable,
@@ -7,6 +15,7 @@ from widgetastic_patternfly4.ouia import (
 
 from airgun.views.common import (
     BaseLoggedInView,
+    PF4LCESelectorGroup,
     SearchableViewMixinPF4,
     WizardStepView,
 )
@@ -18,6 +27,19 @@ class AllHostsMenu(Menu):
     IS_ALWAYS_OPEN = False
     BUTTON_LOCATOR = ".//button[contains(@class, 'pf-c-menu-toggle')]"
     ROOT = f"{BUTTON_LOCATOR}/.."
+
+
+class AllHostsSelect(Select):
+    BUTTON_LOCATOR = ".//button[@aria-label='Options menu']"
+    ITEMS_LOCATOR = ".//ul[contains(@class, 'pf-c-select__menu')]/li"
+    ITEM_LOCATOR = (
+        "//*[contains(@class, 'pf-c-select__menu-item') and .//*[contains(normalize-space(.), {})]]"
+    )
+    SELECTED_ITEM_LOCATOR = ".//span[contains(@class, 'ins-c-conditional-filter')]"
+    TEXT_LOCATOR = ".//div[contains(@class, 'pf-c-select') and child::button]"
+    DEFAULT_LOCATOR = (
+        './/div[contains(@class, "pf-c-select") and @data-ouia-component-id="select-content-view"]'
+    )
 
 
 class AllHostsTableView(BaseLoggedInView, SearchableViewMixinPF4):
@@ -128,6 +150,24 @@ class AllHostsManageColumnsView(ManageColumnsView):
         Overwritten to ignore the "Expand tree" functionality
         """
         self.checkbox_group.fill(values)
+
+
+class ManageCVEModal(Modal):
+    """
+    This class represents the Manage Content View Environments modal that is used to update the CVE of hosts.
+    """
+
+    ROOT = './/div[@data-ouia-component-id="bulk-change-host-cv-modal"]'
+
+    title = Text("//span[normalize-space(.)='Edit content view environments']")
+    save_btn = Button(locator='//button[normalize-space(.)="Save"]')
+    cancel_btn = Button(locator='//button[normalize-space(.)="Cancel"]')
+    content_source_select = AllHostsSelect()
+    lce_selector = ParametrizedView.nested(PF4LCESelectorGroup)
+
+    @property
+    def is_displayed(self):
+        return self.browser.wait_for_element(self.title, exception=False) is not None
 
 
 class ManagePackagesModal(Modal):

--- a/airgun/views/common.py
+++ b/airgun/views/common.py
@@ -25,6 +25,7 @@ from airgun.widgets import (
     ItemsList,
     LCESelector,
     Pf4ConfirmationDialog,
+    PF4LCESelector,
     PF4NavSearch,
     PF4Search,
     ProgressBar,
@@ -262,6 +263,19 @@ class LCESelectorGroup(ParametrizedView):
 
         """
         return self.lce.read()
+
+
+class PF4LCESelectorGroup(LCESelectorGroup):
+    ROOT = './/div[./div[@class="env-path"]]'
+
+    PARAMETERS = ('lce_name',)
+
+    LAST_ENV = './/div[@class="env-path"][last()]'
+    lce = PF4LCESelector(
+        locator=ParametrizedLocator(
+            './/div[@class="env-path" and .//*[contains(normalize-space(.), "{lce_name}")]]'
+        )
+    )
 
 
 class ListRemoveTab(SatSecondaryTab):

--- a/airgun/widgets.py
+++ b/airgun/widgets.py
@@ -26,7 +26,10 @@ from widgetastic_patternfly import (
     Kebab,
     VerticalNavigation,
 )
-from widgetastic_patternfly4 import Button as PF4Button, Pagination as PF4Pagination
+from widgetastic_patternfly4 import (
+    Button as PF4Button,
+    Pagination as PF4Pagination,
+)
 from widgetastic_patternfly4.ouia import (
     BaseSelect,
     Button as OUIAButton,
@@ -1481,6 +1484,30 @@ class LCESelector(GenericLocatorWidget):
         checkbox_value = value[checkbox_name]
         checkbox_locator = self.CHECKBOX.format(checkbox_name)
         return self.select(checkbox_locator, checkbox_value)
+
+
+class PF4LCESelector(LCESelector):
+    """Group of checkboxes that goes in a line one after another. Usually used
+    to specify lifecycle environment, updated for PF4 pages
+    """
+
+    LABELS = './/label[contains(@class, "pf-c-radio__label")]'
+    CHECKBOX = (
+        './/input[contains(@class, "pf-c-radio__input") and ../label[.//*[contains(text(), "{}")]]]'
+    )
+
+    def __init__(self, parent, locator=None, logger=None):
+        """Allow to specify ``locator`` if needed or use default one otherwise.
+        Locator is needed when multiple :class:`LCESelector` are present,
+        typically as a part of :class:`airgun.views.common.LCESelectorGroup`.
+        """
+        if locator is None:
+            locator = './/div[contains(@class, "env-path")]'
+        super().__init__(parent, locator, logger=logger)
+
+    def checkbox_selected(self, locator):
+        """Identify whether specific checkbox is selected or not"""
+        return self.browser.is_selected(locator)
 
 
 class LimitInput(Widget):


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/airgun/pull/1514

Adds support for the Bulk CVE Assignment action on the All Hosts page, as well as implements a PF4 version of the Lifecycle Environment and Bulk LCE selector widgets. Should be 100% usable on any React page going forward with that functionality. 

Supports: https://github.com/SatelliteQE/robottelo/pull/15976