### PR TITLE
fix CVE Reassign PF4->PF5

### DIFF
--- a/airgun/entities/all_hosts.py
+++ b/airgun/entities/all_hosts.py
@@ -119,7 +119,7 @@ class AllHostsEntity(BaseEntity):
         view.select_all.fill(True)
         view.bulk_actions_kebab.click()
         self.browser.move_to_element(view.bulk_actions_menu.item_element('Manage content'))
-        view.bulk_actions.item_select('Content view environments')
+        view.bulk_actions_manage_content_menu.item_select('Content view environments')
         view = ManageCVEModal(self.browser)
         view.lce_selector.fill({lce: True})
         view.content_source_select.item_select(cv)

--- a/airgun/views/all_hosts.py
+++ b/airgun/views/all_hosts.py
@@ -22,7 +22,7 @@ from widgetastic_patternfly5.ouia import (
 
 from airgun.views.common import (
     BaseLoggedInView,
-    PF4LCESelectorGroup,
+    PF5LCESelectorGroup,
     SearchableViewMixinPF4,
     WizardStepView,
 )
@@ -47,20 +47,18 @@ class AllHostsMenu(PF5Menu):
 
 
 class CVESelect(Select):
-    BUTTON_LOCATOR = ".//button[@aria-label='Options menu']"
-    ITEMS_LOCATOR = ".//ul[contains(@class, 'pf-c-select__menu')]/li"
-    ITEM_LOCATOR = (
-        "//*[contains(@class, 'pf-c-select__menu-item') and .//*[contains(normalize-space(.), {})]]"
-    )
-    SELECTED_ITEM_LOCATOR = ".//span[contains(@class, 'ins-c-conditional-filter')]"
-    TEXT_LOCATOR = ".//div[contains(@class, 'pf-c-select') and child::button]"
-    DEFAULT_LOCATOR = (
-        './/div[contains(@class, "pf-c-select") and @data-ouia-component-id="select-content-view"]'
-    )
+    BUTTON_LOCATOR = './/button[@aria-label="Options menu"]'
+    ITEMS_LOCATOR = './/ul[contains(@class, "pf-v5-c-select__menu")]/li'
+    ITEM_LOCATOR = '//*[contains(@class, "pf-v5-c-select__menu-item") and .//*[contains(normalize-space(.), {})]]'
+    SELECTED_ITEM_LOCATOR = './/span[contains(@class, "ins-c-conditional-filter")]'
+    TEXT_LOCATOR = './/div[contains(@class, "pf-v5-c-select") and child::button]'
+    DEFAULT_LOCATOR = './/div[contains(@class, "pf-v5-c-select") and @data-ouia-component-id="select-content-view"]'
 
 
 class AllHostsTableView(BaseLoggedInView, SearchableViewMixinPF4):
     title = Text("//h1[normalize-space(.)='Hosts']")
+
+    legacy_kebab = PF5Dropdown(locator='.//div[@id="legacy-ui-kebab"]')
     select_all = Checkbox(
         locator='.//input[@data-ouia-component-id="select-all-checkbox-dropdown-toggle-checkbox"]'
     )
@@ -203,7 +201,7 @@ class ManageCVEModal(PF5Modal):
     save_btn = Button(locator='//button[normalize-space(.)="Save"]')
     cancel_btn = Button(locator='//button[normalize-space(.)="Cancel"]')
     content_source_select = CVESelect()
-    lce_selector = ParametrizedView.nested(PF4LCESelectorGroup)
+    lce_selector = ParametrizedView.nested(PF5LCESelectorGroup)
 
     @property
     def is_displayed(self):

--- a/airgun/views/common.py
+++ b/airgun/views/common.py
@@ -25,10 +25,10 @@ from airgun.widgets import (
     ItemsList,
     LCESelector,
     Pf4ConfirmationDialog,
-    PF4LCECheckSelector,
-    PF4LCESelector,
     PF4NavSearch,
     PF4Search,
+    PF5LCECheckSelector,
+    PF5LCESelector,
     ProgressBar,
     ReadOnlyEntry,
     SatFlashMessages,
@@ -302,30 +302,30 @@ class LCESelectorGroup(ParametrizedView):
         return self.lce.read()
 
 
-class PF4LCESelectorGroup(LCESelectorGroup):
+class PF5LCESelectorGroup(LCESelectorGroup):
     ROOT = './/div[./div[@class="env-path"]]'
 
     PARAMETERS = ('lce_name',)
 
     LAST_ENV = './/div[@class="env-path"][last()]'
-    lce = PF4LCESelector(
+    lce = PF5LCESelector(
         locator=ParametrizedLocator(
             './/div[@class="env-path" and .//*[contains(normalize-space(.), "{lce_name}")]]'
         )
     )
 
 
-class PF4LCECheckSelectorGroup(PF4LCESelectorGroup):
-    """Checkbox version of PF4 LCE Selector"""
+class PF5LCECheckSelectorGroup(PF5LCESelectorGroup):
+    """Checkbox version of PF5 LCE Selector"""
 
-    lce = PF4LCECheckSelector(
+    lce = PF5LCECheckSelector(
         locator=ParametrizedLocator(
             './/div[@class="env-path" and .//*[contains(normalize-space(.), "{lce_name}")]]'
         )
     )
 
 
-class PF4LCEGroup(ParametrizedLocator):
+class PF5LCEGroup(ParametrizedLocator):
     "Group of LCE indicators"
 
     ROOT = './/td and '
@@ -333,7 +333,7 @@ class PF4LCEGroup(ParametrizedLocator):
     PARAMETERS = ('lce_name',)
 
     LAST_ENV = './/div[@class="env-path"][last()]'
-    lce = PF4LCESelector(
+    lce = PF5LCESelector(
         locator=ParametrizedLocator(
             './/div[@class="env-path" and .//*[contains(normalize-space(.), "{lce_name}")]]'
         )

--- a/airgun/views/contentview_new.py
+++ b/airgun/views/contentview_new.py
@@ -14,8 +14,8 @@ from widgetastic_patternfly4.ouia import (
 from airgun.views.common import (
     BaseLoggedInView,
     NewAddRemoveResourcesView,
-    PF4LCECheckSelectorGroup,
-    PF4LCESelectorGroup,
+    PF5LCECheckSelectorGroup,
+    PF5LCESelectorGroup,
     SearchableViewMixinPF4,
 )
 from airgun.widgets import (
@@ -225,7 +225,7 @@ class ContentViewVersionPublishView(BaseLoggedInView):
     cancel_button = Button('Cancel')
     close_button = Button('Close')
     progressbar = PF4ProgressBar('.//div[contains(@class, "pf-c-wizard__main-body")]')
-    lce_selector = ParametrizedView.nested(PF4LCECheckSelectorGroup)
+    lce_selector = ParametrizedView.nested(PF5LCECheckSelectorGroup)
 
     @property
     def is_displayed(self):
@@ -256,7 +256,7 @@ class ContentViewVersionPromoteView(Modal):
     ROOT = './/div[@data-ouia-component-id="promote-version"]'
 
     description = Text('.//h2[@data-ouia-component-id="description-text-value"]')
-    lce_selector = ParametrizedView.nested(PF4LCESelectorGroup)
+    lce_selector = ParametrizedView.nested(PF5LCESelectorGroup)
     promote_btn = Button(locator='//button[normalize-space(.)="Promote"]')
     cancel_btn = Button(locator='//button[normalize-space(.)="Cancel"]')
 

--- a/airgun/widgets.py
+++ b/airgun/widgets.py
@@ -1500,15 +1500,13 @@ class LCESelector(GenericLocatorWidget):
         return self.select(checkbox_locator, checkbox_value)
 
 
-class PF4LCESelector(LCESelector):
+class PF5LCESelector(LCESelector):
     """Group of checkboxes that goes in a line one after another. Usually used
-    to specify lifecycle environment, updated for PF4 pages
+    to specify lifecycle environment, updated for PF5 pages
     """
 
-    LABELS = './/label[contains(@class, "pf-c-radio__label")]'
-    CHECKBOX = (
-        './/input[contains(@class, "pf-c-radio__input") and ../label[.//*[contains(text(), "{}")]]]'
-    )
+    LABELS = './/label[contains(@class, "pf-v5-c-radio__label")]'
+    CHECKBOX = './/input[contains(@class, "pf-v5-c-radio__input") and ../label[.//*[contains(text(), "{}")]]]'
 
     def __init__(self, parent, locator=None, logger=None):
         """Allow to specify ``locator`` if needed or use default one otherwise.
@@ -1524,11 +1522,13 @@ class PF4LCESelector(LCESelector):
         return self.browser.is_selected(locator)
 
 
-class PF4LCECheckSelector(PF4LCESelector):
-    """Checkbox version of PF4 LCE Selector"""
+class PF5LCECheckSelector(PF5LCESelector):
+    """Checkbox version of PF5 LCE Selector"""
 
-    LABELS = './/label[contains(@class, "pf-c-check__label")]'
-    CHECKBOX = './/input[contains(@class, "pf-c-check") and ../label[.//*[contains(text(), "{}")]]]'
+    LABELS = './/label[contains(@class, "pf-v5-c-check__label")]'
+    CHECKBOX = (
+        './/input[contains(@class, "pf-v5-c-check") and ../label[.//*[contains(text(), "{}")]]]'
+    )
 
 
 class LimitInput(Widget):


### PR DESCRIPTION
This PR fixes `test_all_hosts_bulk_cve_reassign` test by updating related views and some entities to PF5

### PRT Example
```
trigger: test-robottelo
pytest: tests/foreman/ui/test_host.py -k 'test_all_hosts_bulk_cve_reassign'
```