### PR TITLE
[6.16.z] Add a couple of waits to RH repos pages

### DIFF
--- a/airgun/entities/redhat_repository.py
+++ b/airgun/entities/redhat_repository.py
@@ -29,6 +29,7 @@ class RedHatRepositoryEntity(BaseEntity):
         :param recommended_repo: on/off RH recommended repositories
         """
         view = self.navigate_to(self, 'All')
+        view.wait_displayed()
 
         if recommended_repo:
             current_value = self.browser.get_attribute(
@@ -68,6 +69,7 @@ class RedHatRepositoryEntity(BaseEntity):
         :param bool orphaned: Whether the repository is Orphaned
         """
         view = self.navigate_to(self, 'All')
+        view.wait_displayed()
         view.search(f'name = "{entity_name}"', category='Enabled')
         entity_text = f'{entity_name} (Orphaned)' if orphaned else entity_name
         view.enabled.items(name=entity_text)[0].disable()


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/airgun/pull/1631

Couple of tests for RH repos pages are failing with `NoSuchElementException` and it looks like they don't wait for the page display. This should fix it.
