### PR TITLE
content views PF5 updates

### DIFF
--- a/airgun/entities/contentview_new.py
+++ b/airgun/entities/contentview_new.py
@@ -1,7 +1,7 @@
-from asyncio import wait_for
 import time
 
 from navmazing import NavigateToSibling
+from wait_for import wait_for
 from widgetastic.exceptions import NoSuchElementException
 from widgetastic_patternfly4.dropdown import DropdownItemDisabled
 
@@ -54,11 +54,10 @@ class NewContentViewEntity(BaseEntity):
             view.fill(values)
         if promote:
             view.promote.click()
-            wait_for(lambda: view.lce_selector.is_displayed, timeout=10)
-            view.lce_selector.fill(lce or {lce: True})
+            wait_for(lambda: view.lce_selector(lce_name=lce).is_displayed, timeout=10)
+            view.lce_selector.fill({lce: True})
         view.next_button.click()
         view.finish_button.click()
-        wait_for(lambda: view.progressbar.is_displayed, timeout=10)
         view.progressbar.wait_for_result()
         view = self.navigate_to(self, 'Edit', entity_name=entity_name)
         self.browser.plugin.ensure_page_safe(timeout='5s')
@@ -85,9 +84,7 @@ class NewContentViewEntity(BaseEntity):
         view = self.navigate_to(self, 'Edit', entity_name=entity_name)
         self.browser.plugin.ensure_page_safe(timeout='5s')
         view.wait_displayed()
-        # click the 'cv-details-action' dropdown, then click 'Delete'
-        view.cv_actions.click()
-        view.cv_delete.click()
+        view.cv_actions.item_select('Delete')
         view.wait_displayed()
         # Remove from environment(s) wizard, if it appears
         if view.next_button.is_displayed:

