### PR TITLE
Update fill method logic for button values

### DIFF
--- a/airgun/widgets.py
+++ b/airgun/widgets.py
@@ -1631,10 +1631,12 @@ class EditableEntry(GenericLocatorWidget):
         # not required for it
         if self.edit_button.is_displayed:
             self.edit_button.click()
+        if self.edit_field.is_displayed:
             self.edit_field.fill(value)
             self.save_button.click()
         if self.pf4_edit_button.is_displayed:
             self.pf4_edit_button.click()
+        if self.pf4_edit_field.is_displayed:
             self.pf4_edit_field.fill(value)
             self.pf4_save_button.click()
 


### PR DESCRIPTION
After a thorough debugging session. It was discovered that when a user selects a new LCE, the "edit" button disappears and then requires and additional "fill" and "save" action. This is the case for PF4 as well. 

This was introduced by a logic change here: https://github.com/SatelliteQE/airgun/pull/939

If you think this looks gross... IT IS. But  I want to clarify that we cannot add any additional parameters/arguments to the fill method and we have nothing to really iterate over. So if you have any suggestions on how to make this look pretty im all ears :) 