### PR TITLE
validations with warnings too

### DIFF
--- a/airgun/views/sync_templates.py
+++ b/airgun/views/sync_templates.py
@@ -17,7 +17,7 @@ class SyncTemplatesView(BaseLoggedInView):
     breadcrumb = BreadCrumb()
     title = Text("//h2[contains(., 'Import or Export Templates')]")
     sync_type = RadioGroup("//div[label[contains(., 'Action type')]]")
-    submit = Text("//button[@type='submit']")
+    submit = Text(".//button[contains(.,'Submit')]")
 
     template = ConditionalSwitchableView(reference='sync_type')
 

--- a/airgun/widgets.py
+++ b/airgun/widgets.py
@@ -1049,7 +1049,8 @@ class ValidationErrors(Widget):
 
     ERROR_ELEMENTS = ".//*[contains(@class,'has-error') and not(contains(@style,'display:none'))]"
     ERROR_MESSAGES = (
-        ".//*[(contains(@class, 'alert base in fade alert-danger')"
+        ".//*[(contains(@class, 'alert base in fade alert-danger') "
+        "or contains(@class, 'alert base in fade alert-warning') "
         "or contains(@class,'error-msg') "
         "or contains(@class,'error-msg-block')"
         "or contains(@class,'error-message') "


### PR DESCRIPTION
fixing submit button definition for templates, also adding warning alert to the list of registered validations. The test failed for non-airgun related reason, but airgun did not stop on validation as UI shows only a warning-level box, so the test timed out without a meaningful message. 