### PR TITLE
Fix cloud Inventory view locators 

### DIFF
--- a/airgun/views/cloud_inventory.py
+++ b/airgun/views/cloud_inventory.py
@@ -128,8 +128,8 @@ class CloudInventoryListView(BaseLoggedInView):
         './/label[@for="rh-cloud-switcher-allow_auto_insights_mismatch_delete"]'
     )
 
-    auto_upload_desc = PF5OUIAText('OUIA-Generated-Text-6')
-    manual_upload_desc = PF5OUIAText('OUIA-Generated-Text-7')
+    auto_upload_desc = PF5OUIAText('text-enable-report')
+    manual_upload_desc = PF5OUIAText('text-restart-button')
     dialog = Pf5ConfirmationDialog()
     cloud_connector = PF5Button(locator='//button[normalize-space(.)="Configure cloud connector"]')
     reconfigure_cloud_connector = PF5Button(


### PR DESCRIPTION
Fix changed locators.

This PR fixes `test_subscription_connection_settings_ui_behavior`


### PRT Example
```
trigger: test-robottelo
pytest: tests/foreman/ui/test_rhcloud_inventory.py -k test_subscription_connection_settings_ui_behavior
```
<img width="306" height="85" alt="image" src="https://github.com/user-attachments/assets/ae5a328b-63d2-4ed8-8693-bf7456149acb" />

## Summary by Sourcery

Update locator identifiers for report upload descriptions in the cloud inventory view to restore UI test compatibility

Bug Fixes:
- Change auto_upload_desc locator to 'text-enable-report'
- Change manual_upload_desc locator to 'text-restart-button'