### PR TITLE
[6.16.z] update alert msg after host delete

### DIFF
--- a/airgun/entities/host.py
+++ b/airgun/entities/host.py
@@ -141,9 +141,7 @@ class HostEntity(BaseEntity):
         view.table.row(name=entity_name)['Actions'].widget.fill('Delete')
         self.browser.handle_alert()
         wait_for(
-            lambda: view.flash.assert_message(
-                f"Success alert: Successfully deleted {entity_name}."
-            ),
+            lambda: view.flash.assert_message(f"Successfully deleted {entity_name}."),
             timeout=120,
         )
         view.flash.assert_no_error()


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/airgun/pull/1900

Updated the alert message for host deletion. An unnecessary line removed, which was causing some tests to fail.

## Summary by Sourcery

Bug Fixes:
- Remove the unnecessary "Success alert:" prefix from the host deletion confirmation message