### PR TITLE
[6.17.z] Fix external usergroup locator

### DIFF
--- a/airgun/views/usergroup.py
+++ b/airgun/views/usergroup.py
@@ -67,10 +67,8 @@ class UserGroupDetailsView(BaseLoggedInView):
             )
         )
         auth_source = FilteredDropdown(
-            locator=(
-                "//div[starts-with(@id, 'usergroup_external_usergroups_attributes')]"
-                "[contains(@id, 'auth_source_id')]"
-            )
+            # this locator fails when there are multiple user groups, it doesn't specify which
+            locator=("//span[contains(@class, 'select2-selection__rendered')]")
         )
 
         def before_fill(self, values):


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/airgun/pull/1865

null

## Summary by Sourcery

Bug Fixes:
- Update the auth_source locator in external_groups to use a span with the select2-selection__rendered class instead of the previous XPath