### PR TITLE
Add reclaim_space_warning node to the capsule view

### DIFF
--- a/airgun/views/capsule.py
+++ b/airgun/views/capsule.py
@@ -96,6 +96,7 @@ class CapsuleDetailsView(BaseLoggedInView):
         TAB_NAME = 'Overview'
 
         reclaim_space_button = Button('Reclaim Space')
+        reclaim_space_warning = Text('.//div[@id="properties"]/div/div/p[contains(., "Warning")]')
 
         url = Text('.//div[preceding-sibling::div[contains(., "URL")]]')
         version = Text('.//span[@class="proxy-version"]')


### PR DESCRIPTION
Just adding the reclaim_space_warning node to the capsule view so that we can test its hiding from robottelo.