### PR TITLE
Job Templates: fix breadcrumb text

### DIFF
--- a/airgun/views/job_template.py
+++ b/airgun/views/job_template.py
@@ -53,7 +53,7 @@ class JobTemplateCreateView(BaseLoggedInView):
         breadcrumb_loaded = self.browser.wait_for_element(self.breadcrumb, exception=False)
         return (
             breadcrumb_loaded
-            and self.breadcrumb.locations[0] == 'Job templates'
+            and self.breadcrumb.locations[0] == 'Job Templates'
             and self.breadcrumb.read() == 'New Job Template'
         )
 


### PR DESCRIPTION
### Fix breadcrum text for New Job Templates page ###

Due to text change from `Job templates` to `Job Templates`,
the `JobTemplateCreateView.is_displayed` was failing and so was the navigation step.

### PRT example ###
```
trigger: test-robottelo
pytest: tests/foreman/ui/test_remoteexecution.py -k test_positive_run_custom_job_template
```

