### PR TITLE
Extend http proxy with Test Connection button

### DIFF
--- a/airgun/entities/http_proxy.py
+++ b/airgun/entities/http_proxy.py
@@ -55,6 +55,14 @@ class HTTPProxyEntity(BaseEntity):
         view.flash.assert_no_error()
         view.flash.dismiss()
 
+    def test_connection(self, entity_name):
+        """Test connection from http-proxy"""
+        view = self.navigate_to(self, 'Edit', entity_name=entity_name)
+        view.test_button.click()
+        view.validations.assert_no_errors()
+        view.flash.assert_no_error()
+        view.flash.dismiss()
+
 
 @navigator.register(HTTPProxyEntity, 'All')
 class ShowAllHTTPProxy(NavigateStep):

--- a/airgun/views/http_proxy.py
+++ b/airgun/views/http_proxy.py
@@ -26,6 +26,7 @@ class HTTPProxyCreateView(BaseLoggedInView):
     breadcrumb = BreadCrumb()
     submit = Text('//input[@name="commit"]')
     cancel = Text('//a[normalize-space(.)="Cancel"]')
+    test_button = Text('//a[@id="test_connection_button"]')
 
     @property
     def is_displayed(self):


### PR DESCRIPTION
Just a small addition to the HTTP proxy view and entity.
Robottelo test PR follows: https://github.com/SatelliteQE/robottelo/pull/18128