### PR TITLE
[6.15.z] add read ansible role entities and views

### DIFF
--- a/airgun/entities/ansible_role.py
+++ b/airgun/entities/ansible_role.py
@@ -51,6 +51,13 @@ class AnsibleRolesEntity(BaseEntity):
         view.submit.click()
         return available_roles_count
 
+    def read_all(self):
+        """Read all roles before importing"""
+        view = self.navigate_to(self, 'Import')
+        view.dropdown.click()
+        view.max_per_pg.click()
+        return view.roles.read()
+
 
 @navigator.register(AnsibleRolesEntity, 'All')
 class ShowAllRoles(NavigateStep):

--- a/airgun/views/ansible_role.py
+++ b/airgun/views/ansible_role.py
@@ -45,6 +45,9 @@ class AnsibleRolesImportView(BaseLoggedInView):
             0: Checkbox(locator='.//input[@type="checkbox"]'),
         },
     )
+    roles = Text("//table[contains(@class, 'pf-c-table')]")
+    dropdown = Text("//button[contains(@class, 'pf-c-options-menu')]")
+    max_per_pg = Text("//ul[contains(@class, 'pf-c-options-menu')]/li[6]")
     pagination = CompactPagination()
     submit = Button('Submit')
     cancel = Button('Cancel')


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/airgun/pull/1620

Added the `read_all` method to read all Ansible roles before importing.

Dependent PR: https://github.com/SatelliteQE/robottelo/pull/16873