### PR TITLE
hostgroups: PF5 update & navigation improvements

### DIFF
--- a/airgun/entities/hostgroup.py
+++ b/airgun/entities/hostgroup.py
@@ -43,7 +43,6 @@ class HostGroupEntity(BaseEntity):
         """Read values from host group edit page"""
         view = self.navigate_to(self, 'Edit', entity_name=entity_name)
         value = view.read(widget_names=widget_names)
-        view.submit.click()
         return value
 
     def read_all(self):
@@ -67,6 +66,7 @@ class HostGroupEntity(BaseEntity):
         view.submit.click()
         view.flash.assert_no_error()
         view.flash.dismiss()
+        self.browser.plugin.ensure_page_safe()
 
     def total_no_of_assigned_role(self, entity_name):
         """Count of assigned role to the host group"""
@@ -113,6 +113,7 @@ class ShowAllHostGroups(NavigateStep):
     @retry_navigation
     def step(self, *args, **kwargs):
         self.view.menu.select('Configure', 'Host Groups')
+        self.view.wait_displayed()
 
 
 @navigator.register(HostGroupEntity, 'New')
@@ -128,6 +129,7 @@ class AddNewHostGroup(NavigateStep):
             self.parent.new.click()
         except NoSuchElementException:
             self.parent.new_on_blank_page.click()
+        self.view.wait_displayed()
 
 
 @navigator.register(HostGroupEntity, 'Edit')
@@ -147,3 +149,4 @@ class EditHostGroup(NavigateStep):
         entity_name = kwargs.get('entity_name')
         self.parent.search(entity_name)
         self.parent.table.row(name=entity_name)['Name'].widget.click()
+        self.view.wait_displayed()

--- a/airgun/views/hostgroup.py
+++ b/airgun/views/hostgroup.py
@@ -1,7 +1,7 @@
 from widgetastic.widget import ConditionalSwitchableView, Table, Text, TextInput, View
 from widgetastic_patternfly import BreadCrumb
-from widgetastic_patternfly4 import Button as PF4Button, Pagination as PF4Pagination
 from widgetastic_patternfly4.ouia import Select as OUIASelect
+from widgetastic_patternfly5 import Button as PF5Button, Pagination as PF5Pagination
 
 from airgun.views.common import BaseLoggedInView, SatTab, SearchableViewMixinPF4
 from airgun.widgets import (
@@ -32,7 +32,7 @@ class HostGroupsView(BaseLoggedInView, SearchableViewMixinPF4):
         "//h1[contains(., 'Host Group Configuration') or normalize-space(.)='Host Groups']"
     )
     new = Text("//a[contains(@href, '/hostgroups/new')]")
-    new_on_blank_page = PF4Button('Create Host Group')
+    new_on_blank_page = PF5Button('Create Host Group')
     table = Table(
         './/table',
         column_widgets={
@@ -43,9 +43,10 @@ class HostGroupsView(BaseLoggedInView, SearchableViewMixinPF4):
 
     @property
     def is_displayed(self):
-        return self.browser.wait_for_element(
+        page_loaded = self.browser.wait_for_element(
             self.title, exception=False
-        ) is not None and self.browser.url.endswith('hostgroups')
+        ) or self.browser.wait_for_element(self.new_on_blank_page, exception=False)
+        return page_loaded and self.browser.url.endswith('hostgroups')
 
 
 class HostGroupCreateView(BaseLoggedInView):
@@ -81,7 +82,7 @@ class HostGroupCreateView(BaseLoggedInView):
     class ansible_roles(SatTab):
         TAB_NAME = 'Ansible Roles'
         resources = MultiSelectNoFilter(id='ansible_roles')
-        pagination = PF4Pagination()
+        pagination = PF5Pagination()
 
     @View.nested
     class puppet_enc(SatTab):
@@ -158,4 +159,4 @@ class HostGroupEditView(HostGroupCreateView):
         no_of_available_role = Text('//span[@class="pf-c-options-menu__toggle-text"]//b[2]')
         resources = MultiSelectNoFilter(id='ansible_roles')
         submit = Text('//input[@name="commit"]')
-        pagination = PF4Pagination()
+        pagination = PF5Pagination()


### PR DESCRIPTION
*** hostgroups: PF5 update & navigation improvements

Requires https://github.com/SatelliteQE/airgun/pull/1812

PatternFly5 updates for the host groups pages.

Additional changes:
- several `view.wait_displayed()` added for more reliable page loading
- Host Groups page now also expects if no host groups are present
- `hostgroup.read()` no longer submits the form
   - it can cause to submit unintentional data (not likely, but still)
   - it prolongs the test time as new page needs to load
   - the navigation can clash with actions chains like `read() && update(...)`
     where `read()` submitted the form while `update()` expects to interact with the page immediately

*** PRT Example
```
trigger: test-robottelo
pytest: tests/foreman/ui/test_hostgroup.py -k test_positive_end_to_end
airgun: 1812
```
