### PR TITLE
[PF5] MenuToggleDropdownInTable

### DIFF
--- a/airgun/views/all_hosts.py
+++ b/airgun/views/all_hosts.py
@@ -1,7 +1,6 @@
 from widgetastic.widget import Checkbox, ParametrizedView, Text, View
 from widgetastic_patternfly4 import (
     Button,
-    Dropdown,
     Pagination,
     Radio,
     Select,
@@ -28,6 +27,24 @@ from airgun.views.common import (
 )
 from airgun.views.host_new import ManageColumnsView, PF5CheckboxTreeView
 from airgun.widgets import ItemsList, SearchInput
+
+
+class MenuToggleDropdownInTable(PF5Dropdown):
+    """
+    This class is PF5 implementation of dropdown component within the table row.
+    Which is MenuToggle->Dropdown and not just Dropdown as it was in PF4.
+    """
+
+    IS_ALWAYS_OPEN = False
+    BUTTON_LOCATOR = ".//button[contains(@class, 'pf-v5-c-menu-toggle')]"
+    DEFAULT_LOCATOR = (
+        './/div[contains(@class, "pf-v5-c-menu") and @data-ouia-component-id="PF5/Dropdown"]'
+    )
+    ROOT = f"{BUTTON_LOCATOR}/.."
+    ITEMS_LOCATOR = ".//ul[contains(@class, 'pf-v5-c-menu__list')]/li"
+    ITEM_LOCATOR = (
+        "//*[contains(@class, 'pf-v5-c-menu__item') and .//*[contains(normalize-space(.), {})]]"
+    )
 
 
 class AllHostsSelect(Select):
@@ -62,6 +79,7 @@ class AllHostsTableView(BaseLoggedInView, SearchableViewMixinPF4):
     select_all = Checkbox(
         locator='.//input[@data-ouia-component-id="select-all-checkbox-dropdown-toggle-checkbox"]'
     )
+    top_bulk_actions = MenuToggleDropdownInTable(locator='.//button[@aria-label="plain kebab"]')
     bulk_actions = AllHostsMenu()
     bulk_actions_kebab = Button(locator='.//button[@aria-label="plain kebab"]')
     bulk_actions_menu = PF5Menu(
@@ -79,7 +97,7 @@ class AllHostsTableView(BaseLoggedInView, SearchableViewMixinPF4):
         column_widgets={
             0: Checkbox(locator='.//input[@type="checkbox"]'),
             'Name': Text('./a'),
-            2: Dropdown(locator='.//div[contains(@class, "pf-c-dropdown")]'),
+            2: MenuToggleDropdownInTable(),
         },
     )
     alert_message = Text('.//div[contains(@class, "pf-v5-c-alert")]')


### PR DESCRIPTION
This PR adds the implementation of `MenuToggleDropdownInTable`.
It represents the kebab dropdown within the AllHost page table rows.

Upon this implementation we should come up with some global implementation of some view that would cover all the PF5(MenuToggle->Dropdown) menu views across the Satellite.

This PR also fixes `all_hosts_delete`.

### PRT Example
```
trigger: test-robottelo
pytest: tests/foreman/ui/test_host.py -k 'all_hosts_delete'
```