### PR TITLE
Lowercase HTTP proxy

### DIFF
--- a/airgun/entities/product.py
+++ b/airgun/entities/product.py
@@ -81,9 +81,9 @@ class ProductEntity(BaseEntity):
         return view.read()
 
     def manage_http_proxy(self, entities_list, values):
-        """Manage HTTP Proxy for product/products
+        """Manage HTTP proxy for product/products
 
-        :param entities_list: The product names to perform Manage HTTP Proxy action.
+        :param entities_list: The product names to perform Manage HTTP proxy action.
         :param values: dict containing http_proxy_policy and http_proxy values.
             eg: {'http_proxy_policy': 'No HTTP Proxy'}, {'http_proxy_policy': 'Global Default'},
             {'http_proxy_policy': 'Use specific HTTP Proxy', 'http_proxy': 'proxy_name'}
@@ -91,7 +91,7 @@ class ProductEntity(BaseEntity):
         view = self.navigate_to(
             self,
             'Select Action',
-            action_name='Manage HTTP Proxy',
+            action_name='Manage HTTP proxy',
             entities_list=entities_list,
         )
         if values['http_proxy_policy'] == "Global Default":
@@ -208,7 +208,7 @@ class ProductsSelectAction(NavigateStep):
     """
 
     ACTIONS_VIEWS = {
-        'Manage HTTP Proxy': ProductManageHttpProxy,
+        'Manage HTTP proxy': ProductManageHttpProxy,
         'Advanced Sync': ProductAdvancedSync,
         'Verify Content Checksum': ProductVerifyContentChecksum,
     }

--- a/airgun/views/product.py
+++ b/airgun/views/product.py
@@ -246,14 +246,14 @@ class ProductSyncPlanView(SyncPlanCreateView):
 
 
 class ProductManageHttpProxy(BaseLoggedInView):
-    """Represents Http Proxy Management page for Products."""
+    """Represents Http proxy Management page for Products."""
 
-    title = Text("//h4[normalize-space(.)='Http Proxy Management']")
+    title = Text("//h4[normalize-space(.)='HTTP proxy Management']")
     http_proxy_policy = Select(id="http_proxy_policy")
     proxy_policy = ConditionalSwitchableView(reference='http_proxy_policy')
     update = Text('//button[@ng-click="update()"]')
 
-    @proxy_policy.register('Use specific HTTP Proxy')
+    @proxy_policy.register('Use specific HTTP proxy')
     class ExistingProductForm(View):
         http_proxy = Select(id="http_proxy")
 

--- a/airgun/views/repository.py
+++ b/airgun/views/repository.py
@@ -74,7 +74,7 @@ class RepositoryCreateView(BaseLoggedInView):
         ssl_client_cert = Select(id='ssl_client_cert_id')
         ssl_client_key = Select(id='ssl_client_key_id')
 
-        @proxy_policy.register('Use specific HTTP Proxy')
+        @proxy_policy.register('Use specific HTTP proxy')
         class SpecificHttpProxy(View):
             http_proxy = Select(id="http_proxy")
 
@@ -93,7 +93,7 @@ class RepositoryCreateView(BaseLoggedInView):
         ssl_client_cert = Select(id='ssl_client_cert_id')
         ssl_client_key = Select(id='ssl_client_key_id')
 
-        @proxy_policy.register('Use specific HTTP Proxy')
+        @proxy_policy.register('Use specific HTTP proxy')
         class SpecificHttpProxy(View):
             http_proxy = Select(id="http_proxy")
 
@@ -108,7 +108,7 @@ class RepositoryCreateView(BaseLoggedInView):
         http_proxy_policy = Select(id="http_proxy_policy")
         proxy_policy = ConditionalSwitchableView(reference='http_proxy_policy')
 
-        @proxy_policy.register('Use specific HTTP Proxy')
+        @proxy_policy.register('Use specific HTTP proxy')
         class SpecificHttpProxy(View):
             http_proxy = Select(id="http_proxy")
 
@@ -135,7 +135,7 @@ class RepositoryCreateView(BaseLoggedInView):
         http_proxy_policy = Select(id="http_proxy_policy")
         proxy_policy = ConditionalSwitchableView(reference='http_proxy_policy')
 
-        @proxy_policy.register('Use specific HTTP Proxy')
+        @proxy_policy.register('Use specific HTTP proxy')
         class SpecificHttpProxy(View):
             http_proxy = Select(id="http_proxy")
 
@@ -160,7 +160,7 @@ class RepositoryCreateView(BaseLoggedInView):
         http_proxy_policy = Select(id="http_proxy_policy")
         proxy_policy = ConditionalSwitchableView(reference='http_proxy_policy')
 
-        @proxy_policy.register('Use specific HTTP Proxy')
+        @proxy_policy.register('Use specific HTTP proxy')
         class SpecificHttpProxy(View):
             http_proxy = Select(id="http_proxy")
 
@@ -182,7 +182,7 @@ class RepositoryCreateView(BaseLoggedInView):
         ssl_client_cert = Select(id='ssl_client_cert_id')
         ssl_client_key = Select(id='ssl_client_key_id')
 
-        @proxy_policy.register('Use specific HTTP Proxy')
+        @proxy_policy.register('Use specific HTTP proxy')
         class SpecificHttpProxy(View):
             http_proxy = Select(id="http_proxy")
 
@@ -232,7 +232,7 @@ class RepositoryEditView(BaseLoggedInView):
         repo_name = ReadOnlyEntry(name='Name')
         verify_ssl = EditableEntryCheckbox(name='Verify SSL')
         upstream_authorization = AuthorizationEntry(name='Upstream Authorization')
-        http_proxy_policy = EditableEntrySelect(name='HTTP Proxy')
+        http_proxy_policy = EditableEntrySelect(name='HTTP proxy')
         proxy_policy = ConditionalSwitchableView(reference='http_proxy_policy')
         mirroring_policy = EditableEntrySelect(name='Mirroring Policy')
         include_tags = EditableEntry(name='Include Tags')
@@ -251,7 +251,7 @@ class RepositoryEditView(BaseLoggedInView):
         upstream_authorization = AuthorizationEntry(name='Upstream Authorization')
         metadata_type = EditableEntrySelect(name='Yum Metadata Checksum')
         retain_package_versions = EditableEntry(name='Retain package versions')
-        http_proxy_policy = EditableEntrySelect(name='HTTP Proxy')
+        http_proxy_policy = EditableEntrySelect(name='HTTP proxy')
         ignore_srpms = EditableEntryCheckbox(name='Ignore SRPMs')
         unprotected = EditableEntryCheckbox(name='Unprotected')
         gpg_key = EditableEntrySelect(name='GPG Key')
@@ -274,7 +274,7 @@ class RepositoryEditView(BaseLoggedInView):
         upstream_authorization = AuthorizationEntry(name='Upstream Authorization')
         upload_content = FileInput(name='content[]')
         upload = Text("//button[contains(., 'Upload')]")
-        http_proxy_policy = EditableEntrySelect(name='HTTP Proxy')
+        http_proxy_policy = EditableEntrySelect(name='HTTP proxy')
         proxy_policy = ConditionalSwitchableView(reference='http_proxy_policy')
         mirroring_policy = EditableEntrySelect(name='Mirroring Policy')
 
@@ -288,7 +288,7 @@ class RepositoryEditView(BaseLoggedInView):
         verify_ssl = EditableEntryCheckbox(name='Verify SSL')
         upstream_authorization = AuthorizationEntry(name='Upstream Authorization')
         published_at = ReadOnlyEntry(name='Published At')
-        http_proxy_policy = EditableEntrySelect(name='HTTP Proxy')
+        http_proxy_policy = EditableEntrySelect(name='HTTP proxy')
         proxy_policy = ConditionalSwitchableView(reference='http_proxy_policy')
 
         @proxy_policy.register(True, default=True)


### PR DESCRIPTION
In 6.17 the HTTP proxy was generally lower-cased, which makes related UI tests to fail.

This PR updates the related views.