### PR TITLE
Remove Purpose addons from airgun code

### DIFF
--- a/airgun/views/contenthost.py
+++ b/airgun/views/contenthost.py
@@ -29,7 +29,6 @@ from airgun.widgets import (
     ConfirmationDialog,
     EditableEntry,
     EditableEntryCheckbox,
-    EditableEntryMultiCheckbox,
     EditableEntrySelect,
     Pagination,
     ReadOnlyEntry,
@@ -147,7 +146,6 @@ class ContentHostDetailsView(BaseLoggedInView):
         service_level = EditableEntrySelect(name='Service Level (SLA)')
         usage_type = EditableEntrySelect(name='Usage Type')
         role = EditableEntrySelect(name='Role')
-        addons = EditableEntryMultiCheckbox(name='Add ons')
         # Content Host Properties
         os = ReadOnlyEntry(
             locator=".//dt[.='OS']/following-sibling::dd[not(contains(@class, 'ng-hide'))]"

--- a/airgun/views/host_new.py
+++ b/airgun/views/host_new.py
@@ -16,7 +16,6 @@ from widgetastic_patternfly4.ouia import (
     ExpandableTable,
     FormSelect as OUIAFormSelect,
     PatternflyTable,
-    Select as OUIASelect,
 )
 
 from airgun.views.common import BaseLoggedInView
@@ -772,7 +771,6 @@ class EditSystemPurposeView(View):
     sla = OUIAFormSelect('service-level-select')
     usage = OUIAFormSelect('usage-select')
     release_version = OUIAFormSelect('release-version-select')
-    add_ons = OUIASelect('syspurpose-addons-select')
 
     save = OUIAButton('save-syspurpose')
     cancel = OUIAButton('cancel-syspurpose')

--- a/airgun/widgets.py
+++ b/airgun/widgets.py
@@ -1685,7 +1685,7 @@ class CheckboxGroup(GenericLocatorWidget):
         """Check or uncheck one of the checkboxes
 
         :param value: string with specification of fields' values
-            Example: value={'details.addons': {'Test addon 1': True, 'Test addon 2': False}}
+            Example: value={'details.role': {'Test role 1': True, 'Test role 2': False}}
         """
         for name, value in values.items():
             self.checkboxes[name].fill(value)


### PR DESCRIPTION
##### Description of changes
- purpose_addons is removed from katello https://github.com/Katello/katello/pull/11196 will/is cause robottelo tests to fail.

Describe in detail the changes made, and any potential impacts to callers.
- remove purpose_addons
##### Upstream API documentation, plugin, or feature links
- https://github.com/Katello/katello/pull/11196
