### PR TITLE
6.17 tracer fixes

### DIFF
--- a/airgun/entities/host_new.py
+++ b/airgun/entities/host_new.py
@@ -618,6 +618,15 @@ class NewHostEntity(HostEntity):
         self.browser.plugin.ensure_page_safe()
         return view.traces.read()
 
+    def get_tracer_tab_title(self, entity_name):
+        view = self.navigate_to(self, 'NewDetails', entity_name=entity_name)
+        view.wait_displayed()
+        self.browser.plugin.ensure_page_safe()
+        view.traces.click()
+        view.wait_displayed()
+        self.browser.plugin.ensure_page_safe()
+        return view.traces.title.text
+
     def get_os_info(self, entity_name):
         view = self.navigate_to(self, 'NewDetails', entity_name=entity_name)
         view.wait_displayed()


### PR DESCRIPTION
manual cherry pick of (some part of) https://github.com/SatelliteQE/airgun/pull/1843/files

## Summary by Sourcery

Enhancements:
- Add get_tracer_tab_title method to retrieve the tracer tab title for a host entity.