### PR TITLE
Update locators to PF5 for DiscoveryPlugin

### DIFF
--- a/airgun/views/host_new.py
+++ b/airgun/views/host_new.py
@@ -69,10 +69,10 @@ class Card(View):
     title = Text('.//div[@class="pf-v5-c-card__title"]')
 
 
-class DropdownWithDescripton(Dropdown):
+class DropdownWithDescripton(PF5Dropdown):
     """Dropdown with description below items"""
 
-    ITEM_LOCATOR = ".//*[contains(@class, 'pf-c-dropdown__menu-item') and contains(text(), {})]"
+    ITEM_LOCATOR = ".//*[contains(@class, 'pf-v5-c-dropdown__menu-item') and contains(text(), {})]"
 
 
 class HostDetailsCard(Widget):
@@ -105,8 +105,8 @@ class HostDetailsCard(Widget):
 class HostColectionsList(Widget):
     """Host collections list in host details page"""
 
-    ROOT = './/div[@class="pf-c-card__body host-collection-card-body"]'
-    ITEMS = './/span[contains(@class, "pf-c-expandable-section__toggle-text")]'
+    ROOT = './/div[@class="pf-v5-c-card__body host-collection-card-body"]'
+    ITEMS = './/span[contains(@class, "pf-v5-c-expandable-section__toggle-text")]'
 
     def read(self):
         """Return a list of assigned host collections"""
@@ -121,12 +121,12 @@ class NewHostDetailsView(BaseLoggedInView):
         breadcrumb_loaded = self.browser.wait_for_element(self.breadcrumb, exception=False)
         return breadcrumb_loaded and self.breadcrumb.locations[0] == 'Hosts'
 
-    edit = OUIAButton('host-edit-button')
+    edit = PF5OUIAButton('host-edit-button')
     dropdown = PF5Dropdown(locator='//button[@id="hostdetails-kebab"]/..')
     schedule_job = Pf4ActionsDropdown(locator='.//div[div/button[@aria-label="Select"]]')
     run_job = ActionsDropdown('//button[@data-ouia-component-id="schedule-a-job-dropdown-toggle"]')
     select = Text(
-        '//ul[@class="pf-c-dropdown__menu pf-m-align-right"]/li/a/div[normalize-space(text())="Run Ansible roles"]'
+        '//ul[@class="pf-v5-c-dropdown__menu pf-m-align-right"]/li/a/div[normalize-space(text())="Run Ansible roles"]'
     )
 
     @View.nested
@@ -135,11 +135,10 @@ class NewHostDetailsView(BaseLoggedInView):
 
         @View.nested
         class details(Card):
-            ROOT = './/article[.//div[text()="Details"]]'
-            edit = Text('.//div[@class="pf-c-description-list__group"]/dd//div[2]')
+            ROOT = './/div[@data-ouia-component-id="details-card"]'
+            edit = Text('.//div[@class="pf-v5-c-description-list__group"]/dd//div[2]')
             details = HostDetailsCard()
-
-            power_operations = OUIAButton('power-status-dropdown-toggle')
+            power_operations = PF5OUIAButton('power-status-dropdown-toggle')
 
         @View.nested
         class host_status(Card):
@@ -163,7 +162,7 @@ class NewHostDetailsView(BaseLoggedInView):
         class recent_communication(Card):
             ROOT = './/article[.//div[text()="Recent communication"]]'
 
-            last_checkin_value = Text('.//div[@class="pf-c-description-list__text"]')
+            last_checkin_value = Text('.//div[@class="pf-v5-c-description-list__text"]')
 
         @View.nested
         class errata(Card):
@@ -174,7 +173,7 @@ class NewHostDetailsView(BaseLoggedInView):
         @View.nested
         class content_view_details(Card):
             ROOT = './/article[.//div[text()="Content view details"]]'
-            actions = Dropdown(locator='.//div[contains(@class, "pf-c-dropdown")]')
+            actions = Dropdown(locator='.//div[contains(@class, "pf-v5-c-dropdown")]')
 
             org_view = Text('.//a[contains(@href, "content_views")]')
 
