### PR TITLE
[6.16.z] waiting for alert message after host delete

### DIFF
--- a/airgun/entities/host.py
+++ b/airgun/entities/host.py
@@ -140,6 +140,12 @@ class HostEntity(BaseEntity):
         view.search(entity_name)
         view.table.row(name=entity_name)['Actions'].widget.fill('Delete')
         self.browser.handle_alert()
+        wait_for(
+            lambda: view.flash.assert_message(
+                f"Success alert: Successfully deleted {entity_name}."
+            ),
+            timeout=120,
+        )
         view.flash.assert_no_error()
         view.flash.dismiss()
 


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/airgun/pull/1891

This test `tests.foreman.ui.test_computeresource_azurerm.test_positive_end_to_end_azurerm_ft_host_provision` is inconsistent — it passes sometimes and fails other times. In Azure, deleting a host take some time, so I'm adding a check to look for the 'delete' message to avoid failures.

## Summary by Sourcery

Bug Fixes:
- Add a wait_for check for the delete success flash message after host deletion to handle Azure’s variable deletion latency and prevent intermittent test failures.