### PR TITLE
[6.15.z] Add Python 3.13 for PR checks in GHA

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -51,6 +51,9 @@ jobs:
     name: Robottelo installation cross-check
     runs-on: ubuntu-latest
     needs: codechecks
+    strategy:
+      matrix:
+        python-version: ['3.13']
     steps:
       - name: Checkout Airgun
         uses: actions/checkout@v4
@@ -58,12 +61,12 @@ jobs:
       - name: Set Up Python
         uses: actions/setup-python@v5
         with:
-          python-version: '3.13'
+          python-version: ${{ matrix.python-version }}
 
       - name: Install the latest version of uv and set the Python version
         uses: astral-sh/setup-uv@v5
         with:
-          python-version: '3.12'
+          python-version: ${{ matrix.python-version }}
           enable-cache: true
           cache-dependency-glob: |
             **/requirements*.txt

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.10', '3.11', '3.12']
+        python-version: ['3.10', '3.11', '3.12', '3.13']
     steps:
       - name: Checkout Airgun
         uses: actions/checkout@v4
@@ -58,7 +58,7 @@ jobs:
       - name: Set Up Python
         uses: actions/setup-python@v5
         with:
-          python-version: '3.12'
+          python-version: '3.13'
 
       - name: Install the latest version of uv and set the Python version
         uses: astral-sh/setup-uv@v5

--- a/setup.py
+++ b/setup.py
@@ -41,5 +41,7 @@ setup(
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3.10',
         'Programming Language :: Python :: 3.11',
+        'Programming Language :: Python :: 3.12',
+        'Programming Language :: Python :: 3.13',
     ],
 )


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/airgun/pull/1703

### Problem Statement
Python 3.13 was released on October 7, 2024, and we're not covering this in the PR checks in GHA yet

### Solution
Add Python 3.13 for PR checks in GHA