@@ -189,7 +188,7 @@ class NewHostDetailsView(BaseLoggedInView):
         @View.nested
         class total_risks(Card):
             ROOT = './/article[.//div[text()="Total risks"]]'
-            actions = Dropdown(locator='.//div[contains(@class, "pf-c-dropdown")]')
+            actions = Dropdown(locator='.//div[contains(@class, "pf-v5-c-dropdown")]')
 
             low = Text('.//*[@id="legend-labels-0"]/*')
             moderate = Text('.//*[@id="legend-labels-1"]/*')
@@ -199,16 +198,16 @@ class NewHostDetailsView(BaseLoggedInView):
         @View.nested
         class host_collections(Card):
             ROOT = './/article[.//div[text()="Host collections"]]'
-            kebab_menu = Dropdown(locator='.//div[contains(@class, "pf-c-dropdown")]')
+            kebab_menu = Dropdown(locator='.//div[contains(@class, "pf-v5-c-dropdown")]')
             no_host_collections = Text('.//h2')
-            add_to_host_collection = OUIAButton('add-to-a-host-collection-button')
+            add_to_host_collection = PF5OUIAButton('add-to-a-host-collection-button')
 
             assigned_host_collections = HostColectionsList()
 
         @View.nested
         class recent_jobs(Card):
             ROOT = './/article[.//div[text()="Recent jobs"]]'
-            actions = Dropdown(locator='.//div[contains(@class, "pf-c-dropdown")]')
+            actions = Dropdown(locator='.//div[contains(@class, "pf-v5-c-dropdown")]')
 
             class finished(Tab):
                 table = SatTableWithoutHeaders(locator='.//table[@aria-label="recent-jobs-table"]')
@@ -289,7 +288,7 @@ class NewHostDetailsView(BaseLoggedInView):
         class installed_products(Card):
             ROOT = './/div[contains(@data-ouia-component-id, "card-template-Installed products")]'
 
-            installed_products_list = ItemsList(locator='.//ul[contains(@class, "pf-c-list")]')
+            installed_products_list = ItemsList(locator='.//ul[contains(@class, "pf-v5-c-list")]')
 
         @View.nested
         class networking_interfaces(Card):
@@ -298,10 +297,10 @@ class NewHostDetailsView(BaseLoggedInView):
             )
 
             networking_interfaces_accordion = Accordion(
-                locator='.//div[contains(@class, "pf-c-card__expandable-content")]'
+                locator='.//div[contains(@class, "pf-v5-c-card__expandable-content")]'
             )
             locator_templ = (
-                './/div[contains(@class, "pf-c-accordion__expanded-content-body")]'
+                './/div[contains(@class, "pf-v5-c-accordion__expanded-content-body")]'
                 '//div[.//dt[normalize-space(.)="{}"]]//div'
             )
             networking_interfaces_dict = {
@@ -370,7 +369,7 @@ class NewHostDetailsView(BaseLoggedInView):
             ROOT = './/div[@id="errata-tab"]'
 
             select_all = Checkbox(locator='.//div[@id="selection-checkbox"]/div/label')
-            searchbar = SearchInput(locator='.//input[contains(@class, "pf-c-text-input")]')
+            searchbar = SearchInput(locator='.//input[contains(@class, "pf-v5-c-text-input")]')
             type_filter = Select(locator='.//div[@aria-label="select Type container"]/div')
             severity_filter = Select(locator='.//div[@aria-label="select Severity container"]/div')
             apply = Pf4ActionsDropdown(locator='.//div[@aria-label="errata_dropdown"]')
@@ -390,7 +389,7 @@ class NewHostDetailsView(BaseLoggedInView):
                 },
             )
             pagination = PF4Pagination(
-                "//div[@class = 'pf-c-pagination pf-m-bottom tfm-pagination']"
+                "//div[@class = 'pf-v5-c-pagination pf-m-bottom tfm-pagination']"
             )
 
         @View.nested
