### PR TITLE
[6.13z cp] Table locator updated to get value from "Provisioning Templates" table

### DIFF
--- a/airgun/views/provisioning_template.py
+++ b/airgun/views/provisioning_template.py
@@ -31,7 +31,7 @@ class ProvisioningTemplatesView(BaseLoggedInView, SearchableViewMixinPF4):
     table = Table(
         './/table',
         column_widgets={
-            'Name': Text('.'),
+            'Name': Text('.//a'),
             'Locked': Text('.'),
             'Actions': ActionsDropdown("./div[contains(@class, 'btn-group')]"),
         },


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/airgun/pull/1494

This small fix ensures that the table and its values are correctly located and function as expected. Previously, the locator was not properly configured, resulting in only the table being fetched without retrieving its values.