### PR TITLE
[6.16.z] [pre-commit.ci] pre-commit autoupdate

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,11 +5,11 @@ ci:
 
 repos:
 - repo: https://github.com/psf/black
-  rev: 24.10.0
+  rev: 25.1.0
   hooks:
   - id: black
 - repo: https://github.com/astral-sh/ruff-pre-commit
-  rev: v0.8.2
+  rev: v0.9.4
   hooks:
     - id: ruff
       args: [--fix, --exit-non-zero-on-fix]

--- a/airgun/views/common.py
+++ b/airgun/views/common.py
@@ -326,6 +326,7 @@ class PF4LCECheckSelectorGroup(PF4LCESelectorGroup):
 
 class PF4LCEGroup(ParametrizedLocator):
     "Group of LCE indicators"
+
     ROOT = './/td and '
 
     PARAMETERS = ('lce_name',)


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/airgun/pull/1678

<!--pre-commit.ci start-->
updates:
- [github.com/psf/black: 24.10.0 → 25.1.0](https://github.com/psf/black/compare/24.10.0...25.1.0)
- [github.com/astral-sh/ruff-pre-commit: v0.8.2 → v0.9.4](https://github.com/astral-sh/ruff-pre-commit/compare/v0.8.2...v0.9.4)
<!--pre-commit.ci end-->