### PR TITLE
fixed PF5 select locator for host group/activation keys

### DIFF
--- a/airgun/views/host.py
+++ b/airgun/views/host.py
@@ -543,7 +543,9 @@ class HostRegisterView(BaseLoggedInView):
         capsule = PF5FormSelect('reg_smart_proxy')
         insecure = Checkbox(id='reg_insecure')
         activation_keys = BaseMultiSelect('activation-keys-field')
-        activation_key_helper = Text("//div[@id='activation_keys_field-helper']")
+        activation_key_helper = Text(
+            locator='//div[@data-ouia-component-id="activation-keys-field"]/..//div[contains(@class, "-c-helper-text")]'
+        )
         new_activation_key_link = Link('//a[normalize-space(.)="Create new activation key"]')
 
     @View.nested
@@ -563,7 +565,9 @@ class HostRegisterView(BaseLoggedInView):
         rex_pull_mode = PF5FormSelect('registration_setup_remote_execution_pull')
         ignore_error = Checkbox(id='reg_katello_ignore')
         force = Checkbox(id='reg_katello_force')
-        install_packages_helper = Text("//div[@id='reg_packages-helper']")
+        install_packages_helper = Text(
+            locator='//input[@id="reg_packages"]/../..//div[contains(@class, "-c-helper-text")]'
+        )
         repository_add = PF5Button('host_reg_add_more_repositories')
 
     @property

--- a/airgun/views/hostgroup.py
+++ b/airgun/views/hostgroup.py
@@ -1,7 +1,7 @@
 from widgetastic.widget import ConditionalSwitchableView, Table, Text, TextInput, View
 from widgetastic_patternfly import BreadCrumb
-from widgetastic_patternfly4.ouia import Select as OUIASelect
 from widgetastic_patternfly5 import Button as PF5Button, Pagination as PF5Pagination
+from widgetastic_patternfly5.ouia import Select as PF5OUIASelect
 
 from airgun.views.common import BaseLoggedInView, SatTab, SearchableViewMixinPF4
 from airgun.widgets import (
@@ -132,7 +132,7 @@ class HostGroupCreateView(BaseLoggedInView):
     @View.nested
     class activation_keys(SatTab):
         TAB_NAME = 'Activation Keys'
-        activation_keys = OUIASelect('ak-select')
+        activation_keys = PF5OUIASelect(component_id='ak-select')
 
 
 class HostGroupEditView(HostGroupCreateView):


### PR DESCRIPTION
## PF5 update: Host groups / Activation keys

Updated locator for Host group / Activation Keys select.

Updated locators of two text `_helper` elements on the Register Host form.

## PRT example
```
trigger: test-robottelo
pytest: tests/foreman/ui/test_registration.py::test_global_registration_form_populate
```

## Summary by Sourcery

Bug Fixes:
- Replace OUIASelect with PF5OUIASelect for the activation keys selector to support the PF5 update