### PR TITLE
[6.16.z] hosts table: Name locator fix (again)

### DIFF
--- a/airgun/views/host.py
+++ b/airgun/views/host.py
@@ -228,7 +228,7 @@ class HostsView(BaseLoggedInView, SearchableViewMixinPF4):
         column_widgets={
             0: Checkbox(locator=".//input[@class='host_select_boxes']"),
             'Name': Text(
-                "//a[contains(@href, '/new/hosts/') and not(contains(@href, 'Insights'))]"
+                ".//a[contains(@href, '/new/hosts/') and not(contains(@href, 'Insights'))]"
             ),
             'Recommendations': Text("./a"),
             'Actions': ActionsDropdown("./div[contains(@class, 'btn-group')]"),


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/airgun/pull/1603

### Problem Statement

Re-introducing this fix after being reverted.
This commit unintentionally broke navigation to host details page,
which was caused by another issue in the Sat hosts table
and fixed in https://github.com/SatelliteQE/airgun/pull/1465

Description:

The `HostsView` `Name` table column XPath was missing leading '.' character,
which caused that all host rows that were returned, had the same Name value,
equal to the first table row host Name.