@@ -448,7 +447,7 @@ class NewHostDetailsView(BaseLoggedInView):
                     'Repository': Text('./span'),
                     'Product': Text('./a'),
                     'Repository path': Text('./span'),
-                    'Status': Text('.//span[contains(@class, "pf-c-label__content")]'),
+                    'Status': Text('.//span[contains(@class, "pf-v5-c-label__content")]'),
                     'Repository Type': Text('./span'),
                     6: PF5Button(locator='./button'),
                 },
@@ -464,7 +463,7 @@ class NewHostDetailsView(BaseLoggedInView):
 
         add_parameter = Button(locator='.//button[text()="Add parameter"]')
         searchbar = SearchInput(
-            locator='//input[contains(@class, "pf-c-search-input__text-input")]'
+            locator='//input[contains(@class, "pf-v5-c-search-input__text-input")]'
         )
         parameter_name_input = TextInput(locator='.//td//input[contains(@aria-label, "name")]')
         parameter_type_input = Select(
@@ -488,7 +487,7 @@ class NewHostDetailsView(BaseLoggedInView):
                         '[contains(@data-ouia-component-id, "OUIA-Generated-Button-plain-")]'
                     )
                 ),
-                5: Dropdown(locator='.//div[contains(@class, "pf-c-dropdown")]'),
+                5: Dropdown(locator='.//div[contains(@class, "pf-v5-c-dropdown")]'),
             },
         )
         pagination = PF4Pagination()
@@ -501,7 +500,7 @@ class NewHostDetailsView(BaseLoggedInView):
         enable_traces = PF5OUIAButton('enable-traces-button')
         select_all = Checkbox(locator='.//input[contains(@aria-label, "Select all")]')
         searchbar = SearchInput(locator='.//input[contains(@aria-label, "Select all")]')
-        Pf4ActionsDropdown = Button(
+        Pf4ActionsDropdown = PF5Button(
             locator='.//div[contains(@aria-label, "bulk_actions_dropdown")]'
         )
         traces_table = PatternflyTable(
@@ -511,7 +510,7 @@ class NewHostDetailsView(BaseLoggedInView):
                 'Application': Text('.//td[2]'),
                 'Type': Text('.//td[3]'),
                 'Helper': Text('.//td[4]'),
-                4: Button(locator='.//button[contains(@aria-label, "Actions")]'),
+                4: PF5Button(locator='.//button[contains(@aria-label, "Actions")]'),
             },
         )
         pagination = PF4Pagination()
@@ -528,10 +527,10 @@ class NewHostDetailsView(BaseLoggedInView):
             ROOT = './/div[@class="ansible-host-detail"]'
 
             assignedRoles = Text('.//a[contains(@href, "roles/all")]')
