### PR TITLE
[cp 6.14] removing updated value and takes default value

### DIFF
--- a/airgun/entities/host_new.py
+++ b/airgun/entities/host_new.py
@@ -868,6 +868,26 @@ class NewHostEntity(HostEntity):
                 host_facts_view.expand_fact_value.click()
         return host_facts_view.table.read()
 
+    def update_variable_value(self, entity_name, key, value):
+        view = self.navigate_to(self, 'NewDetails', entity_name=entity_name)
+        wait_for(lambda: view.ansible.variables.table.is_displayed, timeout=10)
+        # Index [5] essentially refers to the button used to edit the value. The same index is then applied to either 'Yes' or 'No' options to update the value
+        view.ansible.variables.table.row(name=key)[5].widget.click()
+        view.ansible.variables.table.row(name=key)['Value'].click()
+        view.ansible.variables.table.row(name=key)['Value'].widget.fill(value)
+        view.ansible.variables.table1.row(name=key)[5].widget.click()
+
+    def del_variable_value(self, entity_name):
+        view = self.navigate_to(self, 'NewDetails', entity_name=entity_name)
+        view.ansible.variables.actions.click()
+        view.ansible.variables.delete.click()
+        view.ansible.variables.confirm.click()
+
+    def read_variable_value(self, entity_name, key):
+        view = self.navigate_to(self, 'NewDetails', entity_name=entity_name)
+        value = view.ansible.variables.table.row(name=key)['Value'].read()
+        return value
+
 
 @navigator.register(NewHostEntity, 'NewDetails')
 class ShowNewHostDetails(NavigateStep):

--- a/airgun/views/host_new.py
+++ b/airgun/views/host_new.py
@@ -509,6 +509,10 @@ class NewHostDetailsView(BaseLoggedInView):
         class variables(Tab):
             TAB_NAME = 'Variables'
             ROOT = './/div[@class="ansible-host-detail"]'
+
+            actions = Button(locator='//tbody/tr/td[7]//button')
+            delete = Button(locator='//button[@role="menuitem"]')
+            confirm = Button(locator='//button[@data-ouia-component-id="btn-modal-confirm"]')
             table = Table(
                 locator='.//table[contains(@class, "pf-c-table")]',
                 column_widgets={
@@ -516,13 +520,19 @@ class NewHostDetailsView(BaseLoggedInView):
                     'Ansible role': Text('./span'),
                     'Type': Text('./span'),
                     # the next field can also be a form group
-                    'Value': Text('./span'),
+                    'Value': TextInput(locator='//textarea[contains(@class, "pf-c-form")]'),
                     'Source attribute': Text('./span'),
                     # The next 2 buttons are hidden by default, but appear in this order
-                    5: Button(locator='.//button[@aria-label="Cancel editing override button"]'),
-                    6: Button(locator='.//button[@aria-label="Submit override button"]'),
+                    6: Button(locator='.//button[@aria-label="Cancel editing override button"]'),
+                    7: Button(locator='.//button[@aria-label="Submit override button"]'),
                     # Clicking this button hides it, and displays the previous 2
-                    7: Button(locator='.//button[@aria-label="Edit override button"]'),
+                    5: Button(locator='.//button[@aria-label="Edit override button"]'),
+                },
+            )
+            table1 = Table(
+                locator='.//table[contains(@class, "pf-c-table")]',
+                column_widgets={
+                    5: Button(locator='.//button[@aria-label="Submit editing override button"]'),
                 },
             )
             pagination = PF4Pagination()


### PR DESCRIPTION
Added to the entities with their respective locators:

update_variable_value: Updating the ansible variable value in the host.
del_variable_value: Deletes the updated value, reverts to the default value.
read_variable_value: Read the value of ansible variable in the host.

Dependent PR: https://github.com/SatelliteQE/robottelo/pull/17131

Fixes - https://github.com/SatelliteQE/airgun/issues/1688