### PR TITLE
RFE: added widgets for the new job invocation page

### DIFF
--- a/airgun/views/job_invocation.py
+++ b/airgun/views/job_invocation.py
@@ -16,7 +16,7 @@ from airgun.views.common import (
     SearchableViewMixin,
     WizardStepView,
 )
-from airgun.widgets import ActionsDropdown
+from airgun.widgets import ActionsDropdown, ExpandableSection, PF4DataList
 
 
 class JobInvocationsView(BaseLoggedInView, SearchableViewMixin):
@@ -276,3 +276,20 @@ class NewJobInvocationStatusView(BaseLoggedInView):
         def read(self):
             """Return `dict` without trailing ':' in the key names."""
             return {key.replace(':', ''): val for key, val in super().read().items()}
+
+    @View.nested
+    class target_hosts(ExpandableSection):
+        label = 'Target Hosts'
+        search_query = Text('./div[contains(@class, "pf-c-expandable-section__content")]/pre')
+        data = PF4DataList()
+
+        def read(self):
+            return {'search_query': self.search_query.read(), 'data': self.data.read()}
+
+    @View.nested
+    class user_inputs(ExpandableSection):
+        label = 'User Inputs'
+        data = PF4DataList()
+
+        def read(self):
+            return {'data': self.data.read()}

--- a/airgun/widgets.py
+++ b/airgun/widgets.py
@@ -2901,3 +2901,43 @@ class SatPatternflyTable(BasePatternflyTable, Table):
 
 class SatExpandableTable(BaseExpandableTable, SatPatternflyTable):
     pass
+
+
+class ExpandableSection(Widget):
+    ROOT = ParametrizedLocator(
+        '//div[contains(@class, "pf-c-expandable-section")]/button[normalize-space(.)={@label|quote}]/..'
+    )
+    TOGGLE_BUTTON = ParametrizedLocator('./button[normalize-space(.)={@label|quote}]')
+    EXPANDED_CLASS_NAME = 'pf-m-expanded'
+
+    @property
+    def is_expanded(self):
+        return self.EXPANDED_CLASS_NAME in self.browser.classes(self.ROOT)
+
+    def expand(self):
+        if not self.is_expanded:
+            self.browser.click(self.TOGGLE_BUTTON)
+
+    def collapse(self):
+        if self.is_expanded:
+            self.browser.click(self.TOGGLE_BUTTON)
+
+    def read(self):
+        self.expand()
+
+
+class PF4DataList(Widget):
+    """Widget for PatternFly 4 Data list: https://pf4.patternfly.org/components/data-list"""
+
+    ROOT = './/ul[contains(@class, "pf-c-data-list")]'
+    ITEMS = './li//div[contains(@class, "pf-c-data-list__item-content")]/div[1]'
+    VALUES = './li//div[contains(@class, "pf-c-data-list__item-content")]/div[2]'
+
+    def read(self):
+        items = [self.browser.text(item) for item in self.browser.elements(self.ITEMS)]
+        values = [self.browser.text(value) for value in self.browser.elements(self.VALUES)]
+        if len(items) != len(values):
+            raise ValueError(
+                f'The count of data list labels and values does not match. Labels: {items}. Values: {values}'
+            )
+        return dict(zip(items, values))


### PR DESCRIPTION
### RFE SAT-26605: new job_invocations detail page, vol. 2 ###

Added few more widgets for the new job invocations page.
This patch adds the expandable sections `Target Hosts` and `User Inputs`.

The expandable host table below currently doesn't seem to work with the widgetastic
table widgets, nor PF4, PF4/OUIA, etc., even with modifications.
After this issue is addressed and solved, the table widget will be added in a separate PR.
