### PR TITLE
[6.14.z] adding ansible role as per given input...

### DIFF
--- a/airgun/entities/host_new.py
+++ b/airgun/entities/host_new.py
@@ -442,7 +442,7 @@ class NewHostEntity(HostEntity):
         view.flash.assert_no_error()
         view.flash.dismiss()
 
-    def add_single_ansible_role(self, entity_name):
+    def add_single_ansible_role(self, entity_name, role=None):
         view = self.navigate_to(self, 'NewDetails', entity_name=entity_name)
         view.wait_displayed()
         self.browser.plugin.ensure_page_safe()
@@ -450,10 +450,8 @@ class NewHostEntity(HostEntity):
         view.ansible.roles.edit.click()
         wait_for(lambda: EditAnsibleRolesView(self.browser).addAnsibleRole.is_displayed, timeout=10)
         edit_view = EditAnsibleRolesView(self.browser)
-        actions = [edit_view.addAnsibleRole, edit_view.selectRoles, edit_view.confirm]
-        for action in actions:
-            wait_for(lambda: edit_view.is_displayed, timeout=5)
-            action.click()
+        edit_view.addAnsibleRole.select_and_move([role])
+        edit_view.confirm.click()
 
     def get_ansible_roles(self, entity_name):
         view = self.navigate_to(self, 'NewDetails', entity_name=entity_name)

--- a/airgun/views/host_new.py
+++ b/airgun/views/host_new.py
@@ -5,6 +5,7 @@ from widgetastic.widget.table import Table
 from widgetastic_patternfly4 import (
     Button,
     Dropdown,
+    DualListSelector,
     Pagination as PF4Pagination,
     Select,
     Tab,
@@ -796,9 +797,7 @@ class ManageHostStatusesView(View):
 class EditAnsibleRolesView(View):
     """Edit Ansible Roles Modal"""
 
-    addAnsibleRole = Text(
-        './/span[contains(text(),"RedHatInsights.insights-client") or contains(text(),"theforeman.foreman_scap_client")]'
-    )
+    addAnsibleRole = DualListSelector('//div[@class = "pf-c-dual-list-selector"]')
     confirm = Button(locator='.//button[@aria-label="submit ansible roles"]')
     hostAssignedAnsibleRoles = Text(
         './/button[@class="pf-c-dual-list-selector__item"]/span[1]//span[2]'


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/airgun/pull/1542

- I've updated the code. Previously, the role selection was hardcoded based on the locator, but now the code dynamically selects a single Ansible role based on user input.

- This update has been applied wherever the 'add_single_ansible_role' method is used in the test case.

Dependent PR: https://github.com/SatelliteQE/robottelo/pull/16054