### PR TITLE
Fix navigation for Job Templates

### DIFF
--- a/airgun/entities/job_template.py
+++ b/airgun/entities/job_template.py
@@ -76,7 +76,7 @@ class ShowAllTemplates(NavigateStep):
 
     @retry_navigation
     def step(self, *args, **kwargs):
-        self.view.menu.select('Hosts', 'Templates', 'Job templates')
+        self.view.menu.select('Hosts', 'Templates', 'Job Templates')
 
 
 @navigator.register(JobTemplateEntity, 'New')


### PR DESCRIPTION
`test_positive_documentation_links` is failing because locator for `jobtemplate` has changed.

## Summary by Sourcery

Bug Fixes:
- Update menu.select locator to use capitalized 'Job Templates' in ShowAllTemplates