### PR TITLE
Disassociate Hosts Coverage [SAT-31029]

### DIFF
--- a/airgun/entities/all_hosts.py
+++ b/airgun/entities/all_hosts.py
@@ -12,6 +12,7 @@ from airgun.views.all_hosts import (
     AllHostsTableView,
     BuildManagementDialog,
     BulkHostDeleteDialog,
+    DisassociateHostsModal,
     HostDeleteDialog,
     HostgroupDialog,
     ManageCVEModal,
@@ -515,6 +516,39 @@ class AllHostsEntity(BaseEntity):
         if view.review.number_of_repository_status_changed.text != str(len(repository_names)):
             raise Exception("Repository count not matches")
         view.review.set_content_overrides.click()
+
+    def disassociate_hosts(self, host_names, select_all_hosts=False):
+        """
+        Navigate to the Disassociate hosts modal for selected hosts and disassociate them.
+
+        :param hosts_to_disassociate: List of host names to disassociate.
+        :param select_all_hosts: If True, all hosts will be selected for disassociation.
+        """
+
+        # Check validity of user input
+        if select_all_hosts and host_names:
+            raise ValueError('Cannot select all and specify host names at the same time!')
+        # Navigate to All Hosts
+        view = self.navigate_to(self, 'All')
+        self.browser.plugin.ensure_page_safe(timeout='5s')
+        view.wait_displayed()
+
+        # Select all hosts from the table
+        if select_all_hosts:
+            view.select_all.fill(True)
+        # Select user-specified hosts
+        else:
+            if not isinstance(host_names, list):
+                host_names = [host_names]
+            for host_name in host_names:
+                view.search(host_name)
+                view.table[0][0].widget.fill(True)
+
+        view.bulk_actions_kebab.click()
+        view.bulk_actions_menu.item_select('Disassociate hosts')
+
+        view = DisassociateHostsModal(self.browser)
+        view.confirm_btn.click()
 
 
 @navigator.register(AllHostsEntity, 'All')

--- a/airgun/entities/all_hosts.py
+++ b/airgun/entities/all_hosts.py
@@ -521,7 +521,7 @@ class AllHostsEntity(BaseEntity):
         """
         Navigate to the Disassociate hosts modal for selected hosts and disassociate them.
 
-        :param hosts_to_disassociate: List of host names to disassociate.
+        :param host_names: List of host names to disassociate.
         :param select_all_hosts: If True, all hosts will be selected for disassociation.
         """
 

--- a/airgun/entities/all_hosts.py
+++ b/airgun/entities/all_hosts.py
@@ -525,18 +525,15 @@ class AllHostsEntity(BaseEntity):
         :param select_all_hosts: If True, all hosts will be selected for disassociation.
         """
 
-        # Check validity of user input
         if select_all_hosts and host_names:
             raise ValueError('Cannot select all and specify host names at the same time!')
-        # Navigate to All Hosts
+
         view = self.navigate_to(self, 'All')
         self.browser.plugin.ensure_page_safe(timeout='5s')
         view.wait_displayed()
 
-        # Select all hosts from the table
         if select_all_hosts:
             view.select_all.fill(True)
-        # Select user-specified hosts
         else:
             if not isinstance(host_names, list):
                 host_names = [host_names]

--- a/airgun/views/all_hosts.py
+++ b/airgun/views/all_hosts.py
@@ -18,6 +18,7 @@ from widgetastic_patternfly5 import (
     Radio as PF5Radio,
 )
 from widgetastic_patternfly5.ouia import (
+    Button as PF5OUIAButton,
     PatternflyTable as PF5OUIATable,
 )
 
@@ -581,6 +582,24 @@ class ManageRepositorySetsModal(PF5Modal):
         set_content_overrides = Button(
             locator='//button[@type="submit" and @data-ouia-component-id="bulk-repo-sets-wizard-finish-button"]'
         )
+
+    @property
+    def is_displayed(self):
+        return self.browser.wait_for_element(self.title, exception=False) is not None
+
+
+class DisassociateHostsModal(PF5Modal):
+    """
+    This class represents the Disassociate Hosts modal
+    that is used to disassociate hosts from a repository set.
+    """
+
+    OUIA_ID = 'bulk-disassociate-modal'
+
+    title = './/h1[@class="pf-v5-c-modal-box__title"]'
+    close_btn = PF5OUIAButton('bulk-disassociate-modal-ModalBoxCloseButton')
+    confirm_btn = PF5OUIAButton('bulk-disassociate-modal-add-button')
+    cancel_btn = PF5OUIAButton('bulk-disassociate-modal-cancel-button')
 
     @property
     def is_displayed(self):

--- a/airgun/views/all_hosts.py
+++ b/airgun/views/all_hosts.py
@@ -591,7 +591,8 @@ class ManageRepositorySetsModal(PF5Modal):
 class DisassociateHostsModal(PF5Modal):
     """
     This class represents the Disassociate Hosts modal
-    that is used to disassociate hosts from a repository set.
+    which is used to disassociate hosts from their UUID
+    and compute_resource_id associations.
     """
 
     OUIA_ID = 'bulk-disassociate-modal'


### PR DESCRIPTION
This PR adds airgun coverage for Disassociate hosts function coming to stream on All hosts page.
See SAT-31029.
Needed by: https://github.com/SatelliteQE/robottelo/pull/18859

## Summary by Sourcery

Add Airgun test coverage for the Disassociate Hosts function on the All hosts page, including navigation, selection logic, and modal interactions.

New Features:
- Add disassociate_hosts action to automate disassociating hosts from the All hosts page
- Introduce DisassociateHostsModal view to represent and interact with the disassociate hosts modal

Enhancements:
- Validate mutually exclusive select_all_hosts and host_names parameters
- Support both individual host selection and select-all flow in the disassociate_hosts method