### PR TITLE
[6.17.z Cherrypick] Fix class name typo 

### DIFF
--- a/airgun/views/host_new.py
+++ b/airgun/views/host_new.py
@@ -58,7 +58,7 @@ class Card(View):
     title = Text('.//div[@class="pf-c-card__title"]')
 
 
-class DropdownWithDescripton(Dropdown):
+class DropdownWithDescription(Dropdown):
     """Dropdown with description below items"""
 
     ITEM_LOCATOR = ".//*[contains(@class, 'pf-c-dropdown__menu-item') and contains(text(), {})]"
@@ -399,7 +399,7 @@ class NewHostDetailsView(BaseLoggedInView):
                     'Stream': Text('./parent::td'),
                     'Installation status': Text('.//small'),
                     'Installed profile': Text('./parent::td'),
-                    5: DropdownWithDescripton(locator='.//div[contains(@class, "pf-c-dropdown")]'),
+                    5: DropdownWithDescription(locator='.//div[contains(@class, "pf-c-dropdown")]'),
                 },
             )
             pagination = PF4Pagination()


### PR DESCRIPTION
Failed Cherrypick: https://github.com/SatelliteQE/airgun/issues/1912 