### PR TITLE
remove rhev functionality

### DIFF
--- a/airgun/entities/computeresource.py
+++ b/airgun/entities/computeresource.py
@@ -4,8 +4,6 @@ from airgun.entities.base import BaseEntity
 from airgun.navigation import NavigateStep, navigator
 from airgun.utils import retry_navigation
 from airgun.views.computeresource import (
-    ComputeResourceRHVImageCreateView,
-    ComputeResourceRHVImageEditView,
     ComputeResourcesView,
     ComputeResourceVMwareImageCreateView,
     ComputeResourceVMwareImageEditView,
@@ -299,7 +297,6 @@ class ComputeResourceImageProvider(NavigateStep):
 @navigator.register(ComputeResourceEntity, 'Create Image')
 class ComputeResourceImageCreate(ComputeResourceImageProvider):
     PROVIDER_VIEWS = {
-        'RHV': ComputeResourceRHVImageCreateView,
         'VMware': ComputeResourceVMwareImageCreateView,
     }
 
@@ -310,7 +307,6 @@ class ComputeResourceImageCreate(ComputeResourceImageProvider):
 @navigator.register(ComputeResourceEntity, 'Edit Image')
 class ComputeResourceImageEdit(ComputeResourceImageProvider):
     PROVIDER_VIEWS = {
-        'RHV': ComputeResourceRHVImageEditView,
         'VMware': ComputeResourceVMwareImageEditView,
     }
 

--- a/airgun/entities/virtwho_configure.py
+++ b/airgun/entities/virtwho_configure.py
@@ -19,7 +19,6 @@ class VirtwhoConfigureEntity(BaseEntity):
             'esx': 'VMware vSphere / vCenter (esx)',
             'xen': 'XenServer (xen)',
             'hyperv': 'Microsoft Hyper-V (hyperv)',
-            'rhevm': 'Red Hat Virtualization Hypervisor (rhevm)',
             'libvirt': 'libvirt',
             'kubevirt': 'Container-native virtualization',
             'ahv': 'Nutanix AHV (ahv)',

--- a/airgun/views/computeresource.py
+++ b/airgun/views/computeresource.py
@@ -126,21 +126,6 @@ class ResourceProviderCreateView(BaseLoggedInView):
             def before_fill(self, values=None):
                 self.load_datacenters.click()
 
-    @provider_content.register('RHV')
-    class RHVProviderForm(View):
-        url = TextInput(id='compute_resource_url')
-        user = TextInput(id='compute_resource_user')
-        password = TextInput(id='compute_resource_password')
-        certification_authorities = TextInput(id='compute_resource_public_key')
-
-        @View.nested
-        class datacenter(View):
-            load_datacenters = Text("//a[contains(@id,'test_connection_button')]")
-            value = FilteredDropdown(id='compute_resource_uuid')
-
-            def before_fill(self, values=None):
-                self.load_datacenters.click()
-
     @View.nested
     class compute_resource(SatTab):
         TAB_NAME = 'Compute Resource'
@@ -252,38 +237,6 @@ class ComputeResourceLibvirtProfileStorageItem(GenericRemovableWidgetItem):
     storage_type = FilteredDropdown(id="format_type")
 
 
-class ComputeResourceRHVProfileNetworkItem(GenericRemovableWidgetItem):
-    """RHV Compute Resource profile "Network interface" item widget"""
-
-    name = TextInput(locator=".//input[contains(@id, 'name')]")
-    network = FilteredDropdown(id="network")
-    interface_type = FilteredDropdown(id="interface")
-
-
-class ComputeResourceRHVProfileStorageItem(GenericRemovableWidgetItem):
-    """RHV Compute Resource profile "Storage" item widget"""
-
-    size = TextInput(locator=".//input[contains(@id, 'size_gb')]")
-    storage_domain = FilteredDropdown(id="storage_domain")
-    preallocate_disk = Checkbox(locator=".//input[contains(@id, 'preallocate')]")
-    wipe_disk_after_delete = Checkbox(locator=".//input[contains(@id, 'wipe_after_delete')]")
-    disk_interface = FilteredDropdown(id="interface")
-
-    @View.nested
-    class bootable(View):
-        ROOT = ".//input[contains(@id, 'bootable')]"
-
-        def _is_checked(self):
-            return self.browser.get_attribute('checked', self)
-
-        def read(self):
-            return self.browser.is_selected(self)
-
-        def fill(self, value):
-            if value is True and not self.browser.is_selected(self):
-                self.browser.click(self)
-
-
 class ComputeResourceVMwareProfileNetworkItem(GenericRemovableWidgetItem):
     """VMware Compute Resource Profile "Network interface" item widget"""
 
@@ -345,8 +298,7 @@ class ResourceProviderProfileView(BaseLoggedInView):
         Note: The provider name is always appended to the end of the compute resource name,
         for example: compute resource name "foo"
 
-        1. For RHV provider, the compute resource name will be displayed as: "foo (RHV)"
-        2. For EC2 provider, the compute resource name will be displayed as:
+        1. For EC2 provider, the compute resource name will be displayed as:
             "foo (ca-central-1-EC2)" where "ca-central-1" is the region.
         """
         compute_resource_name = self.compute_resource.read()
@@ -385,27 +337,6 @@ class ResourceProviderProfileView(BaseLoggedInView):
         network = FilteredDropdown(id='compute_attribute_vm_attrs_network')
         external_ip = Checkbox(id='compute_attribute_vm_attrs_associate_external_ip')
         default_disk_size = TextInput(id='compute_attribute_vm_attrs_volumes_attributes_0_size_gb')
-
-    @provider_content.register('RHV')
-    class RHVResourceForm(View):
-        cluster = FilteredDropdown(id='compute_attribute_vm_attrs_cluster')
-        template = FilteredDropdown(id='compute_attribute_vm_attrs_template')
-        instance_type = FilteredDropdown(id='compute_attribute_vm_attrs_instance_type')
-        cores = TextInput(id='compute_attribute_vm_attrs_cores')
-        sockets = TextInput(id='compute_attribute_vm_attrs_sockets')
-        memory = TextInput(id='compute_attribute_vm_attrs_memory')
-        highly_available = Checkbox(id='compute_attribute_vm_attrs_ha')
-
-        @View.nested
-        class network_interfaces(RemovableWidgetsItemsListView):
-            ROOT = "//fieldset[@id='network_interfaces']"
-            ITEM_WIDGET_CLASS = ComputeResourceRHVProfileNetworkItem
-
-        @View.nested
-        class storage(RemovableWidgetsItemsListView):
-            ROOT = "//fieldset[@id='storage_volumes']"
-            ITEMS = "./div/div[contains(@class, 'removable-item')]"
-            ITEM_WIDGET_CLASS = ComputeResourceRHVProfileStorageItem
 
     @provider_content.register('VMware')
     class VMwareResourceForm(View):
@@ -514,16 +445,6 @@ class ComputeResourceGenericImageEditViewMixin:
             and self.breadcrumb.locations[2] == 'Images'
             and self.breadcrumb.read().startswith('Edit ')
         )
-
-
-class ComputeResourceRHVImageCreateView(ComputeResourceGenericImageCreateView):
-    """RHV Compute resource Image create view."""
-
-
-class ComputeResourceRHVImageEditView(
-    ComputeResourceRHVImageCreateView, ComputeResourceGenericImageEditViewMixin
-):
-    """RHV Compute resource Image edit view."""
 
 
 class ComputeResourceVMwareImageCreateView(ComputeResourceGenericImageCreateView):

--- a/airgun/views/host.py
+++ b/airgun/views/host.py
@@ -310,8 +310,7 @@ class HostCreateView(BaseLoggedInView):
         Note: The provider name is always appended to the end of the compute resource name,
         for example: compute resource name "foo"
 
-        1. For RHV provider, the compute resource name will be displayed as: "foo (RHV)"
-        2. For Libvirt provider, the compute resource name will be displayed as: "foo (Libvirt)"
+        1. For Libvirt provider, the compute resource name will be displayed as: "foo (Libvirt)"
 
         Return "Compute resource is not specified" value in case no compute resource specified
         in deployment procedure (e.g. "Bare Metal")

--- a/airgun/views/virtwho_configure.py
+++ b/airgun/views/virtwho_configure.py
@@ -158,7 +158,7 @@ class VirtwhoConfigureCreateView(BaseLoggedInView):
     submit = Text('//input[@name="commit"]')
 
     @hypervisor_content.register(
-        lambda hypervisor_type: hypervisor_type.endswith(('(esx)', '(rhevm)', '(hyperv)', '(xen)'))
+        lambda hypervisor_type: hypervisor_type.endswith(('(esx)', '(hyperv)', '(xen)'))
     )
     class HypervisorForm(View):
         server = TextInput(id='foreman_virt_who_configure_config_hypervisor_server')


### PR DESCRIPTION
Since RHEV is not supported in Stream, removing the RHEV-related code from Airgun.

## Summary by Sourcery

Remove unsupported RHEV functionality and clean up related code paths in Airgun

Chores:
- Remove RHV provider form and nested datacenter view in compute resource UI
- Delete RHV-specific network and storage profile widgets under compute resource
- Unregister RHV image create/edit views from compute resource entities
- Remove RHEV entries from host provider listing and virtwho hypervisor registration
- Eliminate 'rhevm' mapping from virtwho configuration entity