### PR TITLE
Alert Fix PF4 to PF5

### DIFF
--- a/airgun/entities/all_hosts.py
+++ b/airgun/entities/all_hosts.py
@@ -375,7 +375,7 @@ class AllHostsEntity(BaseEntity):
         view.bulk_actions_kebab.click()
         # This is here beacuse there is nested flyout menu which needs to be hovered over first so we can use item_select in the next step
         self.browser.move_to_element(view.bulk_actions_menu.item_element('Manage content'))
-        view.bulk_actions.item_select('Errata')
+        view.bulk_actions_manage_content_menu.item_select('Errata')
 
         view = ManageErrataModal(self.browser)
 

--- a/airgun/widgets.py
+++ b/airgun/widgets.py
@@ -1007,19 +1007,19 @@ class SatFlashMessages(FlashMessages):
 
     Example html representation::
 
-        <ul class="pf-c-alert-group pf-m-toast"><li>
-        <div class="pf-c-alert pf-m-success foreman-toast" aria-label="Success Alert"
+        <ul class="pf-v5-c-alert-group pf-m-toast"><li>
+        <div class="pf-v5-c-alert pf-m-success foreman-toast" aria-label="Success Alert"
             data-ouia-component-type="PF4/Alert" data-ouia-safe="true"
             data-ouia-component-id="OUIA-Generated-Alert-success-1">
             <div class="pf-c-alert__icon">
 
     Locator example::
 
-        //ul[@class="pf-c-alert-group pf-m-toast"]/li/div[contains(@class, "pf-c-alert")]
+        //ul[@class=pf-v5-c-alert-group pf-m-toast"]/li/div[contains(@class, pf-v5-c-alert")]
 
     """
 
-    ROOT = '//ul[@class="pf-c-alert-group pf-m-toast"]'
+    ROOT = '//ul[@class="pf-v5-c-alert-group pf-m-toast"]'
     MSG_LOCATOR = f'{ROOT}//div[contains(@class, "foreman-toast")]'
     msg_class = SatFlashMessage
 


### PR DESCRIPTION
This PR updates `SatFlashMessages` so it corresponds to its PF5 definition.

Also, this PR fixes one `manage_errata` entity, which unblocks the test from another failure that is caused by already filed BZ.