### PR TITLE
[6.17.z] fix TemplatesList locator to fetch value

### DIFF
--- a/airgun/views/os.py
+++ b/airgun/views/os.py
@@ -32,7 +32,7 @@ class TemplatesList(View):
 
     SELECT = (
         "//label[@for='provisioning_template_id'][contains(.,'{}')]"
-        "/following-sibling::div/div[contains(@id, 'default_templates')]"
+        "/following-sibling::div/select[contains(@id, 'default_templates')]"
     )
     TITLES = "//label[@for='provisioning_template_id']"
 


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/airgun/pull/1755

Update the locator to retrieve the value from the operating system template.







