### PR TITLE
[6.14z CP] Check dynflow console output for host

### DIFF
--- a/airgun/entities/job_invocation.py
+++ b/airgun/entities/job_invocation.py
@@ -7,11 +7,13 @@ from wait_for import wait_for
 from airgun.entities.base import BaseEntity
 from airgun.navigation import NavigateStep, navigator
 from airgun.utils import retry_navigation
+from airgun.views.dynflowconsole import DynflowConsoleView
 from airgun.views.job_invocation import (
     JobInvocationCreateView,
     JobInvocationStatusView,
     JobInvocationsView,
 )
+from airgun.views.task import TaskDetailsView
 
 
 class JobInvocationEntity(BaseEntity):
@@ -70,6 +72,22 @@ class JobInvocationEntity(BaseEntity):
         view = JobInvocationCreateView(self.browser)
         time.sleep(3)
         return view.target_hosts_and_inputs.read()
+
+    def read_dynflow_output(self, entity_name, host_name):
+        """Read dynflow console output"""
+        view = self.navigate_to(self, 'Job Status', entity_name=entity_name, host_name=host_name)
+        wait_for(lambda: view.overview.hosts_table.is_displayed, timeout=10)
+        view.overview.hosts_table.row(host=host_name)['Actions'].widget.fill('Host task')
+        view = TaskDetailsView(self.browser)
+        wait_for(lambda: view.task.dynflow_console.is_displayed, timeout=10)
+        view.task.dynflow_console.click()
+        self.browser.switch_to_window(self.browser.window_handles[1])
+        console = DynflowConsoleView(self.browser)
+        wait_for(lambda: console.is_displayed, timeout=100)
+        result = console.output.read()
+        self.browser.switch_to_window(self.browser.window_handles[0])
+        self.browser.close_window(self.browser.window_handles[1])
+        return result
 
 
 @navigator.register(JobInvocationEntity, 'All')

--- a/airgun/views/dynflowconsole.py
+++ b/airgun/views/dynflowconsole.py
@@ -1,0 +1,15 @@
+from widgetastic.widget import Text
+from widgetastic_patternfly4 import Pagination as PF4Pagination
+
+from airgun.views.common import BaseLoggedInView
+
+
+class DynflowConsoleView(BaseLoggedInView):
+    title = Text("//a[@class='navbar-brand']//img")
+    output = Text("//div[@class='action']/pre[2]")
+
+    pagination = PF4Pagination()
+
+    @property
+    def is_displayed(self):
+        return self.browser.wait_for_element(self.title, exception=False) is not None

--- a/airgun/views/job_invocation.py
+++ b/airgun/views/job_invocation.py
@@ -165,7 +165,7 @@ class JobInvocationStatusView(BaseLoggedInView):
             './/table',
             column_widgets={
                 'Host': Text('./a'),
-                'Actions': ActionsDropdown("./div[contains(@class, 'btn-group')]"),
+                'Actions': ActionsDropdown('.//div[contains(@class, "btn-group")]'),
             },
         )
         total_hosts = Text(

--- a/airgun/views/task.py
+++ b/airgun/views/task.py
@@ -1,6 +1,6 @@
 from wait_for import wait_for
 from widgetastic.widget import Table, Text, View
-from widgetastic_patternfly import BreadCrumb
+from widgetastic_patternfly import BreadCrumb, Button
 from widgetastic_patternfly4 import Pagination as PF4Pagination
 
 from airgun.views.common import BaseLoggedInView, SatTab, SearchableViewMixinPF4
@@ -97,6 +97,7 @@ class TaskDetailsView(BaseLoggedInView):
         progressbar = ProgressBar(locator='//div[contains(@class,"progress-bar")]')
         output = TaskReadOnlyEntry(name='Output')
         errors = TaskReadOnlyEntryError(name='Errors')
+        dynflow_console = Button('Dynflow console')
 
     def wait_for_result(self, timeout=60, delay=1):
         """Wait for invocation job to finish"""


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/airgun/pull/1522

When enabling debug mode on Satellite, the task is generating an output log for all hosts present on the Job.

The host execution log is showing the debug log for all hosts present on the inventory instead of just the expected host.

Solution : -

Below automation check the host execution log should show the debug log for expected host instead of the all host present in the inventory.

Dependent PR: https://github.com/SatelliteQE/robottelo/pull/16529

Fixes: https://github.com/SatelliteQE/airgun/issues/1573