### PR TITLE
PF5 Locators. Host > Content tabs. searchbars, dropdowns

### DIFF
--- a/airgun/views/host_new.py
+++ b/airgun/views/host_new.py
@@ -345,7 +345,7 @@ class NewHostDetailsView(BaseLoggedInView):
 
             select_all = Checkbox(locator='.//div[@id="selection-checkbox"]/div/label')
             searchbar = SearchInput(
-                locator='.//input[contains(@class, "pf-c-text-input-group__text-input")]'
+                locator='.//input[contains(@class, "pf-v5-c-text-input-group__text-input")]'
             )
             status_filter = Dropdown(locator='.//div[@aria-label="select Status container"]/div')
             upgrade = Pf4ActionsDropdown(locator='.//div[div/button[normalize-space(.)="Upgrade"]]')
@@ -359,7 +359,7 @@ class NewHostDetailsView(BaseLoggedInView):
                     'Status': Text('./span'),
                     'Installed version': Text('./parent::td'),
                     'Upgradable to': Text('./span'),
-                    5: Dropdown(locator='.//div[contains(@class, "pf-c-dropdown")]'),
+                    5: Dropdown(locator='.//div[button(@aria-label="Kebab toggle")]'),
                 },
             )
             pagination = PF4Pagination()
@@ -386,7 +386,7 @@ class NewHostDetailsView(BaseLoggedInView):
                     'Installable': Text('./span'),
                     'Synopsis': Text('./span'),
                     'Published date': Text('./span/span'),
-                    8: Dropdown(locator='./div'),
+                    8: Dropdown(locator='.//div[button(@aria-label="Kebab toggle")]'),
                 },
             )
             pagination = PF4Pagination(
@@ -416,7 +416,7 @@ class NewHostDetailsView(BaseLoggedInView):
                     'Stream': Text('./parent::td'),
                     'Installation status': Text('.//small'),
                     'Installed profile': Text('./parent::td'),
-                    5: DropdownWithDescripton(locator='.//div[contains(@class, "pf-c-dropdown")]'),
+                    5: Dropdown(locator='.//div[button(@aria-label="Kebab toggle")]'),
                 },
             )
             pagination = PF4Pagination()


### PR DESCRIPTION
Searchbar and dropdowns on Content subtabs like 'Packages', 'Errata', 'Module Streams' have old PF4 locators.
similar to changes of the `repository_sets(Tab)` PF5 updates: see `views/host_new.py` in #1789 

New Host UI > Content > subtab (such as MS, Errata) > searchbar (pf5 locator), dropdown for each table entry (Kebab toggle).

## Summary by Sourcery

Update PF5 locators for search inputs and kebab dropdowns in Host UI Content subtabs

Enhancements:
- Replace PF4 search input locator with PF5 class in Content subtabs
- Standardize table entry dropdown locator to Kebab toggle across packages, errata, and module streams
- Migrate dropdown locator implementations from generic PF4 to PF5-specific selectors