### PR TITLE
hosts Content/Packages fixes

### DIFF
--- a/airgun/entities/host_new.py
+++ b/airgun/entities/host_new.py
@@ -350,12 +350,15 @@ class NewHostEntity(HostEntity):
         view = self.navigate_to(self, 'NewDetails', entity_name=entity_name)
         view.content.packages.wait_displayed()
         view.content.packages.select()
-        view.content.packages.table.wait_displayed()
+        wait_for(lambda: view.content.packages.table.is_displayed, timeout=5)
         view.content.packages.searchbar.fill(search)
-        # wait for filter to apply
         self.browser.plugin.ensure_page_safe()
-        view.content.packages.table.wait_displayed()
-        return view.content.packages.read()
+        # Check if there is a match
+        if view.content.packages.no_matching_packages.is_displayed:
+            return None
+        else:
+            view.content.packages.table.wait_displayed()
+            return view.content.packages.table.read()
 
     def install_package(self, entity_name, package):
         """Installs package on host using the installation modal"""
@@ -369,7 +372,7 @@ class NewHostEntity(HostEntity):
         view.searchbar.fill(package)
         # wait for filter to apply
         self.browser.plugin.ensure_page_safe()
-        view.select_all.click()
+        view.table[0][0].widget.fill(True)
         view.install.click()
 
     def apply_package_action(self, entity_name, package_name, action):

--- a/airgun/views/common.py
+++ b/airgun/views/common.py
@@ -1,5 +1,3 @@
-from functools import partial
-
 from selenium.common.exceptions import ElementNotInteractableException
 from widgetastic.widget import (
     Checkbox,
@@ -15,7 +13,7 @@ from widgetastic.widget import (
 from widgetastic_patternfly import BreadCrumb, Tab, TabWithDropdown
 from widgetastic_patternfly4 import Button
 from widgetastic_patternfly4.navigation import Navigation
-from widgetastic_patternfly5 import OptionsMenu
+from widgetastic_patternfly5 import Dropdown as PF5Dropdown
 from widgetastic_patternfly5.ouia import (
     Dropdown as PF5OUIADropdown,
     PatternflyTable,
@@ -336,9 +334,11 @@ class PF5LCECheckSelectorGroup(PF5LCESelectorGroup):
 
 
 # PF5 kebab menu present in table rows
-TableRowKebabMenu = partial(
-    OptionsMenu, './/button[contains(@data-ouia-component-type, "MenuToggle")]/..'
-)
+class TableRowKebabMenu(PF5Dropdown):
+    """Dropdown for PF5 kebab menus used in table rows."""
+
+    ROOT = '.'
+    DEFAULT_LOCATOR = './/button[contains(@class, "-c-menu-toggle") and @aria-label="Kebab toggle"]'
 
 
 class PF5LCEGroup(ParametrizedLocator):

--- a/airgun/views/host_new.py
+++ b/airgun/views/host_new.py
@@ -42,6 +42,24 @@ from airgun.widgets import (
 )
 
 
+class MenuToggleButtonMenu(PF5Dropdown):
+    """
+    This class is PF5 implementation of a PF5 MenuToggle which is implemented like Button->Dropdown
+    i.e. the kebab menu in the host/content/packages table
+    """
+
+    IS_ALWAYS_OPEN = False
+    BUTTON_LOCATOR = ".//button[contains(@class, 'pf-v5-c-menu-toggle')]"
+    DEFAULT_LOCATOR = (
+        './/button[contains(@class, "pf-v5-c-menu-toggle") and @aria-label="Kebab toggle"]'
+    )
+    ROOT = f"{BUTTON_LOCATOR}/.."
+    ITEMS_LOCATOR = ".//ul[contains(@class, 'pf-v5-c-menu__list')]/li"
+    ITEM_LOCATOR = (
+        "//*[contains(@class, 'pf-v5-c-menu__item') and .//*[contains(normalize-space(.), {})]]"
+    )
+
+
 class RemediationView(View):
     """Remediation window view"""
 
@@ -349,8 +367,11 @@ class NewHostDetailsView(BaseLoggedInView):
             status_filter = Dropdown(locator='.//div[@aria-label="select Status container"]/div')
             upgrade = Pf4ActionsDropdown(locator='.//div[div/button[normalize-space(.)="Upgrade"]]')
             dropdown = PF5Dropdown(locator='.//div[button[@aria-label="bulk_actions"]]')
+            no_matching_packages = Text(
+                './/h2[contains(@class, "pf-v5-c-empty-state__title-text")]'
+            )
 
-            table = PatternflyTable(
+            table = PF5OUIATable(
                 component_id="host-packages-table",
                 column_widgets={
                     0: Checkbox(locator='.//input[@type="checkbox"]'),
@@ -358,7 +379,7 @@ class NewHostDetailsView(BaseLoggedInView):
                     'Status': Text('./span'),
                     'Installed version': Text('./parent::td'),
                     'Upgradable to': Text('./span'),
-                    5: Dropdown(locator='.//div[button(@aria-label="Kebab toggle")]'),
+                    5: MenuToggleButtonMenu(locator='.//button[@aria-label="Kebab toggle"]'),
                 },
             )
             pagination = PF4Pagination()


### PR DESCRIPTION
Update hosts->content->packages views and entities so it works again with new PF5 implementations

Needed by: https://github.com/SatelliteQE/robottelo/pull/19006

## Summary by Sourcery

Update host content packages views and entities to support PF5 components and handle empty-state scenarios

Enhancements:
- Add MenuToggleButtonMenu class for PF5 kebab menu interactions
- Switch packages table view to use PF5OUIATable and include empty-state detection
- Modify get_packages to handle no matching packages and use a lambda-based table display wait
- Update install_package to select packages via table checkbox widget instead of select_all button