### PR TITLE
[6.16.z] subscription page search field ui selector update

### DIFF
--- a/airgun/views/subscription.py
+++ b/airgun/views/subscription.py
@@ -10,25 +10,13 @@ from widgetastic.widget import (
 from widgetastic_patternfly import BreadCrumb, Button
 
 from airgun.exceptions import ReadOnlyWidgetError
-from airgun.views.common import BaseLoggedInView, SatTab, SearchableViewMixin
+from airgun.views.common import BaseLoggedInView, SatTab, SearchableViewMixinPF4
 from airgun.widgets import (
     ConfirmationDialog,
     ItemsListReadOnly,
     ProgressBar,
     SatTable,
-    Search,
 )
-
-
-# Search field and button on Subscriptions page uses different locators,
-# so subclass it and use it in our custom SearchableViewMixin
-class SubscriptionSearch(Search):
-    search_field = TextInput(locator=(".//input[starts-with(@id, 'downshift-')]"))
-    search_button = Button('Search')
-
-
-class SubscriptionSearchableViewMixin(SearchableViewMixin):
-    searchbox = SubscriptionSearch()
 
 
 class DeleteSubscriptionConfirmationDialog(ConfirmationDialog):
@@ -115,7 +103,7 @@ class SubscriptionColumnsFilter(GenericLocatorWidget):
         self.close()
 
 
-class SubscriptionListView(BaseLoggedInView, SubscriptionSearchableViewMixin):
+class SubscriptionListView(BaseLoggedInView, SearchableViewMixinPF4):
     """List of all subscriptions."""
 
     table = SatSubscriptionsViewTable(


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/airgun/pull/1702

### Problem Statement

- Test case `test_positive_access_with_non_admin_user_with_manifest` was failing due to Error 
`TypeError: 'NoneType' object is not subscriptable`
- Class variable `search_field` from airgun view `SubscriptionSearch` need to be updated

### Solution
Update `search_field` with expected locator.

### Robottelo PR
https://github.com/SatelliteQE/robottelo/pull/17382
