### PR TITLE
added_refresh_cache_to_refresh_CP

### DIFF
--- a/airgun/entities/host.py
+++ b/airgun/entities/host.py
@@ -43,7 +43,7 @@ class HostEntity(BaseEntity):
     def create(self, values):
         """Create new host entity"""
         view = self.navigate_to(self, 'New')
-        view.fill(values)
+        wait_for(lambda: view.fill(values), timeout=60)
         self.browser.click(view.submit, ignore_ajax=True)
         self.browser.plugin.ensure_page_safe(timeout='800s')
         host_view = NewHostDetailsView(self.browser)

--- a/airgun/views/host.py
+++ b/airgun/views/host.py
@@ -222,7 +222,7 @@ class HostsView(BaseLoggedInView, SearchableViewMixinPF4):
     title = Text("//h1[normalize-space(.)='Hosts']")
     manage_columns = PF5Button('manage-columns-button')
     export = Text(".//a[contains(@class, 'btn')][contains(@href, 'hosts.csv')]")
-    new = Text(".//div[@id='rails-app-content']//a[contains(normalize-space(.),'Create Host')]")
+    new = Text(".//div[@id='foreman-page']//a[@data-ouia-component-id='create-host-button']")
     register = PF4Button('OUIA-Generated-Button-secondary-2')
     new_ui_button = Text(".//a[contains(@class, 'btn')][contains(@href, 'new/hosts')]")
     select_all = Checkbox(locator="//input[@id='check_all']")


### PR DESCRIPTION
Updated the locator for `Create Host` and increased the wait time in the `HostCreate` entity. In Azure, when a CR is passed, it takes time to reflect while creating host. To handle this delay, a `wait_for` has been added to ensure the value is retrieved correctly and the test does not fail.