### PR TITLE
[6.16.z Cherrypick] Fix class name typo (#1911)

### DIFF
--- a/airgun/views/host_new.py
+++ b/airgun/views/host_new.py
@@ -59,7 +59,7 @@ class Card(View):
     title = Text('.//div[@class="pf-c-card__title"]')
 
 
-class DropdownWithDescripton(Dropdown):
+class DropdownWithDescription(Dropdown):
     """Dropdown with description below items"""
 
     ITEM_LOCATOR = ".//*[contains(@class, 'pf-c-dropdown__menu-item') and contains(text(), {})]"
@@ -392,7 +392,7 @@ class NewHostDetailsView(BaseLoggedInView):
                     'Stream': Text('./parent::td'),
                     'Installation status': Text('.//small'),
                     'Installed profile': Text('./parent::td'),
-                    5: DropdownWithDescripton(locator='.//div[contains(@class, "pf-c-dropdown")]'),
+                    5: DropdownWithDescription(locator='.//div[contains(@class, "pf-c-dropdown")]'),
                 },
             )
             pagination = PF4Pagination()


### PR DESCRIPTION
Failed autocherrypick: https://github.com/SatelliteQE/airgun/issues/1914

## Summary by Sourcery

Bug Fixes:
- Rename class "DropdownWithDescripton" to "DropdownWithDescription" in definition and usage