### PR TITLE
[6.15.z] Fix inconsistently failing Errata UI, checking New Host > Installed Packages > table

### DIFF
--- a/airgun/entities/host_new.py
+++ b/airgun/entities/host_new.py
@@ -331,6 +331,7 @@ class NewHostEntity(HostEntity):
     def get_packages(self, entity_name, search=""):
         """Filter installed packages on host"""
         view = self.navigate_to(self, 'NewDetails', entity_name=entity_name)
+        view.content.packages.wait_displayed()
         view.content.packages.select()
         view.content.packages.table.wait_displayed()
         view.content.packages.searchbar.fill(search)


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/airgun/pull/1612

### Purpose
Occasionally see no such element exception for ErrataManagement CI results, 
in `get_packages()` method on `view.content.packages.select()`
locally it runs without issue, but we should wait for the packages tab to appear before selecting it, after we navigate to the page.

See for prt [Robottelo#16814](https://github.com/SatelliteQE/robottelo/pull/16814)

two tests using this method, New Host UI > Installed Packages tab > read table :
- tests/foreman/ui/test_errata.py:: test_positive_apply_for_all_hosts (upgrade)
- tests/foreman/ui/test_host.py:: test_positive_update_delete_package (rhel8 only) _Fails in setup_

### Related Issue (seen occasionally in 6.15, 6.16 el8/9)
```
Error Message
selenium.common.exceptions.NoSuchElementException: Message: Could not find an element Locator(by='xpath', locator='.//div[contains(@class, "pf-c-tabs")]/ul/li[button[normalize-space(.)="Content"]]'); 

Stacktrace
tests/foreman/ui/test_errata.py:947: in test_positive_apply_for_all_hosts
    updated_pkg = session.host_new.get_packages(
../../lib64/python3.12/site-packages/airgun/entities/host_new.py:334: in get_packages
    view.content.packages.select()
../../lib64/python3.12/site-packages/widgetastic/widget/base.py:146: in __get__
    obj.child_widget_accessed(widget)
   
    ...
E   selenium.common.exceptions.NoSuchElementException: Message: Could not find an element Locator(by='xpath', locator='.//div[contains(@class, "pf-c-tabs")]/ul/li[button[normalize-space(.)="Content"]]');
```

