### PR TITLE
Fix class name typo

### DIFF
--- a/airgun/views/host_new.py
+++ b/airgun/views/host_new.py
@@ -69,7 +69,7 @@ class Card(View):
     title = Text('.//div[@class="pf-v5-c-card__title"]')
 
 
-class DropdownWithDescripton(PF5Dropdown):
+class DropdownWithDescription(PF5Dropdown):
     """Dropdown with description below items"""
 
     ITEM_LOCATOR = ".//*[contains(@class, 'pf-v5-c-dropdown__menu-item') and contains(text(), {})]"


### PR DESCRIPTION
class `DropdownWithDescripton` has a typo which is fixed in this PR.

## Summary by Sourcery

Bug Fixes:
- Correct typo in class name from DropdownWithDescripton to DropdownWithDescription