### PR TITLE
Extend sync_status page with active_only support

### DIFF
--- a/airgun/entities/sync_status.py
+++ b/airgun/entities/sync_status.py
@@ -9,16 +9,18 @@ from airgun.views.sync_status import SyncStatusView
 class SyncStatusEntity(BaseEntity):
     endpoint_path = '/katello/sync_management'
 
-    def read(self, widget_names=None):
+    def read(self, widget_names=None, active_only=False):
         """Read all widgets at Sync status entity"""
         view = self.navigate_to(self, 'All')
+        view.active_only.fill(active_only)
         return view.read(widget_names=widget_names)
 
-    def synchronize(self, repository_paths, timeout=3600):
+    def synchronize(self, repository_paths, synchronous=True, timeout=3600):
         """Synchronize repositories
 
         :param repository_paths: A list of repositories to synchronize
             where each element of the list is path to repository represented by a list or tuple.
+        :param synchrounous: bool if to wait for all repos sync, defaults to True.
         :param timeout: time to wait for all repositories to be synchronized.
 
         Usage::
@@ -38,12 +40,13 @@ class SyncStatusEntity(BaseEntity):
         for repo_node in repo_nodes:
             repo_node.fill(True)
         view.synchronize_now.click()
-        wait_for(
-            lambda: all(node.progress is None for node in repo_nodes),
-            timeout=timeout,
-            delay=5,
-            logger=view.logger,
-        )
+        if synchronous:
+            wait_for(
+                lambda: all(node.progress is None for node in repo_nodes),
+                timeout=timeout,
+                delay=5,
+                logger=view.logger,
+            )
 
         return [node.result for node in repo_nodes]
 


### PR DESCRIPTION
There is the "Active only" check-box on the sync status page which adjusts the product/repos table to hide the lines where no sync happens. This is done through the `tr`'s `style` set to `display: none`, which means the table remains still complete, only the style change hides what needs to be hidden.

![image](https://github.com/user-attachments/assets/5187ac0a-921a-47be-97f7-c8af64caade3)


Unfortunately Airgun does not care about styles and returns the complete table since it's still there in the page.

This PR changes this behaviour to let Airgun return the table just like the user can see it based on the style (via `is_displayed` property).
Second change allows user to set the Active only check-box before read.
Third and last change allows user to sync a repo asynchronously without waiting for result.

Test PR: https://github.com/SatelliteQE/robottelo/pull/17413