### PR TITLE
Add entities/views updates for transient-install

### DIFF
--- a/airgun/entities/all_hosts.py
+++ b/airgun/entities/all_hosts.py
@@ -490,7 +490,7 @@ class AllHostsEntity(BaseEntity):
         view.next_btn.click()
         manage_errata_text = view.review_hosts.content_text.read()
         return [manage_package_text, manage_errata_text]
-      
+
     def disassociate_hosts(self, host_names, select_all_hosts=False):
         """
         Navigate to the Disassociate hosts modal for selected hosts and disassociate them.

--- a/airgun/entities/all_hosts.py
+++ b/airgun/entities/all_hosts.py
@@ -516,6 +516,42 @@ class AllHostsEntity(BaseEntity):
             raise Exception("Repository count not matches")
         view.review.set_content_overrides.click()
 
+    def get_package_and_errata_wizard_review_hosts_text(
+        self,
+    ):
+        """Return the text from both the manage packages and manage errata modals review hosts step"""
+        # Navigate to All Hosts
+        view = self.navigate_to(self, 'All')
+        self.browser.plugin.ensure_page_safe(timeout='5s')
+        view.wait_displayed()
+        view.select_all.fill(True)
+
+        # Get text from Manage Packages -> Review Hosts
+        view.bulk_actions_kebab.click()
+        self.browser.move_to_element(view.bulk_actions_menu.item_element('Manage content'))
+        view.bulk_actions_manage_content_menu.item_select('Packages')
+
+        view = ManagePackagesModal(self.browser)
+        view.select_action.upgrade_all_packages_radio.fill(True)
+        manage_package_text = view.review_hosts.content_text.read()
+        view.cancel_btn.click()
+
+        # Get text from Manage Errata -> Review Hosts
+        view = self.navigate_to(self, 'All')
+        self.browser.plugin.ensure_page_safe(timeout='5s')
+        view.wait_displayed()
+        view.select_all.fill(True)
+
+        # Get text from Manage Packages -> Review Hosts
+        view.bulk_actions_kebab.click()
+        self.browser.move_to_element(view.bulk_actions_menu.item_element('Manage content'))
+        view.bulk_actions_manage_content_menu.item_select('Errata')
+
+        view = ManageErrataModal(self.browser)
+        view.next_btn.click()
+        manage_errata_text = view.review_hosts.content_text.read()
+        return [manage_package_text, manage_errata_text]
+
 
 @navigator.register(AllHostsEntity, 'All')
 class ShowAllHostsScreen(NavigateStep):

--- a/airgun/views/all_hosts.py
+++ b/airgun/views/all_hosts.py
@@ -322,7 +322,7 @@ class ManagePackagesModal(PF5Modal):
         locator_prefix = './/div[contains(.,"Review hosts")]/descendant::'
 
         expander = Text('.//button[contains(.,"Review hosts")]')
-        content_text = Text('.//div[@class="pf-v5-c-content"]')
+        content_text = Text('.//p[@data-ouia-component-id="mpw-step-3-content"]')
         error_message = OUIAAlert('no-hosts-alert')
 
         select_all = Checkbox(locator=f'{locator_prefix}div[@id="selection-checkbox"]')

--- a/airgun/views/host_new.py
+++ b/airgun/views/host_new.py
@@ -25,6 +25,7 @@ from widgetastic_patternfly5 import (
     Tab as PF5Tab,
 )
 from widgetastic_patternfly5.ouia import (
+    Alert as PF5OUIAAlert,
     Button as PF5OUIAButton,
     PatternflyTable as PF5OUIATable,
 )
@@ -333,6 +334,7 @@ class NewHostDetailsView(BaseLoggedInView):
         # TODO Setting ROOT is just a workaround because of BZ 2119076,
         # once this gets fixed we should use the parametrized locator from Tab class
         ROOT = './/div'
+        transient_install_alert = PF5OUIAAlert("image-mode-alert-info")
 
         @View.nested
         class packages(PF5Tab):

--- a/airgun/views/oscapreport.py
+++ b/airgun/views/oscapreport.py
@@ -1,6 +1,6 @@
 from widgetastic.widget import Text, View
 from widgetastic_patternfly4 import Button
-from widgetastic_patternfly4.ouia import FormSelect
+from widgetastic_patternfly5.ouia import FormSelect as PF5FormSelect
 
 from airgun.views.common import BaseLoggedInView, SearchableViewMixin, WizardStepView
 from airgun.widgets import (
@@ -58,26 +58,26 @@ class RemediateModal(View):
 
     ROOT = '//div[contains(@data-ouia-component-id, "OUIA-Generated-Modal-large-")]'
 
-    title = Text('.//h2[contains(@class, "pf-c-title")]')
+    title = Text('.//h2[contains(@class, "pf-v5-c-wizard__title-text")]')
     close_modal = Button(locator='.//button[@aria-label="Close"]')
 
     @View.nested
     class select_remediation_method(WizardStepView):
         expander = Text(
-            './/button[contains(@class,"pf-c-wizard__nav-link") and contains(.,"Select snippet")]'
+            './/button[contains(@class,"pf-v5-c-wizard__nav-link") and contains(.,"Select snippet")]'
         )
-        snippet = FormSelect('snippet-select')
+        snippet = PF5FormSelect('snippet-select')
 
     @View.nested
     class name_source(WizardStepView):
         expander = Text(
-            './/button[contains(@class,"pf-c-wizard__nav-link") and contains(.,"Review hosts")]'
+            './/button[contains(@class,"pf-v5-c-wizard__nav-link") and contains(.,"Review hosts")]'
         )
         host_table = SatTable(".//table")
 
     @View.nested
     class select_capsule(WizardStepView):
         expander = Text(
-            './/button[contains(@class,"pf-c-wizard__nav-link") and contains(.,"Review remediation")]'
+            './/button[contains(@class,"pf-v5-c-wizard__nav-link") and contains(.,"Review remediation")]'
         )
         run = Button(locator='.//button[normalize-space(.)="Run"]')


### PR DESCRIPTION
Entity/View Updates to support transient install work.

Needed for: **https://github.com/SatelliteQE/robottelo/pull/18966**

## Summary by Sourcery

Add support for transient install flows by introducing a helper to extract review hosts text for package and errata operations, update various view locators to PatternFly v5 selectors, and expose a transient install alert in the host creation view.

Enhancements:
- Introduce `get_package_and_errata_wizard_review_hosts_text` to retrieve review hosts content for both package upgrade and errata installs.
- Migrate wizard step and modal element locators in `oscapreport` and `all_hosts` views to use PatternFly v5 selectors.
- Add a `transient_install_alert` OUIA alert element in the host creation view to signal image-mode install state.