### PR TITLE
search button not getting clicked on activation key page due to  different locator

### DIFF
--- a/airgun/entities/activationkey.py
+++ b/airgun/entities/activationkey.py
@@ -16,6 +16,7 @@ class ActivationKeyEntity(BaseEntity):
     def create(self, values):
         """Create new activation key entity"""
         view = self.navigate_to(self, 'New')
+        view.wait_displayed()
         view.fill(values)
         view.submit.click()
 

--- a/airgun/widgets.py
+++ b/airgun/widgets.py
@@ -827,7 +827,7 @@ class Search(Widget):
             "or contains(@class, 'search-input') or contains(@aria-label, 'Search input')]"
         )
     )
-    search_button = PF5Button(locator=(".//button[@aria-label='Search']"))
+    search_button = PF5Button(locator=".//button[span[normalize-space(.)='Search']] | .//button[@aria-label='Search']")
     clear_button = Text(
         ".//span[contains(@class,'autocomplete-clear-button') or contains(@class,'fa-close')]"
     )


### PR DESCRIPTION
Summary:
Search button not getting clicked on activation key page due to  different locator
Reason:
- We have search button on activation key page
- But other pages have search arrow and currently we are using locator of search arrow Fix :
- We can add locator with or condition to avoid breaking existing test cases
- PF5Button(locator=".//button[@aria-label='Search'] | .//button[span[normalize-space(.)='Search']]")