### PR TITLE
CloudInventory UI Test Fix

### DIFF
--- a/airgun/entities/cloud_inventory.py
+++ b/airgun/entities/cloud_inventory.py
@@ -1,3 +1,5 @@
+import time
+
 from airgun.entities.base import BaseEntity
 from airgun.navigation import NavigateStep, navigator
 from airgun.utils import retry_navigation
@@ -33,13 +35,18 @@ class CloudInventoryEntity(BaseEntity):
 
     def generate_report(self, entity_name):
         view = self.navigate_to(self, 'All')
+        self.browser.plugin.ensure_page_safe(timeout='5s')
+        view.wait_displayed()
         view.inventory_list.toggle(entity_name)
         view.browser.click(view.inventory_list.generating.restart, ignore_ajax=True)
 
     def download_report(self, entity_name):
         view = self.navigate_to(self, 'All')
+        self.browser.plugin.ensure_page_safe(timeout='5s')
+        view.wait_displayed()
         view.inventory_list.toggle(entity_name)
         view.browser.click(view.inventory_list.uploading.download_report, ignore_ajax=True)
+        time.sleep(3)
         return self.browser.save_downloaded_file()
 
     def update(self, values):


### PR DESCRIPTION
Needed by https://github.com/SatelliteQE/robottelo/pull/18521 (PRT will run there)

## Summary by Sourcery

Add page safety checks and waits to CloudInventory UI test actions to stabilize test execution

Bug Fixes:
- Add ensure_page_safe and wait_displayed calls in generate_report and download_report to ensure the page is ready
- Add a fixed sleep before saving the downloaded file in download_report to allow the download to complete