### PR TITLE
fix: broken techdocs annotations

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -12,10 +12,9 @@ metadata:
     - python
     - rh-satellite
     - interaction-library
-  namespace: quality-community   
+  namespace: quality-community
   annotations:
     github.com/project-slug: SatelliteQE/airgun
-    backstage.io/techdocs-ref: https://airgun.readthedocs.io/en/latest/
 spec:
   type: library
   owner: group:redhat/satellite-qe


### PR DESCRIPTION
Removed the techdocs annotation, as it only supports building docs from md files