-            edit = Button(locator='.//button[@aria-label="edit ansible roles"]')
-            noRoleAssign = Text('.//h5[contains(@class, "pf-c-title pf-m-4xl")]')
-            table = Table(
-                locator='.//table[contains(@class, "pf-c-table")]',
+            edit = PF5Button(locator='.//button[@aria-label="edit ansible roles"]')
+            noRoleAssign = Text('.//h5[contains(@class, "pf-v5-c-empty-state__title-text")]')
+            table = PF5OUIATable(
+                component_id='table-composable-compact',
                 column_widgets={'Name': Text('.//a')},
             )
             pagination = PF4Pagination()
@@ -541,29 +540,31 @@ class NewHostDetailsView(BaseLoggedInView):
             TAB_NAME = 'Variables'
             ROOT = './/div[@class="ansible-host-detail"]'
 
-            actions = Button(locator='//tbody/tr/td[7]//button')
-            delete = Button(locator='//button[@role="menuitem"]')
-            confirm = Button(locator='//button[@data-ouia-component-id="btn-modal-confirm"]')
-            table = Table(
-                locator='.//table[contains(@class, "pf-c-table")]',
+            actions = PF5Button(locator='//button[contains(@aria-label, "Kebab toggle")]')
+            delete = PF5Button(locator='//button[@role="menuitem"]')
+            confirm = PF5Button(locator='//button[@data-ouia-component-id="btn-modal-confirm"]')
+            table = PF5OUIATable(
+                component_id='table-composable-compact',
                 column_widgets={
                     'Name': Text('.//a'),
                     'Ansible role': Text('./span'),
                     'Type': Text('./span'),
                     # the next field can also be a form group
-                    'Value': TextInput(locator='//textarea[contains(@class, "pf-c-form")]'),
+                    'Value': TextInput(
+                        locator='//textarea[contains(@aria-label, "Edit override field")]'
+                    ),
                     'Source attribute': Text('./span'),
                     # The next 2 buttons are hidden by default, but appear in this order
-                    6: Button(locator='.//button[@aria-label="Cancel editing override button"]'),
-                    7: Button(locator='.//button[@aria-label="Submit override button"]'),
+                    6: PF5Button(locator='.//button[@aria-label="Cancel editing override button"]'),
+                    7: PF5Button(locator='.//button[@aria-label="Submit override button"]'),
                     # Clicking this button hides it, and displays the previous 2
-                    5: Button(locator='.//button[@aria-label="Edit override button"]'),
+                    5: PF5Button(locator='.//button[@aria-label="Edit override button"]'),
                 },
             )
-            table1 = Table(
-                locator='.//table[contains(@class, "pf-c-table")]',
+            table1 = PF5OUIATable(
+                component_id='table-composable-compact',
                 column_widgets={
-                    5: Button(locator='.//button[@aria-label="Submit editing override button"]'),
+                    5: PF5Button(locator='.//button[@aria-label="Submit editing override button"]'),
                 },
             )
             pagination = PF4Pagination()
@@ -589,7 +590,7 @@ class NewHostDetailsView(BaseLoggedInView):
             @View.nested
             class schedule(PF5Tab):
                 # Only displays when there isn't a Job scheduled for this host
-                scheduleRecurringJob = Button(
+                scheduleRecurringJob = PF5Button(
                     locator='.//button[@aria-label="schedule recurring job"]'
                 )
 
@@ -602,12 +603,12 @@ class NewHostDetailsView(BaseLoggedInView):
                 # Mutually Exclusive with the above button
                 scheduledText = './/h3[text()="Scheduled recurring jobs"]'
                 scheduledJobsTable = Table(
-                    locator='.//div[contains(@class, "pf-c-table)"]',
+                    locator='.//div[contains(@class, "pf-v5-c-table)"]',
                     column_widgets={
                         'Description': Text('.//a'),
                         'Schedule': Text('./span'),
                         'Next Run': Text('./span'),
-                        4: Dropdown(locator='.//div[contains(@class, "pf-c-dropdown")]'),
+                        4: Dropdown(locator='.//div[contains(@class, "pf-v5-c-dropdown")]'),
                     },
                 )
                 pagination = PF4Pagination()
@@ -651,7 +652,7 @@ class NewHostDetailsView(BaseLoggedInView):
                 'applied': Text('.//td[5]'),
                 'skipped': Text('.//td[6]'),
                 'pending': Text('.//td[7]'),
-                7: Button(locator='.//button[contains(@aria-label, "Actions")]'),
+                7: PF5Button(locator='.//button[contains(@aria-label, "Actions")]'),
             },
         )
         pagination = PF4Pagination()
@@ -666,13 +667,13 @@ class NewHostDetailsView(BaseLoggedInView):
         class puppet_details(Card):
             ROOT = './/article[.//div[text()="Puppet details"]]'
             puppet_environment = Text(
-                './div[2]//div[contains(@class, "pf-c-description-list__group")][1]//dd'
+                './div[2]//div[contains(@class, "pf-v5-c-description-list__group")][1]//dd'
             )
             puppet_capsule = Text(
-                './div[2]//div[contains(@class, "pf-c-description-list__group")][2]//dd'
+                './div[2]//div[contains(@class, "pf-v5-c-description-list__group")][2]//dd'
             )
             puppet_ca_capsule = Text(
-                './div[2]//div[contains(@class, "pf-c-description-list__group")][3]//dd'
+                './div[2]//div[contains(@class, "pf-v5-c-description-list__group")][3]//dd'
             )
 
     @View.nested
@@ -691,7 +692,7 @@ class NewHostDetailsView(BaseLoggedInView):
                 'skipped': Text('.//td[6]'),
                 'origin': Text('.//td[7]'),
                 'pending': Text('.//td[8]'),
-                8: Button(locator='.//button[contains(@aria-label, "Actions")]'),
+                8: PF5Button(locator='.//button[contains(@aria-label, "Actions")]'),
             },
         )
 
