### PR TITLE
[6.16.z] Add support for viewing the needs_publish banner in the cv index page…

### DIFF
--- a/airgun/entities/contentview_new.py
+++ b/airgun/entities/contentview_new.py
@@ -63,6 +63,21 @@ class NewContentViewEntity(BaseEntity):
         view.wait_displayed()
         return view.versions.table.read()
 
+    def check_publish_banner(self, cv_name):
+        """Check if the needs_publish banner is displayed on the content view index page"""
+        view = self.navigate_to(self, 'All')
+        self.browser.plugin.ensure_page_safe(timeout='5s')
+        view.wait_displayed()
+        if not view.table.is_displayed:
+            # no table present, no CVs in this Org
+            return None
+        view.search(cv_name)
+        view.table[0][6].widget.item_select('Publish')
+        view = ContentViewVersionPublishView(self.browser)
+        is_displayed = view.publish_alert.is_displayed
+        view.cancel_button.click()
+        return is_displayed
+
     def delete(self, entity_name):
         """Deletes the content view by name"""
         view = self.navigate_to(self, 'Edit', entity_name=entity_name)

--- a/airgun/views/contentview_new.py
+++ b/airgun/views/contentview_new.py
@@ -77,6 +77,7 @@ class ContentViewTableView(BaseLoggedInView, SearchableViewMixinPF4):
             'Last Published': ('./a'),
             'Last task': Text('.//a'),
             'Latest version': Text('.//a'),
+            6: Dropdown(locator='.//div[contains(@class, "pf-c-dropdown")]'),
         },
     )
 
@@ -213,6 +214,7 @@ class ContentViewVersionPublishView(BaseLoggedInView):
     # publishing view is a popup so adding all navigation within the same context
     ROOT = './/div[contains(@class,"pf-c-wizard")]'
     title = Text(".//h2[contains(., 'Publish') and contains(@aria-label, 'Publish')]")
+    publish_alert = Text(".//h4[contains(., 'No available repository or filter updates')]")
     # publishing screen
     description = TextInput(id='description')
     promote = Switch('promote-switch')


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/airgun/pull/1653

Simple change adding an entity to check the banner on cv publish through cv index page, and support for the needs publish banner on cv publish popup