### PR TITLE
Rename Insights navigation menu items

### DIFF
--- a/airgun/entities/cloud_insights.py
+++ b/airgun/entities/cloud_insights.py
@@ -25,14 +25,14 @@ class CloudInsightsEntity(BaseEntity):
         view.remediation_window.remediate.click()
 
     def sync_hits(self):
-        """Sync RH Cloud - Insights recommendations."""
+        """Sync Insights recommendations."""
         view = self.navigate_to(self, 'All')
         view.insights_dropdown.wait_displayed()
         view.insights_dropdown.item_select('Sync recommendations')
         self.browser.plugin.ensure_page_safe(timeout='60s')
 
     def read(self, widget_names=None):
-        """Read all values for created activation key entity"""
+        """Read all values."""
         view = self.navigate_to(self, 'All')
         return view.read(widget_names=widget_names)
 
@@ -44,7 +44,7 @@ class CloudInsightsEntity(BaseEntity):
         self.browser.plugin.ensure_page_safe(timeout='60s')
 
     def update(self, values):
-        """Update RH Cloud - Insights view."""
+        """Update Insights view."""
         view = self.navigate_to(self, 'All')
         view.fill(values)
 
@@ -68,4 +68,4 @@ class ShowCloudInsightsView(NavigateStep):
 
     @retry_navigation
     def step(self, *args, **kwargs):
-        self.view.menu.select('Configure', 'RH Cloud', 'Insights')
+        self.view.menu.select('Configure', 'Insights', 'Recommendations')

--- a/airgun/entities/cloud_inventory.py
+++ b/airgun/entities/cloud_inventory.py
@@ -56,4 +56,4 @@ class ShowCloudInventoryListView(NavigateStep):
 
     @retry_navigation
     def step(self, *args, **kwargs):
-        self.view.menu.select('Configure', 'RH Cloud', 'Inventory Upload')
+        self.view.menu.select('Configure', 'Insights', 'Inventory Upload')

--- a/airgun/session.py
+++ b/airgun/session.py
@@ -383,12 +383,12 @@ class Session:
 
     @cached_property
     def cloudinventory(self):
-        """Instance of RH Cloud Inventory Upload entity."""
+        """Instance of Insights Inventory Upload entity."""
         return self._open(CloudInventoryEntity)
 
     @cached_property
     def cloudinsights(self):
-        """Instance of RH Cloud Insights entity."""
+        """Instance of Insights entity."""
         return self._open(CloudInsightsEntity)
 
     @cached_property

--- a/airgun/views/cloud_insights.py
+++ b/airgun/views/cloud_insights.py
@@ -7,7 +7,7 @@ from airgun.views.common import BaseLoggedInView, SearchableViewMixinPF4
 
 
 class CloudTokenView(BaseLoggedInView):
-    """RH Cloud Insights Landing page for adding RH Cloud Token."""
+    """Insights Landing page for adding RH Cloud Token."""
 
     rhcloud_token = TextInput(locator='//input[contains(@aria-label, "input-cloud-token")]')
     save_token = Button('Save setting and sync recommendations')
@@ -18,7 +18,7 @@ class CloudTokenView(BaseLoggedInView):
 
 
 class RemediationView(Modal):
-    """Remediation window view"""
+    """Insights Remediations modal view"""
 
     OUIA_ID = 'OUIA-Generated-Modal-large-1'
     remediate = Button('Remediate')
@@ -39,7 +39,7 @@ class RemediationView(Modal):
 
 
 class CloudInsightsView(BaseLoggedInView, SearchableViewMixinPF4):
-    """Main RH Cloud Insights view."""
+    """Main Insights view."""
 
     title = Text('//h1[normalize-space(.)="Red Hat Insights"]')
     insights_sync_switcher = Switch('OUIA-Generated-Switch-1')

--- a/airgun/views/cloud_inventory.py
+++ b/airgun/views/cloud_inventory.py
@@ -12,9 +12,9 @@ from airgun.widgets import Accordion
 
 
 class InventoryTab(Tab):
-    """Cloud Inventory Upload Tab element.
+    """Insights Inventory Upload Tab element.
 
-    This is lightweight subclass needed because Cloud Inventory Upload
+    This is lightweight subclass needed because Insights Inventory Upload
     tabs contain icons, and widgetastic_patternfly Tab looks for exact match.
     """
 
@@ -29,7 +29,7 @@ class InventoryTab(Tab):
 
 
 class InventoryItemsView(Accordion):
-    """Item related to one organization on Cloud Inventory Upload page."""
+    """Item related to one organization on Insights Inventory Upload page."""
 
     ROOT = './/dl[contains(@class, "pf-c-accordion account-list")]'
     DESCRIPTION_LOCATOR = (
@@ -103,7 +103,7 @@ class InventoryItemsView(Accordion):
 
 
 class CloudInventoryListView(BaseLoggedInView):
-    """Main RH Cloud Inventory Upload view."""
+    """Main Insights Inventory Upload view."""
 
     title = Text('//h1[normalize-space(.)="Red Hat Inventory"]')
     auto_update = Switch('.//label[@for="rh-cloud-switcher-allow_auto_inventory_upload"]')


### PR DESCRIPTION
This PR updates the navigation menu for Insights-related items:

`Configure > RH Cloud > Insights` is now `Configure > Insights > Recommendations`
`Configure > RH Cloud > Inventory Upload` is now `Configure > Insights > Inventory Upload`

Corresponding frontend PR:

Iop only nav updates nothing else
https://github.com/theforeman/foreman_rh_cloud/pull/939

SAT-30174