### PR TITLE
[6.16.z] Add support for getting documentation related urls from Satellite page

### DIFF
--- a/airgun/entities/about.py
+++ b/airgun/entities/about.py
@@ -1,0 +1,19 @@
+from airgun.entities.base import BaseEntity
+from airgun.navigation import NavigateStep, navigator
+from airgun.utils import retry_navigation
+from airgun.views.about import AboutView
+
+
+class AboutEntity(BaseEntity):
+    endpoint_path = '/about'
+
+
+@navigator.register(AboutEntity, 'All')
+class ShowAboutPage(NavigateStep):
+    """Navigate to About page."""
+
+    VIEW = AboutView
+
+    @retry_navigation
+    def step(self, *args, **kwargs):
+        self.view.menu.select('Administer', 'About')

--- a/airgun/entities/fact_value.py
+++ b/airgun/entities/fact_value.py
@@ -1,0 +1,19 @@
+from airgun.entities.base import BaseEntity
+from airgun.navigation import NavigateStep, navigator
+from airgun.utils import retry_navigation
+from airgun.views.fact import HostFactView
+
+
+class FactValueEntity(BaseEntity):
+    endpoint_path = '/fact_values'
+
+
+@navigator.register(FactValueEntity, 'All')
+class ShowFactValuePage(NavigateStep):
+    """Navigate to Fact Values page."""
+
+    VIEW = HostFactView
+
+    @retry_navigation
+    def step(self, *args, **kwargs):
+        self.view.menu.select('Monitor', 'Facts')

--- a/airgun/entities/global_parameter.py
+++ b/airgun/entities/global_parameter.py
@@ -1,0 +1,19 @@
+from airgun.entities.base import BaseEntity
+from airgun.navigation import NavigateStep, navigator
+from airgun.utils import retry_navigation
+from airgun.views.global_parameter import GlobalParameterView
+
+
+class GlobalParameterEntity(BaseEntity):
+    endpoint_path = '/common_parameters'
+
+
+@navigator.register(GlobalParameterEntity, 'All')
+class ShowGlobalParameters(NavigateStep):
+    """Navigate to Global Parameters page."""
+
+    VIEW = GlobalParameterView
+
+    @retry_navigation
+    def step(self, *args, **kwargs):
+        self.view.menu.select('Configure', 'Global Parameters')

--- a/airgun/session.py
+++ b/airgun/session.py
@@ -10,6 +10,7 @@ from fauxfactory import gen_string
 
 from airgun import settings
 from airgun.browser import AirgunBrowser, SeleniumBrowserFactory
+from airgun.entities.about import AboutEntity
 from airgun.entities.acs import AcsEntity
 from airgun.entities.activationkey import ActivationKeyEntity
 from airgun.entities.all_hosts import AllHostsEntity
@@ -37,8 +38,10 @@ from airgun.entities.discoveryrule import DiscoveryRuleEntity
 from airgun.entities.domain import DomainEntity
 from airgun.entities.eol_banner import EOLBannerEntity
 from airgun.entities.errata import ErrataEntity
+from airgun.entities.fact_value import FactValueEntity
 from airgun.entities.file import FilesEntity
 from airgun.entities.filter import FilterEntity
+from airgun.entities.global_parameter import GlobalParameterEntity
 from airgun.entities.hardware_model import HardwareModelEntity
 from airgun.entities.host import HostEntity
 from airgun.entities.host_new import NewHostEntity
@@ -329,6 +332,11 @@ class Session:
         return self._open(AcsEntity)
 
     @cached_property
+    def about(self):
+        """Instance of About entity."""
+        return self._open(AboutEntity)
+
+    @cached_property
     def activationkey(self):
         """Instance of Activation Key entity."""
         return self._open(ActivationKeyEntity)
@@ -458,6 +466,11 @@ class Session:
         return self._open(ErrataEntity)
 
     @cached_property
+    def factvalue(self):
+        """Instance of Fact Value entity."""
+        return self._open(FactValueEntity)
+
+    @cached_property
     def filter(self):
         """Instance of Filter entity."""
         return self._open(FilterEntity)
@@ -466,6 +479,11 @@ class Session:
     def file(self):
         """Instance of Files entity."""
         return self._open(FilesEntity)
+
+    @cached_property
+    def global_parameter(self):
+        """Instance of Global Parameters entity."""
+        return self._open(GlobalParameterEntity)
 
     @cached_property
     def hardwaremodel(self):

--- a/airgun/views/about.py
+++ b/airgun/views/about.py
@@ -1,0 +1,11 @@
+from widgetastic.widget import Text
+
+from airgun.views.common import BaseLoggedInView, SearchableViewMixinPF4
+
+
+class AboutView(BaseLoggedInView, SearchableViewMixinPF4):
+    title = Text("//h1[normalize-space(.)='About']")
+
+    @property
+    def is_displayed(self):
+        return self.browser.wait_for_element(self.title, exception=False) is not None

--- a/airgun/views/global_parameter.py
+++ b/airgun/views/global_parameter.py
@@ -1,0 +1,11 @@
+from widgetastic.widget import Text
+
+from airgun.views.common import BaseLoggedInView, SearchableViewMixinPF4
+
+
+class GlobalParameterView(BaseLoggedInView, SearchableViewMixinPF4):
+    title = Text("//h1[normalize-space(.)='Global Parameters']")
+
+    @property
+    def is_displayed(self):
+        return self.browser.wait_for_element(self.title, exception=False) is not None


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/airgun/pull/1611

Historically, after a Satellite release, we have found that the documentation links on Satellite pages were broken, causing bugs and customer cases to be filed, resulting in a poor user experience. 
This PR adds support to get the Documentation related links from a Satellite page. It also adds basic code for missing entities/pages in Airgun/

See SAT-27552