### PR TITLE
Fix locator for ACSes

### DIFF
--- a/airgun/views/acs.py
+++ b/airgun/views/acs.py
@@ -132,7 +132,7 @@ class AddAlternateContentSourceModal(View):
     @View.nested
     class select_capsule(WizardStepView, DualListSelector):
         expander = Text(
-            './/button[contains(.,"Select smart proxy") or contains(.,"Select capsule")]'
+            './/button[contains(.,"Select Smart proxy") or contains(.,"Select Capsule")]'
         )
         use_http_proxies = OUIASwitch('use-http-proxies-switch')
 


### PR DESCRIPTION
Capsule went upper case in ACS create modal in 6.17:

![image](https://github.com/user-attachments/assets/a695f143-72b0-4a6f-bdce-7f2c3d44d683)

This PR updates the locator accordingly.