### PR TITLE
update alert msg after host delete

### DIFF
--- a/airgun/entities/host.py
+++ b/airgun/entities/host.py
@@ -141,9 +141,7 @@ class HostEntity(BaseEntity):
         view.table.row(name=entity_name)['Actions'].widget.fill('Delete')
         self.browser.handle_alert()
         wait_for(
-            lambda: view.flash.assert_message(
-                f"Success alert: Successfully deleted {entity_name}."
-            ),
+            lambda: view.flash.assert_message(f"Successfully deleted {entity_name}."),
             timeout=120,
         )
         view.flash.assert_no_error()


### PR DESCRIPTION
Updated the alert message for host deletion. An unnecessary line removed, which was causing some tests to fail.

## Summary by Sourcery

Bug Fixes:
- Fix host deletion flash message by removing the redundant 'Success alert:' prefix to resolve test failures