### PR TITLE
Update Capsule with PF5

### DIFF
--- a/airgun/entities/capsule.py
+++ b/airgun/entities/capsule.py
@@ -310,7 +310,7 @@ class CapsuleEntity(BaseEntity):
 
 
 @navigator.register(CapsuleEntity, 'Capsules')
-class OpenAcsPage(NavigateStep):
+class OpenCapsulesPage(NavigateStep):
     """Navigate to the Capsules page"""
 
     VIEW = CapsulesView

--- a/airgun/entities/capsule.py
+++ b/airgun/entities/capsule.py
@@ -297,11 +297,13 @@ class CapsuleEntity(BaseEntity):
         view = CapsuleDetailsView(self.browser)
         view.wait_displayed()
         if not cv_name:
+            view.content.top_content_table.row(Environment=lce_name)[3].click()
             view.content.top_content_table.row(Environment=lce_name)[3].widget.item_select(
                 'Refresh counts'
             )
         else:
             view.content.top_content_table.row(Environment=lce_name)[0].click()
+            view.content.mid_content_table.row(content_view=cv_name)[5].click()
             view.content.mid_content_table.row(content_view=cv_name)[5].widget.item_select(
                 'Refresh counts'
             )

--- a/airgun/views/capsule.py
+++ b/airgun/views/capsule.py
@@ -8,12 +8,18 @@ from widgetastic.widget import (
 )
 from widgetastic_patternfly import BreadCrumb, Button
 from widgetastic_patternfly4 import (
-    Dropdown,
     Pagination,
 )
 from widgetastic_patternfly4.ouia import (
     Button as OUIAButton,
-    ExpandableTable,
+)
+from widgetastic_patternfly5 import (
+    Button as PF5Button,
+    Menu as PF5Menu,
+    Pagination as PF5Pagination,
+)
+from widgetastic_patternfly5.ouia import (
+    ExpandableTable as PF5ExpandableTable,
 )
 
 from airgun.views.common import (
@@ -26,12 +32,12 @@ from airgun.widgets import (
     FilteredDropdown,
     ItemsList,
     MultiSelect,
-    Pf4ConfirmationDialog,
+    Pf5ConfirmationDialog,
     SatTable,
 )
 
 
-class DeleteCapsuleConfirmationDialog(Pf4ConfirmationDialog):
+class DeleteCapsuleConfirmationDialog(Pf5ConfirmationDialog):
     confirm_dialog = OUIAButton('btn-modal-confirm')
     cancel_dialog = OUIAButton('btn-modal-cancel')
 
@@ -173,17 +179,17 @@ class CapsuleDetailsView(BaseLoggedInView):
     class content(SatTab):
         TAB_NAME = 'Content'
 
-        top_content_table = ExpandableTable(
+        top_content_table = PF5ExpandableTable(
             component_id='capsule-content-table',
             column_widgets={
-                0: Button(locator='./button[@aria-label="Details"]'),
+                0: PF5Button(locator='./button[@aria-label="Details"]'),
                 'Environment': Text('./a'),
                 'Last sync': Text('./span[contains(@class, "pf-c-label ")]'),
-                3: Dropdown(locator='.//div[contains(@class, "pf-c-dropdown")]'),
+                3: PF5Menu(locator='.//div[contains(@class, "pf-v5-c-menu")]'),
             },
         )
 
-        mid_content_table = ExpandableTable(
+        mid_content_table = PF5ExpandableTable(
             component_id='expandable-content-views',
             column_widgets={
                 0: Button(locator='./button[@aria-label="Details"]'),
@@ -191,7 +197,7 @@ class CapsuleDetailsView(BaseLoggedInView):
                 'Version': Text('./a'),
                 'Last published': Text('./span'),
                 'Synced': Text('./svg'),
-                5: Dropdown(locator='.//div[contains(@class, "pf-c-dropdown")]'),
+                5: PF5Menu(locator='.//div[contains(@class, "pf-v5-c-menu")]'),
             },
         )
 
@@ -268,7 +274,7 @@ class CapsulesView(BaseLoggedInView, SearchableViewMixinPF4):
             'Actions': ActionsDropdown('./div[contains(@class, "btn-group")]'),
         },
     )
-    pagination = Pagination()
+    pagination = PF5Pagination()
 
     @property
     def is_displayed(self):


### PR DESCRIPTION
This PR proposes a PF5 update for the Capsule view, mainly for the Content tab - the current state does not read the content page at all, this PR should fix it.

~The only thing I was not able to get working in PF5 is the refresh `Dropdown` click-ability. A call like `session.capsule.refresh_lce_counts(module_capsule_configured.hostname, lce_name='Library')` should expand the kebab and click on `Refresh counts`. Any help here is appreciated.~