### PR TITLE
updates to new host views

### DIFF
--- a/airgun/views/host_new.py
+++ b/airgun/views/host_new.py
@@ -344,7 +344,7 @@ class NewHostDetailsView(BaseLoggedInView):
             )
             status_filter = Dropdown(locator='.//div[@aria-label="select Status container"]/div')
             upgrade = Pf4ActionsDropdown(locator='.//div[div/button[normalize-space(.)="Upgrade"]]')
-            dropdown = Dropdown(locator='.//div[button[@aria-label="bulk_actions"]]')
+            dropdown = PF5Dropdown(locator='.//div[button[@aria-label="bulk_actions"]]')
 
             table = PatternflyTable(
                 component_id="host-packages-table",
@@ -394,12 +394,14 @@ class NewHostDetailsView(BaseLoggedInView):
             # workaround for BZ 2119076
             ROOT = './/div[@id="modulestreams-tab"]'
 
-            searchbar = SearchInput(locator='.//input[contains(@class, "pf-m-search")]')
+            searchbar = SearchInput(
+                locator='.//input[contains(@class, "pf-v5-c-text-input-group__text-input")]'
+            )
             status_filter = Select(locator='.//div[@aria-label="select Status container"]/div')
             installation_status_filter = Select(
                 locator='.//div[@aria-label="select Installation status container"]/div'
             )
-            dropdown = Dropdown(locator='.//div[button[@aria-label="bulk_actions"]]')
+            dropdown = PF5Dropdown(locator='.//div[button[@aria-label="bulk_actions"]]')
 
             table = Table(
                 locator='.//table[@aria-label="Content View Table"]',
@@ -722,7 +724,9 @@ class InstallPackagesView(View):
     ROOT = './/div[@id="package-install-modal"]'
 
     select_all = Checkbox(locator='.//div[@id="selection-checkbox"]/div/label')
-    searchbar = SearchInput(locator='.//input[contains(@class, "pf-m-search")]')
+    searchbar = SearchInput(
+        locator='.//input[contains(@class, "pf-v5-c-text-input-group__text-input")]'
+    )
 
     table = Table(
         locator='.//table[@aria-label="Content View Table"]',


### PR DESCRIPTION
PF5 related changes, prt not avialable right now as the related tests also need amendments on the robottelo side that are in progress

## Summary by Sourcery

Migrate host-related views to PatternFly 5 by updating component classes and locators.

Enhancements:
- Replace generic Dropdown with PF5Dropdown for bulk actions in host packages and module streams tabs
- Update SearchInput locators to use PF5 text input class in module streams and install packages modal