### PR TITLE
[6.17.z] Fix navigation for Job Templates

### DIFF
--- a/airgun/entities/job_template.py
+++ b/airgun/entities/job_template.py
@@ -76,7 +76,7 @@ class ShowAllTemplates(NavigateStep):
 
     @retry_navigation
     def step(self, *args, **kwargs):
-        self.view.menu.select('Hosts', 'Templates', 'Job templates')
+        self.view.menu.select('Hosts', 'Templates', 'Job Templates')
 
 
 @navigator.register(JobTemplateEntity, 'New')


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/airgun/pull/1859

`test_positive_documentation_links` is failing because locator for `jobtemplate` has changed.

## Summary by Sourcery

Bug Fixes:
- Correct the menu selection from 'Job templates' to 'Job Templates' in the navigation step