### PR TITLE
[6.16.z] [pre-commit.ci] pre-commit autoupdate

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,7 +9,7 @@ repos:
   hooks:
   - id: black
 - repo: https://github.com/astral-sh/ruff-pre-commit
-  rev: v0.11.9
+  rev: v0.11.12
   hooks:
     - id: ruff
       args: [--fix, --exit-non-zero-on-fix]


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/airgun/pull/1856

<!--pre-commit.ci start-->
updates:
- [github.com/astral-sh/ruff-pre-commit: v0.11.9 → v0.11.12](https://github.com/astral-sh/ruff-pre-commit/compare/v0.11.9...v0.11.12)
<!--pre-commit.ci end-->

## Summary by Sourcery

CI:
- Update ruff pre-commit hook from v0.11.9 to v0.11.12