### PR TITLE
[6.17.z] fix: broken techdocs annotations

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -12,10 +12,9 @@ metadata:
     - python
     - rh-satellite
     - interaction-library
-  namespace: quality-community   
+  namespace: quality-community
   annotations:
     github.com/project-slug: SatelliteQE/airgun
-    backstage.io/techdocs-ref: https://airgun.readthedocs.io/en/latest/
 spec:
   type: library
   owner: group:redhat/satellite-qe


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/airgun/pull/1873

Removed the techdocs annotation, as it only supports building docs from md files

## Summary by Sourcery

Bug Fixes:
- Remove backstage.io/techdocs-ref annotation to fix broken TechDocs integration