### PR TITLE
All Hosts legacy UI navigation fix

### DIFF
--- a/airgun/entities/host.py
+++ b/airgun/entities/host.py
@@ -439,13 +439,19 @@ class HostEntity(BaseEntity):
 
 @navigator.register(HostEntity, 'All')
 class ShowAllHosts(NavigateStep):
-    """Navigate to All Hosts page"""
+    """Navigate to legacy All Hosts page.
+    Note: Due to incomplete implementation of the new Hosts page in `airgun.views.host_new.HostsView`,
+    'All' currently navigates to the legacy UI for proper test functionality.
+    Once all functionality is covered, feel free to remove this navigation step and rename 'NewUIAll' step to 'All'.
+    """
 
     VIEW = HostsView
 
+    prerequisite = NavigateToSibling('NewUIAll')
+
     @retry_navigation
     def step(self, *args, **kwargs):
-        self.view.menu.select('Hosts', 'All Hosts')
+        self.view.actions.item_select('Legacy UI')
 
 
 @navigator.register(HostEntity, 'New')

--- a/airgun/entities/host_new.py
+++ b/airgun/entities/host_new.py
@@ -5,12 +5,14 @@ from wait_for import wait_for
 
 from airgun.entities.host import HostEntity
 from airgun.navigation import NavigateStep, navigator
+from airgun.utils import retry_navigation
 from airgun.views.fact import HostFactView
 from airgun.views.host_new import (
     AllAssignedRolesView,
     EditAnsibleRolesView,
     EditSystemPurposeView,
     EnableTracerView,
+    HostsView,
     InstallPackagesView,
     ManageHostCollectionModal,
     ManageHostStatusesView,
@@ -1024,6 +1026,17 @@ class NewHostEntity(HostEntity):
         view = self.navigate_to(self, 'NewDetails', entity_name=entity_name)
         value = view.ansible.variables.table.row(name=key)['Value'].read()
         return value
+
+
+@navigator.register(HostEntity, 'NewUIAll')
+class ShowAllHosts(NavigateStep):
+    """Navigate to new UI All Hosts page"""
+
+    VIEW = HostsView
+
+    @retry_navigation
+    def step(self, *args, **kwargs):
+        self.view.menu.select('Hosts', 'All Hosts')
 
 
 @navigator.register(NewHostEntity, 'NewDetails')

--- a/airgun/views/host_new.py
+++ b/airgun/views/host_new.py
@@ -26,6 +26,7 @@ from widgetastic_patternfly5 import (
 )
 from widgetastic_patternfly5.ouia import (
     Button as PF5OUIAButton,
+    Dropdown as PF5OUIADropdown,
     PatternflyTable as PF5OUIATable,
 )
 
@@ -129,6 +130,20 @@ class HostColectionsList(Widget):
     def read(self):
         """Return a list of assigned host collections"""
         return [self.browser.text(item) for item in self.browser.elements(self.ITEMS)]
+
+
+class HostsView(BaseLoggedInView):
+    """New All Hosts view.
+    Note: This is a minimal implementation of the new Hosts page, and currently it serves only to transition
+    to the now-legacy UI page.
+    """
+
+    title = Text('//h1[normalize-space(.)="Hosts"]')
+    actions = PF5OUIADropdown(component_id='legacy-ui-kebab')
+
+    @property
+    def is_displayed(self):
+        return self.browser.wait_for_element(self.title, exception=False) is not None
 
 
 class NewHostDetailsView(BaseLoggedInView):


### PR DESCRIPTION
### hosts: navigating to 'All' goes to the legacy UI page by default ###

To ensure proper test functionality, navigating to 'All' hosts goes to the now-legacy UI Hosts page.

Once all functionality of the new Hosts page is covered in the new `HostsView` view, this workaround can be removed.

### PRT example: ###
```
trigger: test-robottelo
pytest: tests/foreman/ui/test_host.py -k 'test_all_hosts_manage_columns or test_positive_host_details_read_templates'
```

## Summary by Sourcery

Implement a temporary HostsView and navigation workflow so that selecting 'All Hosts' routes through the new page and defaults back to the legacy UI until full functionality is migrated.

Enhancements:
- Introduce a stub HostsView for the new All Hosts page with a dropdown action for legacy UI fallback
- Add a new 'NewUIAll' navigation step to reach the HostsView via the main menu
- Modify the existing 'All' navigation step to first navigate to HostsView and then select the legacy UI option