### PR TITLE
Add view and entities for Flatpak Remotes

### DIFF
--- a/airgun/entities/flatpak.py
+++ b/airgun/entities/flatpak.py
@@ -1,0 +1,91 @@
+from airgun.entities.base import BaseEntity
+from airgun.navigation import NavigateStep, navigator
+from airgun.views.flatpak import FlatpakRemotesView
+
+
+class FlatpakRemotesEntity(BaseEntity):
+    """Entity for Flatpak remotes."""
+
+    endpoint_path = '/flatpak_remotes'
+
+    def search(self, value):
+        """Search for Flatpak remote in the table.
+
+        :param str value: search query to type into search field.
+        :return: list of table rows that match the search query
+        :rtype: list
+        """
+        view = self.navigate_to(self, 'All')
+        view.wait_displayed()
+        return view.search(value)
+
+    def read(self, widget_names=None):
+        """Read all values for widgets in the view.
+
+        :param list widget_names: list of widgets to read
+        :return: dict of widget names and their values
+        :rtype: dict
+        """
+        view = self.navigate_to(self, 'All')
+        view.wait_displayed()
+        return view.read(widget_names=widget_names)
+
+    def read_table(self):
+        """Read the table of Flatpak remotes.
+
+        :return: list of table rows
+        :rtype: list
+        """
+        view = self.navigate_to(self, 'All')
+        view.wait_displayed()
+        return view.table.read()
+
+    def scan(self, entity_name):
+        """Scan a Flatpak remote.
+
+        :param str entity_name: name of the remote to scan
+        """
+        view = self.navigate_to(self, 'All')
+        view.wait_displayed()
+        view.table.row(name=entity_name)[2].click()
+        view.table.row(name=entity_name)[2].widget.item_select('Scan')
+        view.flash.assert_no_error()
+        view.flash.dismiss()
+
+    def edit(self, entity_name, values):
+        """Edit a Flatpak remote.
+
+        :param str entity_name: name of the remote to edit
+        :param dict values: values to update the remote with
+        """
+        view = self.navigate_to(self, 'All')
+        view.wait_displayed()
+        view.table.row(name=entity_name)[2].click()
+        view.table.row(name=entity_name)[2].widget.item_select('Edit')
+        view.fill(values)
+        view.submit.click()
+        view.flash.assert_no_error()
+        view.flash.dismiss()
+
+    def delete(self, entity_name):
+        """Delete a Flatpak remote.
+
+        :param str entity_name: name of the remote to delete
+        """
+        view = self.navigate_to(self, 'All')
+        view.wait_displayed()
+        view.table.row(name=entity_name)[2].click()
+        view.table.row(name=entity_name)[2].widget.item_select('Delete')
+        self.browser.handle_alert()
+        view.flash.assert_no_error()
+        view.flash.dismiss()
+
+
+@navigator.register(FlatpakRemotesEntity, 'All')
+class ShowAllFlatpakRemotes(NavigateStep):
+    """Navigate to All Flatpak Remotes page."""
+
+    VIEW = FlatpakRemotesView
+
+    def step(self, *args, **kwargs):
+        self.view.menu.select('Content', 'Flatpak Remotes')

--- a/airgun/session.py
+++ b/airgun/session.py
@@ -42,6 +42,7 @@ from airgun.entities.errata import ErrataEntity
 from airgun.entities.fact_value import FactValueEntity
 from airgun.entities.file import FilesEntity
 from airgun.entities.filter import FilterEntity
+from airgun.entities.flatpak import FlatpakRemotesEntity
 from airgun.entities.global_parameter import GlobalParameterEntity
 from airgun.entities.hardware_model import HardwareModelEntity
 from airgun.entities.host import HostEntity
@@ -475,6 +476,11 @@ class Session:
     def factvalue(self):
         """Instance of Fact Value entity."""
         return self._open(FactValueEntity)
+
+    @cached_property
+    def flatpak_remotes(self):
+        """Instance of Flatpak Remotes entity."""
+        return self._open(FlatpakRemotesEntity)
 
     @cached_property
     def filter(self):

--- a/airgun/views/flatpak.py
+++ b/airgun/views/flatpak.py
@@ -1,0 +1,36 @@
+from widgetastic.widget import Text
+from widgetastic_patternfly5 import (
+    Menu as PF5Menu,
+    Pagination,
+)
+from widgetastic_patternfly5.ouia import (
+    PatternflyTable as PF5OUIATable,
+)
+
+from airgun.views.common import BaseLoggedInView, SearchableViewMixinPF4
+
+
+class FlatpakRemotesView(BaseLoggedInView, SearchableViewMixinPF4):
+    """View for the Flatpak Remotes page"""
+
+    title = Text("//h1[normalize-space(.)='Flatpak Remotes']")
+
+    table_loading = Text("//h5[normalize-space(.)='Loading']")
+    no_results = Text("//h5[normalize-space(.)='No Results']")
+
+    table = PF5OUIATable(
+        component_id='flatpak-remotes-table',
+        column_widgets={
+            'Name': Text('./a'),
+            'URL': Text('./a'),
+            2: PF5Menu(locator='.//div[contains(@class, "pf-v5-c-menu")]'),
+        },
+    )
+    pagination = Pagination()
+
+    @property
+    def is_displayed(self):
+        return (
+            self.browser.wait_for_element(self.table_loading, exception=False) is None
+            and self.browser.wait_for_element(self.table, exception=False) is not None
+        )


### PR DESCRIPTION
In 6.18.0 we are adding UI support for Flatpak. Initial is the Content > Flatpak Remotes page, which this PR aims to cover.

As of now, the Scan, Edit and Delete actions are not implemented yet in Katello, but they are to be added soon.

Robottelo companion PR: https://github.com/SatelliteQE/robottelo/pull/18419