### PR TITLE
Move "Insights" navigation menu items from under "Configure"

### DIFF
--- a/airgun/entities/cloud_insights.py
+++ b/airgun/entities/cloud_insights.py
@@ -57,7 +57,7 @@ class SaveCloudTokenView(NavigateStep):
 
     @retry_navigation
     def step(self, *args, **kwargs):
-        self.view.menu.select('Configure', 'Insights')
+        self.view.menu.select('Insights')
 
 
 @navigator.register(CloudInsightsEntity, 'All')
@@ -68,4 +68,4 @@ class ShowCloudInsightsView(NavigateStep):
 
     @retry_navigation
     def step(self, *args, **kwargs):
-        self.view.menu.select('Configure', 'Insights', 'Recommendations')
+        self.view.menu.select('Insights', 'Recommendations')

--- a/airgun/entities/cloud_inventory.py
+++ b/airgun/entities/cloud_inventory.py
@@ -56,4 +56,4 @@ class ShowCloudInventoryListView(NavigateStep):
 
     @retry_navigation
     def step(self, *args, **kwargs):
-        self.view.menu.select('Configure', 'Insights', 'Inventory Upload')
+        self.view.menu.select('Insights', 'Inventory Upload')


### PR DESCRIPTION
Reflect the UI changes in https://github.com/theforeman/foreman_rh_cloud/pull/945:

Configure > Insights is now a top-level Insights item:

Configure > Insights > Inventory Upload is now Insights > Inventory Upload
Configure > Insights > Recommendations is now Insights > Recommendations

