### PR TITLE
update locator and pf5 changes

### DIFF
--- a/airgun/views/ansible_role.py
+++ b/airgun/views/ansible_role.py
@@ -1,10 +1,10 @@
 from widgetastic.widget import Checkbox, Table, Text
 from widgetastic_patternfly import BreadCrumb
-from widgetastic_patternfly4 import (
-    Button,
-    CompactPagination,
-    Pagination as PF4Pagination,
-    PatternflyTable,
+from widgetastic_patternfly5 import (
+    Button as PF5button,
+    CompactPagination as PF5CompactPagination,
+    Pagination as PF5Pagination,
+    PatternflyTable as PF5PatternflyTable,
 )
 
 from airgun.views.common import BaseLoggedInView, SearchableViewMixin
@@ -18,7 +18,7 @@ class AnsibleRolesView(BaseLoggedInView, SearchableViewMixin):
 
     title = Text("//h1[contains(normalize-space(.),'Ansible Roles')]")
     import_button = Text("//a[contains(@href, '/ansible_roles/import')]")
-    submit = Button('Submit')
+    submit = PF5button('Submit')
     total_imported_roles = Text("//span[@class='pf-c-options-menu__toggle-text']//b[2]")
     table = Table(
         './/table',
@@ -26,7 +26,7 @@ class AnsibleRolesView(BaseLoggedInView, SearchableViewMixin):
             'Actions': ActionsDropdown("./div[contains(@class, 'btn-group')]"),
         },
     )
-    pagination = PF4Pagination()
+    pagination = PF5Pagination()
 
     @property
     def is_displayed(self):
@@ -39,7 +39,7 @@ class AnsibleRolesImportView(BaseLoggedInView):
     breadcrumb = BreadCrumb()
     total_available_roles = Text("//span[@class='pf-c-options-menu__toggle-text']/b[2]")
     select_all = Checkbox(locator="//input[@id='select-all']")
-    table = PatternflyTable(
+    table = PF5PatternflyTable(
         component_id='OUIA-Generated-Table-2',
         column_widgets={
             0: Checkbox(locator='.//input[@type="checkbox"]'),
@@ -48,9 +48,9 @@ class AnsibleRolesImportView(BaseLoggedInView):
     roles = Text("//table[contains(@class, 'pf-c-table')]")
     dropdown = Text("//button[contains(@class, 'pf-c-options-menu')]")
     max_per_pg = Text("//ul[contains(@class, 'pf-c-options-menu')]/li[6]")
-    pagination = CompactPagination()
-    submit = Button('Submit')
-    cancel = Button('Cancel')
+    pagination = PF5CompactPagination()
+    submit = PF5button('Submit')
+    cancel = PF5button('Cancel')
 
     @property
     def is_displayed(self):

--- a/airgun/views/computeresource.py
+++ b/airgun/views/computeresource.py
@@ -295,13 +295,13 @@ class ComputeResourceVMwareProfileControllerVolumeItem(GenericRemovableWidgetIte
     """VMware Compute Resource Profile "Storage Controller Volume" item widget"""
 
     storage_pod = FilteredDropdown(
-        locator=".//div[label[contains(., 'Storage Pod')]]//div[contains(@class, 'form-control')]"
+        locator=".//div[label[contains(., 'Storage Pod')]]//select[contains(@class, 'form-control')]"
     )
     data_store = FilteredDropdown(
-        locator=".//div[label[contains(., 'Data store')]]//div[contains(@class, 'form-control')]"
+        locator=".//div[label[contains(., 'Data store')]]//select[contains(@class, 'form-control')]"
     )
     disk_mode = FilteredDropdown(
-        locator=".//div[label[contains(., 'Disk Mode')]]//div[contains(@class, 'form-control')]"
+        locator=".//div[label[contains(., 'Disk Mode')]]//select[contains(@class, 'form-control')]"
     )
     size = TextInput(locator=".//div[label[contains(., 'Size')]]//input")
     thin_provision = Checkbox(locator=".//div[label[contains(., 'Thin provision')]]/div/input")
@@ -323,7 +323,7 @@ class ComputeResourceVMwareProfileStorageItem(GenericRemovableWidgetItem):
     """VMware  Compute Resource Profile Storage Controller item widget"""
 
     controller = FilteredDropdown(
-        locator=".//div[@class='controller-header']//div[contains(@class, 'form-control')]"
+        locator=".//div[@class='controller-header']//select[contains(@class, 'form-control')]"
     )
     remove_button = Text(".//button[contains(concat(' ', @class, ' '), ' btn-remove-controller ')]")
     disks = ComputeResourceVMwareProfileControllerVolumeList()

--- a/airgun/widgets.py
+++ b/airgun/widgets.py
@@ -512,8 +512,8 @@ class MultiSelectNoFilter(MultiSelect):
     they will be stored in a list. Unassigned items contains the list which compare with the values,
     if value is present it will assign the value or vise-versa."""
 
-    more_item = Text('//span[@class="pf-c-options-menu__toggle-button-icon"]')
-    select_pages = Text('//ul[@class="pf-c-options-menu__menu"]/li[6]/button')
+    more_item = Text('//span[@class="pf-v5-c-menu-toggle__toggle-icon"]')
+    select_pages = Text('//ul[@class="pf-v5-c-menu__list"]/li[6]/button')
     available_role_template = '//div[@class="available-roles-container col-sm-6"]/div[2]/div'
     assigned_role_template = '//div[@class="assigned-roles-container col-sm-6"]/div[2]/div'
 


### PR DESCRIPTION
update locator for below compute profile field with PF5 change-

1. controller
2. storage_pod
3. data_store
4. disk_mode

Dependent PR: https://github.com/SatelliteQE/robottelo/pull/18162

## Summary by Sourcery

Adapt UI components and locators to PatternFly 5 by updating widgets and selectors across Ansible roles views, compute resource profile fields, and multi-select menus.

Enhancements:
- Replace PF4 buttons, pagination, and table components with PF5 equivalents in AnsibleRolesView and AnsibleRolesImportView.
- Update compute resource VMware profile dropdown locators for controller, storage_pod, data_store, and disk_mode to target select elements.
- Adjust MultiSelectNoFilter widget locators for PF5 menu toggle icon and menu list classes.