@@ -702,11 +703,11 @@ class NewHostDetailsView(BaseLoggedInView):
         ROOT = './/div'
 
         search_bar = SearchInput(locator='.//input[contains(@class, "pf-v5-c-text-input")]')
-        remediate = Button(locator='.//button[text()="Remediate"]')
+        remediate = PF5Button(locator='.//button[text()="Remediate"]')
         insights_dropdown = Dropdown(locator='.//div[contains(@class, "insights-dropdown")]')
 
         select_all_one_page = Checkbox(locator='.//input[@name="check-all"]')
-        select_all_pages = Button(
+        select_all_pages = PF5Button(
             locator='.//button[text()="Select recommendations from all pages"]'
         )
 
@@ -717,7 +718,7 @@ class NewHostDetailsView(BaseLoggedInView):
                 'Recommendation': Text('.//td[2]'),
                 'Total Risk': Text('.//td[3]'),
                 'Remediate': Text('.//td[4]'),
-                4: Button(locator='.//button[contains(@aria-label, "Actions")]'),
+                4: PF5Button(locator='.//button[contains(@aria-label, "Actions")]'),
             },
         )
         pagination = PF5Pagination()
@@ -743,8 +744,8 @@ class InstallPackagesView(View):
     )
     pagination = PF4Pagination()
 
-    install = Button(locator='.//button[(normalize-space(.)="Install")]')
-    cancel = Button('Cancel')
+    install = PF5Button(locator='.//button[(normalize-space(.)="Install")]')
+    cancel = PF5Button('Cancel')
 
 
 class AllAssignedRolesView(View):
@@ -753,7 +754,7 @@ class AllAssignedRolesView(View):
     ROOT = './/div[@data-ouia-component-id="modal-ansible-roles"]'
 
     table = Table(
-        locator='.//table[contains(@class, "pf-c-table")]',
+        locator='.//table[contains(@class, "pf-v5-c-table")]',
         column_widgets={'Name': Text('.//a'), 'Source': Text('.//a')},
     )
     pagination = PF4Pagination()
