### PR TITLE
[6.17.z] Update host details bootc card to use proper locator

### DIFF
--- a/airgun/views/host_new.py
+++ b/airgun/views/host_new.py
@@ -312,7 +312,7 @@ class NewHostDetailsView(BaseLoggedInView):
         @View.nested
         class bootc(Card):
             # Will file issue for this to be fixed
-            ROOT = './/article[contains(@data-ouia-component-id, "card-template-[object Object]")]'
+            ROOT = './/article[contains(@data-ouia-component-id, "card-template-image-mode")]'
 
             remote_execution_link = Text(".//a[normalize-space(.)='Modify via remote execution']")
             details = HostDetailsCard()


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/airgun/pull/1785

Fix for this locator landed in 6.17, need to get this merged in quickly, so we can see accurate UI test results.