### PR TITLE
[6.15.z] [pre-commit.ci] pre-commit autoupdate

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,16 +5,16 @@ ci:
 
 repos:
 - repo: https://github.com/psf/black
-  rev: 24.8.0
+  rev: 24.10.0
   hooks:
   - id: black
 - repo: https://github.com/astral-sh/ruff-pre-commit
-  rev: v0.6.8
+  rev: v0.7.3
   hooks:
     - id: ruff
       args: [--fix, --exit-non-zero-on-fix]
 - repo: https://github.com/pre-commit/pre-commit-hooks
-  rev: v4.6.0
+  rev: v5.0.0
   hooks:
   - id: check-yaml
   - id: debug-statements


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/airgun/pull/1590

<!--pre-commit.ci start-->
updates:
- [github.com/psf/black: 24.8.0 → 24.10.0](https://github.com/psf/black/compare/24.8.0...24.10.0)
- [github.com/astral-sh/ruff-pre-commit: v0.6.8 → v0.7.3](https://github.com/astral-sh/ruff-pre-commit/compare/v0.6.8...v0.7.3)
- [github.com/pre-commit/pre-commit-hooks: v4.6.0 → v5.0.0](https://github.com/pre-commit/pre-commit-hooks/compare/v4.6.0...v5.0.0)
<!--pre-commit.ci end-->