### PR TITLE
[6.16.z] Fix LegacyDetails navigation

### DIFF
--- a/airgun/entities/contenthost.py
+++ b/airgun/entities/contenthost.py
@@ -293,4 +293,4 @@ class ShowContentHostDetails(NavigateStep):
         host_view = NewHostDetailsView(self.parent.browser)
         host_view.wait_displayed()
         host_view.dropdown.wait_displayed()
-        host_view.dropdown.item_select('Legacy content host UI')
+        host_view.dropdown.item_select('Legacy UI')


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/airgun/pull/1955

### Problem Statement
- Currently, some of the virtwho UI tests are failing with `Navigation failed to reach [LegacyDetails] in the specified tries`.

### Solution
- Update the locator for Legacy UI

### Related Issues
- SAT-36523

## Summary by Sourcery

Bug Fixes:
- Use the correct dropdown label 'Legacy UI' instead of 'Legacy content host UI' in content host details view