### PR TITLE
[6.16.z] Add entity that reads filled searchbox on new and old hosts pages

### DIFF
--- a/airgun/entities/all_hosts.py
+++ b/airgun/entities/all_hosts.py
@@ -29,6 +29,13 @@ class AllHostsEntity(BaseEntity):
         view.wait_displayed()
         return view.search(host_name)
 
+    def read_filled_searchbox(self):
+        """Read filled searchbox"""
+        view = self.navigate_to(self, 'All')
+        self.browser.plugin.ensure_page_safe(timeout='5s')
+        view.wait_displayed()
+        return view.searchbox.read()
+
     def read_table(self):
         """Read All Hosts table"""
         view = self.navigate_to(self, 'All')

--- a/airgun/entities/host.py
+++ b/airgun/entities/host.py
@@ -84,6 +84,13 @@ class HostEntity(BaseEntity):
         view = self.navigate_to(self, 'All')
         return view.search(value)
 
+    def read_filled_searchbox(self):
+        """Read filled searchbox"""
+        view = self.navigate_to(self, 'All')
+        self.browser.plugin.ensure_page_safe(timeout='5s')
+        view.wait_displayed()
+        return view.searchbox.read()
+
     def new_ui_button(self):
         """Click New UI button and return the browser URL"""
         view = self.navigate_to(self, 'All')


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/airgun/pull/1589

Add an entity `read_filled_searchbox` to the `host.py` (old hosts UI) and `all_hosts.py` (new hosts UI) so that it can be used in the automation.

Usage:

- Old UI

```python
with target_sat.ui_session() as session:
    session.host.search('some_search_string')
    read_searchbox_value = session.host.read_filled_searchbox()
    print(read_searchbox_value)
```

- New UI

```python
with target_sat.ui_session() as session:
    session.all_hosts.search('some_search_string')
    read_searchbox_value = session.all_hosts.read_filled_searchbox()
    print(read_searchbox_value)
```
