### PR TITLE
Fix Manifest Alert View PF4->PF5

### DIFF
--- a/airgun/views/subscription.py
+++ b/airgun/views/subscription.py
@@ -146,9 +146,7 @@ class ManageManifestView(BaseLoggedInView):
 
     @View.nested
     class manifest(SatTab):
-        alert_message = Text(
-            '//div[@id="manifest-history-tabs-pane-1"]/div/h3//following-sibling::div[@aria-label="Warning Alert" or @aria-label="Danger Alert"]'
-        )
+        alert_message = Text('.//div[contains(@class, "pf-v5-c-alert")]')
         expire_header = Text('//div[@id="manifest-history-tabs-pane-1"]/div/div/h4')
         expire_message = Text(
             '//div[@id="manifest-history-tabs-pane-1"]/div/div/h4//following-sibling::div'


### PR DESCRIPTION
This PR fixes `test_positive_check_manifest_validity_notification`.
The update of alert view was needed.

### PRT Example
```
trigger: test-robottelo
pytest: tests/foreman/ui/test_subscription.py -k 'test_positive_check_manifest_validity_notification'
```