### PR TITLE
Update locators to PF5 for ComputeResources

### DIFF
--- a/airgun/entities/computeresource.py
+++ b/airgun/entities/computeresource.py
@@ -58,7 +58,7 @@ class ComputeResourceEntity(BaseEntity):
         """Returns all the VMs on the CR or VM with specified name"""
         view = self.navigate_to(self, 'Detail', entity_name=entity_name)
         if expected_vm_name:
-            view.virtual_machines.search(expected_vm_name)
+            view.virtual_machines.search.fill(expected_vm_name)
             return view.virtual_machines.table.row(name=expected_vm_name)
         return view.virtual_machines.table.rows()
 
@@ -71,7 +71,8 @@ class ComputeResourceEntity(BaseEntity):
         :return: The Compute resource virtual machines table rows values.
         """
         view = self.navigate_to(self, 'Detail', entity_name=entity_name)
-        return view.virtual_machines.search(value)
+        view.virtual_machines.search.fill(value)
+        return view.virtual_machines.table.read()
 
     def vm_status(self, entity_name, vm_name):
         """Returns True if the machine is running, False otherwise"""
@@ -267,7 +268,7 @@ class ComputeResourceVMImport(NavigateStep):
 
     def step(self, *args, **kwargs):
         vm_name = kwargs.get('vm_name')
-        self.parent.virtual_machines.search(vm_name)
+        self.parent.virtual_machines.search.fill(vm_name)
         self.parent.virtual_machines.actions.fill("Import as managed Host")
 
 

--- a/airgun/views/computeresource.py
+++ b/airgun/views/computeresource.py
@@ -194,6 +194,7 @@ class ResourceProviderDetailView(BaseLoggedInView):
                 'Power': Text('.//span[contains(@class,"label")]'),
             },
         )
+        search = TextInput(locator=".//input[contains(@aria-controls, 'DataTables_Table')]")
 
     @View.nested
     class compute_profiles(SatTab):


### PR DESCRIPTION
PF5 Updates to VMWare

## Summary by Sourcery

Update compute resource entity and view to use PF5 TextInput locators for VM searches and add a PF5-compatible search input in the virtual machines view

Enhancements:
- Refactor compute resource search methods to use `.search.fill()` for PF5 TextInput
- Add a PF5-compatible TextInput locator for the virtual machines search field in the view