### PR TITLE
Alter CloudInv Read Entity

### DIFF
--- a/airgun/entities/cloud_inventory.py
+++ b/airgun/entities/cloud_inventory.py
@@ -15,6 +15,13 @@ class CloudInventoryEntity(BaseEntity):
             result.update(view.inventory_list.read())
         return result
 
+    def read_org(self, org_name):
+        """Read organization details from the inventory list."""
+        view = self.navigate_to(self, 'All')
+        view.inventory_list.toggle(org_name)
+        result = view.inventory_list.read()
+        return result
+
     def get_displayed_settings_options(self):
         """Get displayed settings options on Red Hat Inventory page"""
         view = self.navigate_to(self, 'All')

--- a/airgun/views/cloud_inventory.py
+++ b/airgun/views/cloud_inventory.py
@@ -41,7 +41,7 @@ class InventoryItemsView(Accordion):
     @View.nested
     class generating(InventoryTab):
         process = Text('.//div[contains(@class, "tab-header")]/div[1]')
-        restart = Button('Generate and upload report')
+        restart = Button('contains', 'Generate')
         terminal = Text(
             './/div[contains(@class, "report-generate")]//div[contains(@class, "terminal")]'
         )
@@ -89,15 +89,24 @@ class InventoryItemsView(Accordion):
             self.click()
 
     def read(self, widget_names=None):
-        return {
+
+        final_dict = {
             'generating': self.generating.read(),
-            'uploading': self.uploading.read(),
+            'uploading': self.uploading.read() if self.uploading.is_displayed else None,
             'status': self.status,
-            'auto_update': self.parent.auto_update.read(),
+            'auto_update': (
+                self.parent.auto_update.read() if self.parent.auto_update.is_displayed else None
+            ),
             'obfuscate_hostnames': self.parent.obfuscate_hostnames.read(),
             'obfuscate_ips': self.parent.obfuscate_ips.read(),
             'exclude_packages': self.parent.exclude_packages.read(),
         }
+        # Remove 'uploading' if not displayed (based on SubscriptionConnectionSetting)
+        if not self.uploading.is_displayed:
+            final_dict.pop('uploading')
+        if not self.parent.auto_update.is_displayed:
+            final_dict.pop('auto_update')
+        return final_dict
 
     def fill(self, values):
         raise ReadOnlyWidgetError('View is read only, fill is prohibited')


### PR DESCRIPTION
This PR adds `read_org` entity and changes the default `read` entity so it does not fail when some element is not present.
Needed by: TODO