### PR TITLE
[6.17.z] wait_to_success_job_task

### DIFF
--- a/airgun/entities/job_invocation.py
+++ b/airgun/entities/job_invocation.py
@@ -93,7 +93,7 @@ class JobInvocationEntity(BaseEntity):
         wait_for(lambda: view.overview.hosts_table.is_displayed, timeout=10)
         view.overview.hosts_table.row(host=host_name)['Actions'].widget.fill('Host task')
         view = TaskDetailsView(self.browser)
-        wait_for(lambda: view.task.dynflow_console.is_displayed, timeout=10)
+        view.wait_for_result()
         view.task.dynflow_console.click()
         self.browser.switch_to_window(self.browser.window_handles[1])
         console = DynflowConsoleView(self.browser)


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/airgun/pull/1801

The page is not loading in time, and that is why unable to click `Dynflow console` button.
Because the button doesn't appear until the page reloads properly.

To avoid this, it will wait until the task result is successful.

 