### PR TITLE
update ansible variable matcher_value locator

### DIFF
--- a/airgun/views/ansible_variable.py
+++ b/airgun/views/ansible_variable.py
@@ -32,7 +32,7 @@ class MatcherActions(View):
     text input field."""
 
     matcher_key = Select(".//select")
-    matcher_value = TextInput(locator=".//input[@class='matcher_value']")
+    matcher_value = TextInput(locator=".//div[@class='matcher-group']/input")
 
 
 class NewAnsibleVariableView(BaseLoggedInView):


### PR DESCRIPTION
Previously, the test case was failing because it couldn’t retrieve the locator. I updated the locator to ensure it fetches the correct value when creating the Ansible variable.