### PR TITLE
adding_permission_denied_entity

### DIFF
--- a/airgun/entities/host.py
+++ b/airgun/entities/host.py
@@ -9,6 +9,7 @@ from airgun.helpers.host import HostHelper
 from airgun.navigation import NavigateStep, navigator
 from airgun.utils import retry_navigation
 from airgun.views.cloud_insights import CloudInsightsView
+from airgun.views.common import BaseLoggedInView
 from airgun.views.host import (
     HostCreateView,
     HostDetailsView,
@@ -425,6 +426,11 @@ class HostEntity(BaseEntity):
         view = self.navigate_to(self, 'All')
         view.wait_displayed()
         return view.displayed_table_header_names
+
+    def permission_denied(self):
+        """Return permission denied error text"""
+        view = BaseLoggedInView(self.browser)
+        return view.permission_denied.text
 
 
 @navigator.register(HostEntity, 'All')

--- a/airgun/views/common.py
+++ b/airgun/views/common.py
@@ -57,7 +57,9 @@ class BaseLoggedInView(View):
     logout = Text("//a[@href='/users/logout']")
     current_user = PF5OUIADropdown('user-info-dropdown')
     account_menu = PF5OUIADropdown('user-info-dropdown')
-    permission_denied = Text('//*[@id="content"]')
+    permission_denied = Text(
+        '//*[@id="content" or contains(@class, "pf-v5-c-empty-state pf-m-xl")]'
+    )
 
     def select_logout(self):
         """logout from satellite"""


### PR DESCRIPTION
Adding support for the following Robottelo PR

Dependent PR: https://github.com/SatelliteQE/robottelo/pull/18652

## Summary by Sourcery

New Features:
- Add `permission_denied` method to `HostEntity` to return permission denied error text