### PR TITLE
Change Owner Fixes

### DIFF
--- a/airgun/entities/all_hosts.py
+++ b/airgun/entities/all_hosts.py
@@ -516,7 +516,8 @@ class AllHostsEntity(BaseEntity):
         view = self.all_hosts_navigate_and_select_hosts_helper(host_names, select_all_hosts)
 
         view.bulk_actions_kebab.click()
-        view.bulk_actions_menu.item_select('Change owner')
+        self.browser.move_to_element(view.bulk_actions_menu.item_element('Change associations'))
+        view.bulk_actions_change_associations_menu.item_select('Owner')
 
         view = ChangeHostsOwnerModal(self.browser)
         view.owner_select.item_select(new_owner_name)
@@ -579,8 +580,8 @@ class AllHostsEntity(BaseEntity):
 
         view.bulk_actions_kebab.click()
         self.browser.move_to_element(view.bulk_actions_menu.item_element('Change associations'))
-
         view.bulk_actions_change_associations_menu.item_select('Location')
+
         view = ChangeLocationModal(self.browser)
         view.location_menu.item_select(new_location)
 


### PR DESCRIPTION
Navigation to the owner change action changed a little bit.
This PR fixes this.

## Summary by Sourcery

Fix bulk action navigation for changing hosts owner and location to match updated 'Change associations' submenu UI.

Bug Fixes:
- Adjust change_hosts_owner to hover over 'Change associations' submenu before selecting 'Owner'
- Update change_associations_location to hover over 'Change associations' submenu before selecting 'Location'