### PR TITLE
Auto branching: Add randomness to branch name

### DIFF
--- a/.github/workflows/auto_branching.yml
+++ b/.github/workflows/auto_branching.yml
@@ -68,7 +68,7 @@ jobs:
       - name: Checkout from ${{ github.event.inputs.target_branch }} branch for auto-branching changes
         id: checkout-to-auto-branch
         run: |
-            branch_name="auto-branching-${{ github.event.inputs.target_branch }}-$(date '+%s')"
+            branch_name="auto-branching-${{ github.event.inputs.target_branch }}-$(date '+%s.%N')"
             git checkout -b "$branch_name"
             echo "branch_name=$branch_name" >> $GITHUB_OUTPUT
 
@@ -167,7 +167,7 @@ jobs:
         run: |
           git config --local user.email "Satellite-QE.satqe.com"
           git config --local user.name "Satellite-QE"
-          branch_name="auto-branching-${{ github.event.inputs.target_branch }}-$(date '+%s')"
+          branch_name="auto-branching-${{ github.event.inputs.target_branch }}-$(date '+%s.%N')"
           git checkout -b "$branch_name"
           git add ./.github/*
           git commit -m "Changes for ${{ github.event.inputs.target_branch }} new branch"


### PR DESCRIPTION
### Problem Statement
`date '+%n` was not random enough. When two jobs run in parallel, they create a branch with the same name.

### Solution
Adding `%N` to add microseconds to add a bit of _random_ to it.