### PR TITLE
Remove 6.14.z from dependabot PR labels

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,8 +15,6 @@ updates:
       - "CherryPick"
       - "dependencies"
       - "6.15.z"
-      - "6.14.z"
-      - "6.13.z"
     ignore:
       - dependency-name: "selenium"
 
@@ -31,5 +29,3 @@ updates:
       - "CherryPick"
       - "dependencies"
       - "6.15.z"
-      - "6.14.z"
-      - "6.13.z"


### PR DESCRIPTION
### Problem Statement
6.14 became unsupported. Dependabot still labels its PRs with 6.14.z label.

### Solution
configure dependabot to not add the 6.14.z label to it's PRs

## Summary by Sourcery

CI:
- Remove 6.14.z and 6.13.z labels from .github/dependabot.yml to avoid labeling unsupported branches