### PR TITLE
[6.16.z] Fixing the timing to ensure smooth host creation.

### DIFF
--- a/airgun/entities/host.py
+++ b/airgun/entities/host.py
@@ -44,7 +44,7 @@ class HostEntity(BaseEntity):
         view = self.navigate_to(self, 'New')
         view.fill(values)
         self.browser.click(view.submit, ignore_ajax=True)
-        self.browser.plugin.ensure_page_safe(timeout='600s')
+        self.browser.plugin.ensure_page_safe(timeout='800s')
         host_view = NewHostDetailsView(self.browser)
         host_view.wait_displayed()
         host_view.flash.assert_no_error()


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/airgun/pull/1776

After host creation, the page load takes time. Therefore, increasing the page load time and the wait time for puppet_sat.







