### PR TITLE
host Status View Update

### DIFF
--- a/airgun/views/host_new.py
+++ b/airgun/views/host_new.py
@@ -144,7 +144,7 @@ class NewHostDetailsView(BaseLoggedInView):
         class host_status(Card):
             ROOT = './/div[@data-ouia-component-id="card-aggregate-status"]'
 
-            status = Text('.//h4[contains(@data-ouia-component-id, "global-state-title")]')
+            status = Text('.//h4[contains(@class, "pf-v5-c-empty-state__title")]')
             manage_all_statuses = Text('.//a[normalize-space(.)="Manage all statuses"]')
 
             status_success = Text('.//a[span[@class="status-success"]]')


### PR DESCRIPTION
Locator change needed for PF5
Fixes `test_positive_read_details_page_from_new_ui`
<img width="282" height="43" alt="image" src="https://github.com/user-attachments/assets/42771bcf-49ba-4575-ba05-d14c24e854ea" />


## Summary by Sourcery

Enhancements:
- Update host status card locator to use PF5 empty state title class for compatibility with PatternFly 5