--- a/airgun/views/common.py
+++ b/airgun/views/common.py
@@ -1,3 +1,5 @@
+from functools import partial
+
 from selenium.common.exceptions import ElementNotInteractableException
 from widgetastic.widget import (
     Checkbox,
@@ -11,10 +13,14 @@ from widgetastic.widget import (
     do_not_read_this_widget,
 )
 from widgetastic_patternfly import BreadCrumb, Tab, TabWithDropdown
-from widgetastic_patternfly4 import Button, Select
+from widgetastic_patternfly4 import Button
 from widgetastic_patternfly4.navigation import Navigation
-from widgetastic_patternfly4.ouia import Dropdown, PatternflyTable
-from widgetastic_patternfly5.ouia import Dropdown as PF5OUIADropdown
+from widgetastic_patternfly5 import OptionsMenu
+from widgetastic_patternfly5.ouia import (
+    Dropdown as PF5OUIADropdown,
+    PatternflyTable,
+    Select as PF5OUIASelect,
+)
 
 from airgun.utils import get_widget_by_name, normalize_dict_values
 from airgun.widgets import (
@@ -327,6 +333,12 @@ class PF5LCECheckSelectorGroup(PF5LCESelectorGroup):
     )
 
 
+# PF5 kebab menu present in table rows
+TableRowKebabMenu = partial(
+    OptionsMenu, './/button[contains(@data-ouia-component-type, "MenuToggle")]/..'
+)
+
+
 class PF5LCEGroup(ParametrizedLocator):
     "Group of LCE indicators"
 
@@ -449,8 +461,8 @@ class AddRemoveResourcesView(View):
 
 class NewAddRemoveResourcesView(View):
     searchbox = PF4Search()
-    status = Select(locator='.//div[@data-ouia-component-id="select Status"]')
-    remove_button = Dropdown(locator='.//div[@data-ouia-component-id="repositoies-bulk-actions"]')
+    status = PF5OUIASelect(component_id='select Status')
+    remove_button = PF5OUIADropdown(component_id='repositoies-bulk-actions')
     add_button = Button(locator='.//button[@data-ouia-component-id="add-repositories"]')
     table = PatternflyTable(
         component_id='content-view-repositories-table',

--- a/airgun/views/contentview_new.py
+++ b/airgun/views/contentview_new.py
@@ -2,13 +2,17 @@ from wait_for import wait_for
 from widgetastic.utils import ParametrizedLocator
 from widgetastic.widget import Checkbox, ParametrizedView, Text, TextInput, View
 from widgetastic_patternfly import BreadCrumb, Tab
-from widgetastic_patternfly4 import Button, Dropdown, Modal, Radio as PF4Radio, Select
-from widgetastic_patternfly4.ouia import (
-    Button as PF4Button,
+from widgetastic_patternfly5 import Button, Modal, Radio as PF5Radio
+from widgetastic_patternfly5.ouia import (
+    Button as PF5Button,
+    Dropdown as PF5Dropdown,
     ExpandableTable,
+    Modal as PF5Modal,
     PatternflyTable,
-    Select as PF4Select,
+    Select as PF5Select,
     Switch,
+    Text as PF5Text,
+    TextInput as PF5TextInput,
 )
 
 from airgun.views.common import (
@@ -17,13 +21,13 @@ from airgun.views.common import (
     PF5LCECheckSelectorGroup,
     PF5LCESelectorGroup,
     SearchableViewMixinPF4,
+    TableRowKebabMenu,
 )
 from airgun.widgets import (
-    ActionsDropdown,
     ConfirmationDialog,
     EditableEntry,
-    PF4ProgressBar,
     PF4Search,
+    PF5ProgressBar,
     ReadOnlyEntry,
 )
 
@@ -31,8 +35,8 @@ LOCATION_NUM = 3
 
 
 class ContentViewAddResourcesView(NewAddRemoveResourcesView):
-    remove_button = Dropdown(locator='.//div[@data-ouia-component-id="cv-components-bulk-actions"]')
-    add_button = Button(locator='.//button[@data-ouia-component-id="add-content-views"]')
+    remove_button = PF5Dropdown(component_id='cv-components-bulk-actions')
+    add_button = PF5Button(component_id='add-content-views')
     table = PatternflyTable(
         component_id='content-view-components-table',
         column_widgets={
@@ -44,7 +48,7 @@ class ContentViewAddResourcesView(NewAddRemoveResourcesView):
             'Repositories': Text('.//a'),
             'Status': Text('.//a'),
             'Description': Text('.//a'),
-            8: Dropdown(locator='.//div[contains(@class, "pf-c-dropdown")]'),
+            8: TableRowKebabMenu(),
         },
     )
 
@@ -55,11 +59,11 @@ class ContentViewAddResourcesView(NewAddRemoveResourcesView):
 
 class AddContentViewModal(BaseLoggedInView):
     title = Text('.//div[@data-ouia-component-id="add-content-views"]')
-    submit_button = PF4Button('add-components-modal-add')
-    cancel_button = PF4Button('add-components-modal-cancel')
+    submit_button = PF5Button(component_id='add-components-modal-add')
+    cancel_button = PF5Button(component_id='add-components-modal-cancel')
 
-    version_select = Select(locator=".//div[@data-ouia-component-id='add-content-views']")
-    always_update = Checkbox(locator=".//input[@class='pf-c-check__input']")
+    version_select = PF5Select(component_id='select-version')
+    always_update = Checkbox(locator='.//input[contains(@data-ouia-component-id, "latest-")]')
 
     @property
     def is_displayed(self):
@@ -67,8 +71,8 @@ class AddContentViewModal(BaseLoggedInView):
 
 
 class ContentViewTableView(BaseLoggedInView, SearchableViewMixinPF4):
-    title = Text('.//h1[@data-ouia-component-id="cvPageHeaderText"]')
-    create_content_view = PF4Button('create-content-view')
+    title = PF5Text(component_id='cvPageHeaderText')
+    create_content_view = PF5Button(component_id='create-content-view')
     table = ExpandableTable(
         component_id='content-views-table',
         column_widgets={
@@ -77,7 +81,7 @@ class ContentViewTableView(BaseLoggedInView, SearchableViewMixinPF4):
             'Last Published': ('./a'),
             'Last task': Text('.//a'),
             'Latest version': Text('.//a'),
-            6: Dropdown(locator='.//div[contains(@class, "pf-c-dropdown")]'),
+            6: TableRowKebabMenu(),
         },
     )
 
@@ -87,12 +91,12 @@ class ContentViewTableView(BaseLoggedInView, SearchableViewMixinPF4):
 
 
 class ContentViewCreateView(BaseLoggedInView):
-    title = Text('.//div[@data-ouia-component-id="create-content-view-modal"]')
-    name = TextInput(id='name')
-    label = TextInput(id='label')
+    title = PF5Modal(component_id='create-content-view-modal')
+    name = PF5TextInput(component_id='input_name')
+    label = PF5TextInput(component_id='input_label')
     description = TextInput(id='description')
-    submit = PF4Button('create-content-view-form-submit')
-    cancel = PF4Button('create-content-view-form-cancel')
+    submit = PF5Button(component_id='create-content-view-form-submit')
+    cancel = PF5Button(component_id='create-content-view-form-cancel')
 
     component_tile = Text('//div[contains(@id, "component")]')
     solve_dependencies = Checkbox(id='dependencies')
@@ -113,11 +117,8 @@ class ContentViewEditView(BaseLoggedInView):
     breadcrumb = BreadCrumb('breadcrumbs-list')
     search = PF4Search()
     dialog = ConfirmationDialog()
-    publish = PF4Button('cv-details-publish-button')
-    # click the cv_actions dropdown, then click copy or delete
-    cv_actions = ActionsDropdown('//div[@data-ouia-component-id="cv-details-actions"]')
-    cv_copy = Text('//a[@data-ouia-component-id="cv-copy"]')
-    cv_delete = Text('//a[@data-ouia-component-id="cv-delete"]')
+    publish = PF5Button(component_id='cv-details-publish-button')
+    cv_actions = PF5Dropdown(component_id='cv-details-actions')
 
     # buttons for wizard: deleting a CV with Version promoted to environment(s)
     next_button = Button('Next')
@@ -129,7 +130,7 @@ class ContentViewEditView(BaseLoggedInView):
     @property
     def is_displayed(self):
         breadcrumb_loaded = self.browser.wait_for_element(self.breadcrumb, exception=False)
-        return breadcrumb_loaded and self.breadcrumb.locations[0] == 'Content Views'
+        return breadcrumb_loaded and self.breadcrumb.locations[0] == 'Content views'
 
     @View.nested
     class details(Tab):
@@ -158,10 +159,10 @@ class ContentViewEditView(BaseLoggedInView):
                 'Errata': Text('.//a'),
                 'Additional content': Text('.//a'),
                 'Description': Text('.//a'),
-                7: Dropdown(locator='.//div[contains(@class, "pf-c-dropdown")]'),
+                7: TableRowKebabMenu(),
             },
         )
-        publishButton = PF4Button('cv-details-publish-button')
+        publishButton = PF5Button(component_id='cv-details-publish-button')
 
         def search(self, version_name):
             """Searches for content view version.
@@ -189,7 +190,7 @@ class ContentViewEditView(BaseLoggedInView):
     @View.nested
     class filters(Tab):
         TAB_LOCATOR = ParametrizedLocator('//a[contains(@href, "#/filters")]')
-        new_filter = PF4Button('create-filter-button')
+        new_filter = PF5Button(component_id='create-filter-button')
         searchbox = PF4Search()
         table = PatternflyTable(
             component_id="content-view-filters-table",
@@ -200,7 +201,7 @@ class ContentViewEditView(BaseLoggedInView):
                 'Updated': Text('.//a'),
                 'Content type': Text('.//a'),
                 'Inclusion type': Text('.//a'),
-                6: Dropdown(locator='.//div[contains(@class, "pf-c-dropdown")]'),
+                6: TableRowKebabMenu(),
             },
         )
 
@@ -212,8 +213,8 @@ class ContentViewEditView(BaseLoggedInView):
 
 class ContentViewVersionPublishView(BaseLoggedInView):
     # publishing view is a popup so adding all navigation within the same context
-    ROOT = './/div[contains(@class,"pf-c-wizard")]'
-    title = Text(".//h2[contains(., 'Publish') and contains(@aria-label, 'Publish')]")
+    ROOT = './/div[@id="content-view-publish-wizard"]'
+    title = Text(".//h2[contains(., 'Publish') and @id='pf-wizard-title-0']")
     publish_alert = Text(".//h4[contains(., 'No available repository or filter updates')]")
     # publishing screen
     description = TextInput(id='description')
@@ -224,7 +225,7 @@ class ContentViewVersionPublishView(BaseLoggedInView):
     back_button = Button('Back')
     cancel_button = Button('Cancel')
     close_button = Button('Close')
-    progressbar = PF4ProgressBar('.//div[contains(@class, "pf-c-wizard__main-body")]')
+    progressbar = PF5ProgressBar()
     lce_selector = ParametrizedView.nested(PF5LCECheckSelectorGroup)
 
     @property
@@ -264,25 +265,16 @@ class ContentViewVersionPromoteView(Modal):
 class ContentViewVersionDetailsView(BaseLoggedInView):
     breadcrumb = BreadCrumb()
     version = Text(locator='.//h2[@data-ouia-component-id="cv-version"]')
-    version_dropdown = Dropdown(
-        locator='.//div[@data-ouia-component-id="cv-version-header-actions-dropdown"]'
-    )
-    promoteButton = PF4Button(
-        locator='.//button[@data-ouia-component-id="cv-details-publish-button"]'
-    )
-    version_dropdown = Dropdown(
-        locator='.//div[@data-ouia-component-id="cv-version-header-actions-dropdown"]'
-    )
-    editDescription = PF4Button(
-        locator='.//button[@data-ouia-component-id="edit-button-description"]'
-    )
+    version_dropdown = PF5Dropdown(component_id='cv-version-header-actions-dropdown')
+    promoteButton = PF5Button(component_id='cv-details-publish-button')
+    editDescription = PF5Button(component_id='edit-button-description')
     # buttons for wizard: deleting a version promoted to environment(s)
     next_button = Button('Next')
     delete_finish = Button('Delete')
     back_button = Button('Back')
     cancel_button = Button('Cancel')
     close_button = Button('Close')
-    progressbar = PF4ProgressBar('.//div[contains(@class, "pf-c-wizard__main-body")]')
+    progressbar = PF5ProgressBar()
 
     @View.nested
     class repositories(Tab):
@@ -366,28 +358,28 @@ class CreateFilterView(View):
     ROOT = './/div[@data-ouia-component-id="create-filter-modal"]'
 
     name = TextInput(id='name')
-    filterType = PF4Select('content_type')
-    includeFilter = PF4Radio(label_text='Include filter')
-    excludeFilter = PF4Radio(label_test='Exclude filter')
-    create = PF4Button('create-filter-form-submit-button')
-    cancel = PF4Button('create-filter-form-cancel-button')
+    filterType = PF5Select(component_id='content_type')
+    includeFilter = PF5Radio(label_text='Include filter')
+    excludeFilter = PF5Radio(label_test='Exclude filter')
+    create = PF5Button(component_id='create-filter-form-submit-button')
+    cancel = PF5Button(component_id='create-filter-form-cancel-button')
 
 
 class EditFilterView(View):
     name = Text('.//h2[@data-ouia-component-id="name-text-value"]')
-    editName = PF4Button('edit-button-name')
+    editName = PF5Button(component_id='edit-button-name')
     nameInput = TextInput('name text input')
-    submitName = PF4Button('submit-button-name')
-    clearName = PF4Button('clear-button-name')
+    submitName = PF5Button(component_id='submit-button-name')
+    clearName = PF5Button(component_id='clear-button-name')
     description = Text('.//h2[@data-ouia-component-id="description-text-value"]')
-    editDescription = PF4Button('edit-button-description')
+    editDescription = PF5Button(component_id='edit-button-description')
     descriptionInput = TextInput(locator='.//textarea[@aria-label="description text area"]')
 
     # Below this, the fields are generally not shared by each Filter Type
 
     # RPM Rule
     search = PF4Search()
-    addRpmRule = PF4Button('add-rpm-rule-button')
+    addRpmRule = PF5Button(component_id='add-rpm-rule-button')
     rpmRuleTable = PatternflyTable(
         component_id="content-view-rpm-filter-table",
         column_widgets={
@@ -395,24 +387,26 @@ class EditFilterView(View):
             'RPM Name': Text('.//a'),
             'Architecture': Text('.//a'),
             'Versions': Text('.//a'),
-            4: Dropdown(locator='.//div[contains(@class, "pf-c-dropdown")]'),
+            4: TableRowKebabMenu(),
         },
     )
 
     # Container Image Tag Rule
-    addTagRule = PF4Button('add-content-view-container-image-filter-button')
+    addTagRule = PF5Button(component_id='add-content-view-container-image-filter-button')
     tagRuleTable = PatternflyTable(
         component_id="content-view-container-image-filter",
         column_widgets={
             0: Checkbox(locator='.//input[@type="checkbox"]'),
             'Tag Name': Text('.//a'),
-            2: Dropdown(locator='.//div[contains(@class, "pf-c-dropdown")]'),
+            2: TableRowKebabMenu(),
         },
     )
 
     # Package Group Rule
-    addPackageGroupRule = PF4Button('add-package-group-filter-rule-button')
-    removePackageGroupRule = Dropdown('cv-package-group-filter-bulk-actions-dropdown')
+    addPackageGroupRule = PF5Button(component_id='add-package-group-filter-rule-button')
+    removePackageGroupRule = PF5Dropdown(
+        component_id='cv-package-group-filter-bulk-actions-dropdown'
+    )
     packageGroupRuleTable = PatternflyTable(
         component_id="content-view-package-group-filter-table",
         column_widgets={
@@ -422,13 +416,13 @@ class EditFilterView(View):
             'Repository': Text('.//a'),
             'Description': Text('.//a'),
             'Status': Text('.//a'),
-            6: Dropdown(locator='.//div[contains(@class, "pf-c-dropdown")]'),
+            6: TableRowKebabMenu(),
         },
     )
 
     # Module Streams Rule
-    addModuleStreamRule = PF4Button('add-module-stream-rule-button')
-    removeModuleStreamRule = Dropdown('bulk-actions-dropdown')
+    addModuleStreamRule = PF5Button(component_id='add-module-stream-rule-button')
+    removeModuleStreamRule = PF5Dropdown(component_id='bulk-actions-dropdown')
     moduleStreamRuleTable = PatternflyTable(
         component_id="content-view-module-stream-filter-table",
         column_widgets={
@@ -438,13 +432,13 @@ class EditFilterView(View):
             'Version': Text('.//a'),
             'Context': Text('.//a'),
             'Status': Text('.//a'),
-            6: Dropdown(locator='.//div[contains(@class, "pf-c-dropdown")]'),
+            6: TableRowKebabMenu(),
         },
     )
 
     # Errata Rule
-    addErrataRule = PF4Button('add-errata-id-button')
-    removeErratRule = Dropdown('cv-errata-id-bulk-action-dropdown')
+    addErrataRule = PF5Button(component_id='add-errata-id-button')
+    removeErratRule = PF5Dropdown(component_id='cv-errata-id-bulk-action-dropdown')
     moduleErrataTable = PatternflyTable(
         component_id="content-view-errata-by-id-filter-table",
         column_widgets={
@@ -456,14 +450,14 @@ class EditFilterView(View):
             'Severity': Text('.//a'),
             'Synopsis': Text('.//a'),
             'Status': Text('.//a'),
-            8: Dropdown(locator='.//div[contains(@class, "pf-c-dropdown")]'),
+            8: TableRowKebabMenu(),
         },
     )
 
     # Errata by Date Range
 
-    saveErrataByDate = PF4Button('save-filter-rule-button')
-    cancelErrataByDate = PF4Button('cancel-save-filter-rule-button')
+    saveErrataByDate = PF5Button(component_id='save-filter-rule-button')
+    cancelErrataByDate = PF5Button(component_id='cancel-save-filter-rule-button')
 
     @property
     def is_displayed(self):
@@ -474,23 +468,23 @@ class AddRPMRuleView(View):
     ROOT = './/div[@data-ouia-component-id="add-edit-rpm-rule-modal"]'
 
     rpmName = TextInput(
-        locator=".//div[contains(.//span, 'RPM name') and @class='pf-c-form__group']/*//input"
+        locator=".//div[contains(.//span, 'RPM name') and @class='pf-v5-c-form__group']/*//input"
     )
     architecture = TextInput(
-        locator=".//div[contains(.//span, 'Architecture') and @class='pf-c-form__group']/*//input"
+        locator=".//div[contains(.//span, 'Architecture') and @class='pf-v5-c-form__group']/*//input"
     )
 
-    versions = PF4Select('version-comparator')
-    addEdit = PF4Button('add-edit-package-modal-submit')
-    cancel = PF4Button('add-edit-package-modal-cancel')
+    versions = PF5Select(component_id='version-comparator')
+    addEdit = PF5Button(component_id='add-edit-package-modal-submit')
+    cancel = PF5Button(component_id='add-edit-package-modal-cancel')
 
 
 class AddContainerTagRuleView(View):
     ROOT = './/div[@data-ouia-component-id="add-edit-container-tag-rule-modal"]'
 
     tagName = TextInput(
-        locator=".//div[contains(.//span, 'Tag name') and @class='pf-c-form__group']/*//input"
+        locator=".//div[contains(.//span, 'Tag name') and @class='pf-v5-c-form__group']/*//input"
     )
 
-    addEdit = PF4Button('add-edit-container-tag-filter-rule-submit')
-    cancel = PF4Button('add-edit-container-tag-filter-rule-cancel')
+    addEdit = PF5Button(component_id='add-edit-container-tag-filter-rule-submit')
+    cancel = PF5Button(component_id='add-edit-container-tag-filter-rule-cancel')

--- a/airgun/widgets.py
+++ b/airgun/widgets.py
@@ -33,8 +33,8 @@ from widgetastic_patternfly4.ouia import (
     Button as OUIAButton,
     Menu,
 )
-from widgetastic_patternfly4.progress import Progress as PF4Progress
 from widgetastic_patternfly4.table import BaseExpandableTable, BasePatternflyTable
+from widgetastic_patternfly5 import Progress as PF5Progress
 from widgetastic_patternfly5.ouia import (
     BaseSelect as PF5BaseSelect,
     Button as PF5OUIAButton,
@@ -2342,8 +2342,21 @@ class ProgressBar(GenericLocatorWidget):
         return self.progress
 
 
-class PF4ProgressBar(PF4Progress):
-    locator = './/div[contains(@class, "pf-c-wizard__main-body")]'
+class PF5ProgressBar(PF5Progress):
+    ROOT = './/div[contains(@class, "pf-v5-c-wizard__main-body")]'
+
+    def __init__(self, parent, locator=None, logger=None):
+        """Overrides `locator` parameter to be optional with default of `PF5ProgressBar.ROOT`"""
+        self.locator = locator or self.ROOT
+        super().__init__(parent, self.locator, logger=logger)
+
+    @property
+    def is_displayed(self):
+        if progress_bar := self.browser.wait_for_element(
+            self.PROGRESS_BAR, timeout=1, exception=False
+        ):
+            return progress_bar.is_displayed
+        return False
 
     @property
     def is_completed(self):


### PR DESCRIPTION
## Summary by Sourcery

Migrate content view automation flows from PatternFly 4 to PatternFly 5 by replacing PF4 component wrappers with PF5 equivalents, updating locators, and adjusting entity logic.

Bug Fixes:
- Streamline content view delete and publish entity methods to use updated PF5 actions and remove redundant waits.

Enhancements:
- Replace PF4 buttons, dropdowns, selects, modals, and search widgets with PF5 counterparts across content view views.
- Introduce TableRowKebabMenu for PF5 kebab menus and update table row menu locators.
- Extend PF5ProgressBar with customized display logic and adjust root locators for publish and details wizards.
- Convert NewAddRemoveResourcesView and common PF4 selectors/dropdowns to PF5 OUIA-based components.

***PRT example***
```
trigger: test-robottelo
pytest: tests/foreman/ui/test_contentview.py -k 'test_positive_end_to_end or test_positive_ccv_e2e or test_version_table_read'
```
