### PR TITLE
[6.17.z] Add view/entity for booted container images page

### DIFF
--- a/airgun/entities/bootc.py
+++ b/airgun/entities/bootc.py
@@ -1,0 +1,35 @@
+from airgun.entities.base import BaseEntity
+from airgun.navigation import NavigateStep, navigator
+from airgun.utils import retry_navigation
+from airgun.views.bootc import BootedContainerImagesView
+
+
+class BootcEntity(BaseEntity):
+    endpoint_path = '/booted_container_images'
+
+    def read(self, booted_image_name):
+        """
+        Read the expanded row of a specific booted_image, returns a tuple
+        with the unexpanded content, and the expanded content
+        """
+        view = self.navigate_to(self, 'All')
+        self.browser.plugin.ensure_page_safe(timeout='5s')
+        # Workaround for SAT-31160
+        script = "document.querySelector('tbody').remove();"
+        self.browser.execute_script(script)
+        view.search(f"bootc_booted_image = {booted_image_name}")
+        view.table.row(image_name=booted_image_name).expand()
+        row = view.table.row(image_name=booted_image_name).read()
+        row_content = view.table.row(image_name=booted_image_name).content.read()
+        return (row, row_content['table'][0])
+
+
+@navigator.register(BootcEntity, 'All')
+class BootedImagesScreen(NavigateStep):
+    """Navigate to Booted Container Images screen."""
+
+    VIEW = BootedContainerImagesView
+
+    @retry_navigation
+    def step(self, *args, **kwargs):
+        self.view.menu.select('Content', 'Booted Container Images')

--- a/airgun/session.py
+++ b/airgun/session.py
@@ -19,6 +19,7 @@ from airgun.entities.ansible_variable import AnsibleVariablesEntity
 from airgun.entities.architecture import ArchitectureEntity
 from airgun.entities.audit import AuditEntity
 from airgun.entities.bookmark import BookmarkEntity
+from airgun.entities.bootc import BootcEntity
 from airgun.entities.capsule import CapsuleEntity
 from airgun.entities.cloud_insights import CloudInsightsEntity
 from airgun.entities.cloud_inventory import CloudInventoryEntity
@@ -370,6 +371,11 @@ class Session:
     def bookmark(self):
         """Instance of Bookmark entity."""
         return self._open(BookmarkEntity)
+
+    @cached_property
+    def bootc(self):
+        """Instance of Bootc entity."""
+        return self._open(BootcEntity)
 
     @cached_property
     def capsule(self):

--- a/airgun/views/bootc.py
+++ b/airgun/views/bootc.py
@@ -1,0 +1,33 @@
+from widgetastic.widget import Table, Text, View
+from widgetastic_patternfly4.ouia import ExpandableTable
+
+from airgun.views.common import (
+    BaseLoggedInView,
+    SearchableViewMixinPF4,
+)
+
+
+class BootedContainerImagesView(BaseLoggedInView, SearchableViewMixinPF4):
+    title = Text('.//h1[@data-ouia-component-id="header-text"]')
+
+    # This represents the contents of the expanded table rows
+    class NestedBootCTable(View):
+        table = Table(
+            locator='.//div[@class="pf-c-table__expandable-row-content"]/table',
+            column_widgets={'Image Digest': Text('./a'), 'Hosts': Text('./a')},
+        )
+
+    # Passing in the nested table as content_view, refer to ExpandableTable docs for info
+    table = ExpandableTable(
+        component_id='booted-containers-table',
+        column_widgets={
+            'Image Name': Text('./a'),
+            'Image Digests': Text('./a'),
+            'Hosts': Text('./a'),
+        },
+        content_view=NestedBootCTable(),
+    )
+
+    @property
+    def is_displayed(self):
+        return self.table.is_displayed


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/airgun/pull/1745

Quick little airgun PR adding support for the booted container image page.

Supports: https://github.com/SatelliteQE/robottelo/pull/17634