### PR TITLE
[6.17.z] Remove Python 3.10 support

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.10', '3.11', '3.12', '3.13']
+        python-version: ['3.11', '3.12', '3.13']
     steps:
       - name: Checkout Airgun
         uses: actions/checkout@v4

--- a/setup.py
+++ b/setup.py
@@ -39,7 +39,6 @@ setup(
         'Natural Language :: English',
         'Operating System :: POSIX :: LinuxProgramming Language :: Python',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.10',
         'Programming Language :: Python :: 3.11',
         'Programming Language :: Python :: 3.12',
         'Programming Language :: Python :: 3.13',


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/airgun/pull/1758

### Problem Statement
We can not update the Sphinx library without dropping Python 3.10 - SatelliteQE/robottelo#17638.

### Solution
Drop Python 3.10 suport.


### Related Issues
SatelliteQE/robottelo#17638
SatelliteQE/robottelo#17666
SatelliteQE/robottelo#17557
