### PR TITLE
[6.15.z] updated read func which will read the value and click on submit.

### DIFF
--- a/airgun/entities/hostgroup.py
+++ b/airgun/entities/hostgroup.py
@@ -42,7 +42,9 @@ class HostGroupEntity(BaseEntity):
     def read(self, entity_name, widget_names=None):
         """Read values from host group edit page"""
         view = self.navigate_to(self, 'Edit', entity_name=entity_name)
-        return view.read(widget_names=widget_names)
+        value = view.read(widget_names=widget_names)
+        view.submit.click()
+        return value
 
     def read_all(self):
         """Read values from host groups title page"""


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/airgun/pull/1701

When we read the value of a host group set within a specific organization, and then attempt to change to a different organization without clicking the "Submit" button, an alert is triggered. This alert is handled by the `WrongContextAlert` class, but its button locator needs to be updated. The locator is part of the `widgetastic_patternfly4` library, which is supported only up to `Python 3.10`.

To avoid this issue, after reading the value in the host group, the "Submit" button will be clicked and change the organization.