### PR TITLE
[6.15.z] Cross check Airgun installation with robottelo's dependencies

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -37,3 +37,28 @@ jobs:
       - name: Docs Build
         run: |
          make docs-html
+
+  robottelo-cross-check:
+    name: Robottelo installation cross-check
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Airgun
+        uses: actions/checkout@v4
+
+      - name: Set Up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Download robottelo's requirements.txt
+        run: |
+          curl -s https://raw.githubusercontent.com/SatelliteQE/robottelo/$GITHUB_BASE_REF/requirements.txt -o requirements-robottelo.txt
+
+      - name: Remove airgun from robottelo requirements
+        run: |
+          sed -i '/airgun/d' requirements-robottelo.txt
+
+      - name: Robottelo Installability
+        run: |
+          pip install -U pip
+          pip install -U -r requirements-robottelo.txt -r requirements.txt -r requirements-optional.txt


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/airgun/pull/1676

## Problem Statement
See the problem statement at https://github.com/SatelliteQE/robottelo/pull/17166.

We lack a mechanism to check whether the proposed Airgun patch works well with robottelo to ensure that breakage #1647 will not repeat.

## Solution
Create a new job to install airgun, airgun's dependencies, and robottelo's dependencies to verify installability.
This way we ensure that dependency bumps in Airgun do not break robottelo installation.

## Note
This patch assumes that robottelo keeps the same branch naming scheme as Airgun.