### PR TITLE
New job invocation details page: updated to PF5

### DIFF
--- a/airgun/views/job_invocation.py
+++ b/airgun/views/job_invocation.py
@@ -1,18 +1,17 @@
 from wait_for import wait_for
 from widgetastic.widget import Checkbox, Text, TextInput, View
 from widgetastic_patternfly import BreadCrumb
-from widgetastic_patternfly4 import Button, DescriptionList
-from widgetastic_patternfly4.donutchart import DonutCircle, DonutLegend
-from widgetastic_patternfly4.ouia import (
-    Dropdown as OUIADropdown,
-    Text as OUIAText,
-)
+from widgetastic_patternfly4 import Button
 from widgetastic_patternfly5 import (
     ChipGroup as PF5ChipGroup,
+    DescriptionList,
     Radio as PF5Radio,
 )
+from widgetastic_patternfly5.charts.donut_chart import DonutCircle, DonutLegend
 from widgetastic_patternfly5.ouia import (
+    Dropdown as PF5OUIADropdown,
     Select as PF5OUIASelect,
+    Text as PF5OUIAText,
     TextInput as PF5OUIATextInput,
 )
 
@@ -23,7 +22,7 @@ from airgun.views.common import (
     SearchableViewMixin,
     WizardStepView,
 )
-from airgun.widgets import ActionsDropdown, ExpandableSection, PF4DataList
+from airgun.widgets import ActionsDropdown, PF5DataList, PF5LabeledExpandableSection
 
 
 class JobInvocationsView(BaseLoggedInView, SearchableViewMixin):
@@ -229,9 +228,9 @@ class JobInvocationStatusView(BaseLoggedInView):
 
 class NewJobInvocationStatusView(BaseLoggedInView):
     breadcrumb = BreadCrumb()
-    title = OUIAText('breadcrumb_title')
+    title = PF5OUIAText(component_id='breadcrumb_title')
     create_report = Button(value='Create report')
-    actions = OUIADropdown('job-invocation-global-actions-dropdown')
+    actions = PF5OUIADropdown(component_id='job-invocation-global-actions-dropdown')
     BREADCRUMB_LENGTH = 2
 
     @property
@@ -290,18 +289,18 @@ class NewJobInvocationStatusView(BaseLoggedInView):
             return {key.replace(':', ''): val for key, val in super().read().items()}
 
     @View.nested
-    class target_hosts(ExpandableSection):
+    class target_hosts(PF5LabeledExpandableSection):
         label = 'Target Hosts'
-        search_query = Text('./div[contains(@class, "pf-c-expandable-section__content")]/pre')
-        data = PF4DataList()
+        search_query = Text('./div[contains(@class, "-c-expandable-section__content")]/pre')
+        data = PF5DataList()
 
         def read(self):
             return {'search_query': self.search_query.read(), 'data': self.data.read()}
 
     @View.nested
-    class user_inputs(ExpandableSection):
+    class user_inputs(PF5LabeledExpandableSection):
         label = 'User Inputs'
-        data = PF4DataList()
+        data = PF5DataList()
 
         def read(self):
             return {'data': self.data.read()}

--- a/airgun/widgets.py
+++ b/airgun/widgets.py
@@ -31,7 +31,11 @@ from widgetastic_patternfly4.ouia import (
     Button as OUIAButton,
 )
 from widgetastic_patternfly4.table import BaseExpandableTable, BasePatternflyTable
-from widgetastic_patternfly5 import Button as PF5Button, Progress as PF5Progress
+from widgetastic_patternfly5 import (
+    Button as PF5Button,
+    ExpandableSection as PF5ExpandableSection,
+    Progress as PF5Progress,
+)
 from widgetastic_patternfly5.ouia import (
     BaseSelect as PF5BaseSelect,
     Button as PF5OUIAButton,
@@ -2926,35 +2930,29 @@ class SatExpandableTable(BaseExpandableTable, SatPatternflyTable):
     pass
 
 
-class ExpandableSection(Widget):
+class PF5LabeledExpandableSection(PF5ExpandableSection):
+    """PF5 Expandable section (https://pf5.patternfly.org/components/expandable-section/)
+    with a labeled button as the section expand/collapse toggle.
+
+    Note: You need to set the `label` attribute yourself in your inherited class!
+    """
+
     ROOT = ParametrizedLocator(
-        '//div[contains(@class, "pf-c-expandable-section")]/button[normalize-space(.)={@label|quote}]/..'
+        '//div[contains(@class, "-c-expandable-section")]/button[normalize-space(.)={@label|quote}]/..'
     )
-    TOGGLE_BUTTON = ParametrizedLocator('./button[normalize-space(.)={@label|quote}]')
-    EXPANDED_CLASS_NAME = 'pf-m-expanded'
-
-    @property
-    def is_expanded(self):
-        return self.EXPANDED_CLASS_NAME in self.browser.classes(self.ROOT)
-
-    def expand(self):
-        if not self.is_expanded:
-            self.browser.click(self.TOGGLE_BUTTON)
-
-    def collapse(self):
-        if self.is_expanded:
-            self.browser.click(self.TOGGLE_BUTTON)
+    BUTTON_LOCATOR = ParametrizedLocator('.//button[normalize-space(.)={@label|quote}]')
+    label = 'You need to set this `label` attribute yourself!'
 
     def read(self):
         self.expand()
 
 
-class PF4DataList(Widget):
-    """Widget for PatternFly 4 Data list: https://pf4.patternfly.org/components/data-list"""
+class PF5DataList(Widget):
+    """Widget for PatternFly 5 Data list: https://pf5.patternfly.org/components/data-list"""
 
-    ROOT = './/ul[contains(@class, "pf-c-data-list")]'
-    ITEMS = './li//div[contains(@class, "pf-c-data-list__item-content")]/div[1]'
-    VALUES = './li//div[contains(@class, "pf-c-data-list__item-content")]/div[2]'
+    ROOT = './/ul[contains(@class, "-c-data-list")]'
+    ITEMS = './li//div[contains(@class, "-c-data-list__item-content")]/div[1]'
+    VALUES = './li//div[contains(@class, "-c-data-list__item-content")]/div[2]'
 
     def read(self):
         items = [self.browser.text(item) for item in self.browser.elements(self.ITEMS)]


### PR DESCRIPTION
### New job invocation details page: updated to PF5 ###
Widgets on the new job invocation details page have been updated to PF5.

### PRT example ###
```
trigger: test-robottelo
pytest: tests/foreman/ui/test_remoteexecution.py -k test_positive_check_job_invocation_details_page
```

## Summary by Sourcery

Update job invocation details page and underlying widget classes to PatternFly 5 by replacing PF4 components and adjusting locators.

Enhancements:
- Replace PF4 ExpandableSection and DataList widgets with PF5LabeledExpandableSection and PF5DataList implementations.
- Switch JobInvocation view to use PF5OUIAText and PF5OUIADropdown and apply new PF5 widget classes for expandable sections and data lists.