### PR TITLE
[6.15.z] Bump pascalgn/automerge-action from 0.16.3 to 0.16.4 (#1575)

### DIFF
--- a/.github/workflows/auto_cherry_pick_merge.yaml
+++ b/.github/workflows/auto_cherry_pick_merge.yaml
@@ -67,7 +67,7 @@ jobs:
 
       - id: automerge
         name: Auto merge of cherry-picked PRs.
-        uses: "pascalgn/automerge-action@v0.16.3"
+        uses: "pascalgn/automerge-action@v0.16.4"
         env:
           GITHUB_TOKEN: "${{ secrets.CHERRYPICK_PAT }}"
           MERGE_LABELS: "AutoMerge_Cherry_Picked, Auto_Cherry_Picked"


### PR DESCRIPTION
This PR backport changes from #1575