### PR TITLE
Fix ContentView view

### DIFF
--- a/airgun/views/common.py
+++ b/airgun/views/common.py
@@ -1,5 +1,3 @@
-from functools import partial
-
 from selenium.common.exceptions import ElementNotInteractableException
 from widgetastic.widget import (
     Checkbox,
@@ -15,7 +13,7 @@ from widgetastic.widget import (
 from widgetastic_patternfly import BreadCrumb, Tab, TabWithDropdown
 from widgetastic_patternfly4 import Button
 from widgetastic_patternfly4.navigation import Navigation
-from widgetastic_patternfly5 import OptionsMenu
+from widgetastic_patternfly5 import Dropdown as PF5Dropdown
 from widgetastic_patternfly5.ouia import (
     Dropdown as PF5OUIADropdown,
     PatternflyTable,
@@ -336,9 +334,11 @@ class PF5LCECheckSelectorGroup(PF5LCESelectorGroup):
 
 
 # PF5 kebab menu present in table rows
-TableRowKebabMenu = partial(
-    OptionsMenu, './/button[contains(@data-ouia-component-type, "MenuToggle")]/..'
-)
+class TableRowKebabMenu(PF5Dropdown):
+    """Dropdown that supports both PF5 dropdown and menu-toggle kebab buttons."""
+
+    ROOT = '.'
+    TOGGLE = './/button[contains(@class, "pf-v5-c-menu-toggle") and contains(@aria-label, "Kebab toggle")]'
 
 
 class PF5LCEGroup(ParametrizedLocator):

--- a/airgun/views/contentview_new.py
+++ b/airgun/views/contentview_new.py
@@ -19,7 +19,6 @@ from airgun.views.common import (
     BaseLoggedInView,
     NewAddRemoveResourcesView,
     PF5LCECheckSelectorGroup,
-    PF5LCESelectorGroup,
     SearchableViewMixinPF4,
     TableRowKebabMenu,
 )
@@ -73,6 +72,7 @@ class AddContentViewModal(BaseLoggedInView):
 class ContentViewTableView(BaseLoggedInView, SearchableViewMixinPF4):
     title = PF5Text(component_id='cvPageHeaderText')
     create_content_view = PF5Button(component_id='create-content-view')
+    search = PF4Search()
     table = ExpandableTable(
         component_id='content-views-table',
         column_widgets={
@@ -227,6 +227,7 @@ class ContentViewVersionPublishView(BaseLoggedInView):
     close_button = Button('Close')
     progressbar = PF5ProgressBar()
     lce_selector = ParametrizedView.nested(PF5LCECheckSelectorGroup)
+    close = Button('Close')
 
     @property
     def is_displayed(self):
@@ -257,7 +258,7 @@ class ContentViewVersionPromoteView(Modal):
     ROOT = './/div[@data-ouia-component-id="promote-version"]'
 
     description = Text('.//h2[@data-ouia-component-id="description-text-value"]')
-    lce_selector = ParametrizedView.nested(PF5LCESelectorGroup)
+    lce_selector = ParametrizedView.nested(PF5LCECheckSelectorGroup)
     promote_btn = Button(locator='//button[normalize-space(.)="Promote"]')
     cancel_btn = Button(locator='//button[normalize-space(.)="Cancel"]')
 


### PR DESCRIPTION
There were few minor fixes needed for new contentview view and entities.

- Contentview Views:
1. version_dropdown = Dropdown(
        locator='.//div[@data-ouia-component-id="cv-version-header-actions-dropdown"]'
    )
locator was mentioned twice in views which could be confusing.
2. Fixed lce_selector locator.

- Contentview Entities:
1. Renamed `version_name` variable to `version` to maintain consistency in the module.
2.  def promote does not handle errors in case incorrect lce or invalid promote happens, added a check for handing and reading the error message. 
3. There is no lce variable in views so updated it to lce_selector.
4. Updated class PromoteContentViewVersion in views