### PR TITLE
[6.15.z] fixed in method for discovery rule and updated it's entities

### DIFF
--- a/airgun/entities/discoveryrule.py
+++ b/airgun/entities/discoveryrule.py
@@ -50,13 +50,17 @@ class DiscoveryRuleEntity(BaseEntity):
         return view.read(widget_names=widget_names)
 
     def read_all(self):
-        """Reads the whole discovery rules table.
+        """Reads the entire discovery rules page
 
-        :return: list of table rows, each row is dict,
-            attribute as key with correct value
+        :return:
+            1) list of table rows, each row is dict, attribute as key with correct value
+            2) After deleting the rule, the page context is displayed
         """
         view = self.navigate_to(self, 'All')
-        return view.table.read()
+        if view.table.is_displayed:
+            return view.table.read()
+        elif view.page_info.is_displayed:
+            return view.page_info.read()
 
     def update(self, entity_name, values):
         """Update existing Discovery rule

--- a/airgun/views/discoveryrule.py
+++ b/airgun/views/discoveryrule.py
@@ -1,4 +1,4 @@
-from widgetastic.widget import Checkbox, Text, TextInput, View
+from widgetastic.widget import Checkbox, Table, Text, TextInput, View
 from widgetastic_patternfly import BreadCrumb
 from widgetastic_patternfly4 import Button as PF4Button
 
@@ -8,18 +8,18 @@ from airgun.widgets import (
     AutoCompleteTextInput,
     FilteredDropdown,
     MultiSelect,
-    SatTable,
 )
 
 
 class DiscoveryRulesView(BaseLoggedInView, SearchableViewMixinPF4):
     title = Text("//h1[normalize-space(.)='Discovery Rules']")
+    page_info = Text("//foreman-react-component[contains(@name, 'DiscoveryRules')]/div/div")
     new = Text("//a[contains(@href, '/discovery_rules/new')]")
     new_on_blank_page = PF4Button('Create Rule')
-    table = SatTable(
+    table = Table(
         './/table',
         column_widgets={
-            'Name': Text('./a'),
+            'Name': Text('.//a'),
             'Actions': ActionsDropdown("./div[contains(@class, 'btn-group')]"),
         },
     )


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/airgun/pull/1480

- Updated the views with Table() widget instead SatTable(), to read all the table values.

- Added entities to read the page after deleting discovery rules table.


Dependent PR: https://github.com/SatelliteQE/robottelo/pull/15783