### PR TITLE
[Test Fixes] Revert search_field locators to include multiple cases

### DIFF
--- a/airgun/widgets.py
+++ b/airgun/widgets.py
@@ -819,7 +819,12 @@ class Search(Widget):
         'or contains(@class, "dataTables_filter") or @id="search-bar"]'
     )
     search_field = TextInput(
-        locator=("//div[@class='title_filter']//input[contains(@aria-label, 'Search input')]")
+        locator=(
+            ".//input[@id='search' or contains(@placeholder, 'Filter') or "
+            "@ng-model='table.searchTerm' or contains(@ng-model, 'Filter') or "
+            "@data-autocomplete-id='searchBar' or contains(@placeholder, 'Search') "
+            "or contains(@class, 'search-input') or contains(@aria-label, 'Search input')]"
+        )
     )
     search_button = PF5Button(locator=(".//button[@aria-label='Search']"))
     clear_button = Text(


### PR DESCRIPTION
Formal PR https://github.com/SatelliteQE/airgun/pull/1897 was used to update airgun code to PF5. However to reduce clutter, changes were made to the search_field locator. This search widget gets used across multiple components and is causing failure on activation keys. 

```
tests/foreman/ui/test_activationkey.py:133: in test_positive_create_with_cv
    assert session.activationkey.search(name)[0]['Name'] == name
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
E   TypeError: 'NoneType' object is not subscriptable
```

I am leaving in the added PF5 search_button field but adding back the locators to support multiple use cases.

## Summary by Sourcery

Bug Fixes:
- Broaden the search_field locator to match various attributes (id, placeholder, ng-model, data-autocomplete-id, class, aria-label) across different components