@@ -786,7 +787,7 @@ class ManageHostCollectionModal(View):
     searchbar = SearchInput(locator='.//input[contains(@class, "pf-m-search")]')
 
     host_collection_table = Table(
-        locator='.//table[contains(@class, "pf-c-table")]',
+        locator='.//table[contains(@class, "pf-v5-c-table")]',
         column_widgets={
             0: Checkbox(locator='.//input[@type="checkbox"]'),
             'host_collecntion': Text('.//a'),
@@ -820,14 +821,14 @@ class ManageHostStatusesView(View):
     """Manage host statuses modal"""
 
     ROOT = './/div[@data-ouia-component-id="statuses-modal"]'
-    close_modal = Button(locator='.//button[@aria-label="Close"]')
+    close_modal = PF5Button(locator='.//button[@aria-label="Close"]')
     host_statuses_table = PF5OUIATable(
         component_id='statuses-table',
         column_widgets={
             'Name': Text('.//td[contains(@data-label, "Name")]'),
             'Status': Text('.//td[contains(@data-label, "Status")]'),
             'Reported at': Text('.//td[contains(@data-label, "Reported at")]'),
-            3: Button(locator='.//td[contains(@class, "action")]'),
+            3: PF5Button(locator='.//td[contains(@class, "action")]'),
         },
     )
 
@@ -839,23 +840,23 @@ class ManageHostStatusesView(View):
 class EditAnsibleRolesView(View):
     """Edit Ansible Roles Modal"""
 
-    addAnsibleRole = DualListSelector('//div[@class = "pf-c-dual-list-selector"]')
-    confirm = Button(locator='.//button[@aria-label="submit ansible roles"]')
+    addAnsibleRole = DualListSelector('//div[@class = "pf-v5-c-dual-list-selector"]')
+    confirm = PF5Button(locator='.//button[@aria-label="submit ansible roles"]')
     hostAssignedAnsibleRoles = Text(
-        './/button[@class="pf-c-dual-list-selector__item"]/span[1]//span[2]'
+        './/button[@class="pf-v5-c-dual-list-selector__item"]/span[1]//span[2]'
     )
-    selectRoles = Button(locator='.//button[@aria-label="Add selected"]')
-    unselectRoles = Button(locator='.//button[@aria-label="Remove selected"]')
+    selectRoles = PF5Button(locator='.//button[@aria-label="Add selected"]')
+    unselectRoles = PF5Button(locator='.//button[@aria-label="Remove selected"]')
 
 
 class ModuleStreamDialog(Pf4ConfirmationDialog):
-    confirm_dialog = Button(locator='.//button[@aria-label="confirm-module-action"]')
-    cancel_dialog = Button(locator='.//button[@aria-label="cancel-module-action"]')
+    confirm_dialog = PF5Button(locator='.//button[@aria-label="confirm-module-action"]')
+    cancel_dialog = PF5Button(locator='.//button[@aria-label="cancel-module-action"]')
 
 
 class RecurringJobDialog(Pf4ConfirmationDialog):
-    confirm_dialog = Button(locator='.//button[@data-ouia-component-id="btn-modal-confirm"]')
-    cancel_dialog = Button(locator='.//button[@data-ouia-component-id="btn-modal-cancel"]')
+    confirm_dialog = PF5Button(locator='.//button[@data-ouia-component-id="btn-modal-confirm"]')
+    cancel_dialog = PF5Button(locator='.//button[@data-ouia-component-id="btn-modal-cancel"]')
 
 
 class PF5CheckboxTreeView(CheckboxGroup):
@@ -891,8 +892,8 @@ class ManageColumnsView(BaseLoggedInView):
         './/header//span[contains(@class, "pf-v5-c-modal-box__title")]'
         '[normalize-space(.)="Manage columns"]'
     )
-    confirm_dialog = Button(locator='.//button[normalize-space(.)="Save"]')
-    cancel_dialog = Button(locator='.//button[normalize-space(.)="Cancel"]')
+    confirm_dialog = PF5Button(locator='.//button[normalize-space(.)="Save"]')
+    cancel_dialog = PF5Button(locator='.//button[normalize-space(.)="Cancel"]')
     checkbox_group = PF5CheckboxTreeView(locator='.//div[contains(@class, "pf-v5-c-tree-view")]')
 
     def collapsed_sections(self):


### PR DESCRIPTION
Update Host Page locators to fix Discovery Tests

Jira tracker for fixing typo in class DropdownWithDescripton https://issues.redhat.com/browse/SAT-35485

## Summary by Sourcery

Migrate host page views to PatternFly 5 by updating component classes and XPath locators

Bug Fixes:
- Fix Discovery plugin tests by updating host page locators to PF5 conventions

Enhancements:
- Migrate widget classes (Dropdown, Button, OUIAButton, Table, Pagination) to PF5 equivalents
- Replace pf-c-… CSS class references with pf-v5-c-… in XPath locators throughout host_new.py
- Adjust component locators (dual list selector, tree view, etc.) to match PF5 structure