### PR TITLE
Add new Refresh button in capsule content

### DIFF
--- a/airgun/entities/capsule.py
+++ b/airgun/entities/capsule.py
@@ -281,12 +281,14 @@ class CapsuleEntity(BaseEntity):
 
         self.sync(capsule_name, 'Complete Sync')
 
-    def refresh_lce_counts(self, capsule_name, lce_name):
+    def refresh_lce_counts(self, capsule_name, lce_name, cv_name=None):
         """
-        Function that refreshes LCE counts of given capsule
+        Function that refreshes the content counts of given capsule
 
         Args:
             capsule_name (str): Name of capsule to be refreshed
+            lce_name (str): Name of LCE to be refreshed
+            cv_name (str, optional): Name of CV within LCE to be refreshed only
         """
 
         view = self.navigate_to(self, 'Capsules')
@@ -294,9 +296,15 @@ class CapsuleEntity(BaseEntity):
         view.table.row(name=capsule_name)['Name'].click()
         view = CapsuleDetailsView(self.browser)
         view.wait_displayed()
-        view.content.top_content_table.row(Environment=lce_name)[3].widget.item_select(
-            'Refresh counts'
-        )
+        if not cv_name:
+            view.content.top_content_table.row(Environment=lce_name)[3].widget.item_select(
+                'Refresh counts'
+            )
+        else:
+            view.content.top_content_table.row(Environment=lce_name)[0].click()
+            view.content.mid_content_table.row(content_view=cv_name)[5].widget.item_select(
+                'Refresh counts'
+            )
 
 
 @navigator.register(CapsuleEntity, 'Capsules')

--- a/airgun/views/capsule.py
+++ b/airgun/views/capsule.py
@@ -185,7 +185,12 @@ class CapsuleDetailsView(BaseLoggedInView):
         mid_content_table = ExpandableTable(
             component_id='expandable-content-views',
             column_widgets={
-                'cv_info_list': ItemsList(locator='//ul'),
+                0: Button(locator='./button[@aria-label="Details"]'),
+                'Content view': Text('./span/a'),
+                'Version': Text('./a'),
+                'Last published': Text('./span'),
+                'Synced': Text('./svg'),
+                5: Dropdown(locator='.//div[contains(@class, "pf-c-dropdown")]'),
             },
         )
 


### PR DESCRIPTION
A new kebab for the content counts update has been added in 6.17 to granularize the counts calculation.

![ccc](https://github.com/user-attachments/assets/35fc69d4-88af-4742-a1d7-f9744d24f365)

This PR just adds the ability to refresh content counts for particular CV under a LCE.

Tested locally with packit instance for https://github.com/Katello/katello/pull/11187 and some populated capsule and a dummie like this worked 
```
def test_dummie(target_sat, module_capsule_configured):
    with target_sat.ui_session() as session:
        session.organization.select(org_name='Any organization')
        details = session.capsule.read_details(module_capsule_configured.hostname)
        session.capsule.refresh_lce_counts(module_capsule_configured.hostname, lce_name='etPJDb')
        session.capsule.refresh_lce_counts(
            module_capsule_configured.hostname, lce_name='etPJDb', cv_name='AzrxdmTifn'
        )
```