### PR TITLE
confirm modal for PF5

### DIFF
--- a/airgun/browser.py
+++ b/airgun/browser.py
@@ -19,7 +19,11 @@ from widgetastic.exceptions import NoAlertPresentException, NoSuchElementExcepti
 import yaml
 
 from airgun import settings
-from airgun.widgets import ConfirmationDialog, Pf4ConfirmationDialog
+from airgun.widgets import (
+    ConfirmationDialog,
+    Pf4ConfirmationDialog,
+    Pf5ConfirmationDialog,
+)
 
 LOGGER = logging.getLogger(__name__)
 
@@ -453,8 +457,13 @@ class AirgunBrowser(Browser):
             :py:class:`selenium.common.exceptions.NoAlertPresentException`
         """
         pf4_modal_locator = "//div[@data-ouia-component-type='PF4/ModalContent']"
+        pf5_modal_locator = "//div[@data-ouia-component-type='PF5/ModalContent']"
         modal_locator = "//div[@class='modal-content']"
-        modal_map = {pf4_modal_locator: Pf4ConfirmationDialog, modal_locator: ConfirmationDialog}
+        modal_map = {
+            pf4_modal_locator: Pf4ConfirmationDialog,
+            modal_locator: ConfirmationDialog,
+            pf5_modal_locator: Pf5ConfirmationDialog,
+        }
         if not self.handles_alerts:
             return None
         try:
@@ -478,7 +487,7 @@ class AirgunBrowser(Browser):
     ):
         """Extend the behaviour of widgetstatic.browser.handle_alert to handle PF4 alerts"""
         popup = self.get_alert(squash=squash)
-        if isinstance(popup, Pf4ConfirmationDialog | ConfirmationDialog):
+        if isinstance(popup, Pf4ConfirmationDialog | ConfirmationDialog | Pf5ConfirmationDialog):
             if cancel:
                 self.logger.info("  dismissing")
                 popup.cancel()

--- a/airgun/widgets.py
+++ b/airgun/widgets.py
@@ -38,6 +38,9 @@ from widgetastic_patternfly4.ouia import (
 )
 from widgetastic_patternfly4.progress import Progress as PF4Progress
 from widgetastic_patternfly4.table import BaseExpandableTable, BasePatternflyTable
+from widgetastic_patternfly5.ouia import (
+    Button as PF5OUIAButton,
+)
 
 from airgun.exceptions import DisabledWidgetError, ReadOnlyWidgetError
 from airgun.utils import get_widget_by_name
@@ -1414,6 +1417,16 @@ class Pf4ConfirmationDialog(ConfirmationDialog):
     confirm_dialog = OUIAButton('btn-modal-confirm')
     cancel_dialog = OUIAButton('btn-modal-cancel')
     discard_dialog = OUIAButton('app-confirm-modal-ModalBoxCloseButton')
+
+
+class Pf5ConfirmationDialog(ConfirmationDialog):
+    """PF5 confirmation dialog with two buttons and close 'x' button in the
+    right corner."""
+
+    ROOT = '//div[@id="app-confirm-modal" or @data-ouia-component-type="PF5/ModalContent"]'
+    confirm_dialog = PF5OUIAButton('btn-modal-confirm')
+    cancel_dialog = PF5OUIAButton('btn-modal-cancel')
+    discard_dialog = PF5OUIAButton('app-confirm-modal-ModalBoxCloseButton')
 
 
 class LCESelector(GenericLocatorWidget):


### PR DESCRIPTION
Airgun needs to recognize the deletion confirmation modal in PF5, affects a bunch of tests that delete stuff in the UI 