### PR TITLE
fix reads from JobDetailsPage

### DIFF
--- a/airgun/entities/hostcollection.py
+++ b/airgun/entities/hostcollection.py
@@ -17,7 +17,11 @@ from airgun.views.hostcollection import (
     HostCollectionManagePackagesView,
     HostCollectionsView,
 )
-from airgun.views.job_invocation import JobInvocationCreateView, JobInvocationStatusView
+from airgun.views.job_invocation import (
+    JobInvocationCreateView,
+    JobInvocationStatusView,
+    NewJobInvocationStatusView,
+)
 
 
 class HostCollectionEntity(BaseEntity):
@@ -114,17 +118,14 @@ class HostCollectionEntity(BaseEntity):
         # wait for the job deatils to load
         time.sleep(3)
         # After this step the user is redirected to job status view.
-        job_status_view = JobInvocationStatusView(view.browser)
+        job_status_view = NewJobInvocationStatusView(view.browser)
         wait_for(
-            lambda: (
-                job_status_view.overview.job_status.read() != 'Pending'
-                and job_status_view.overview.job_status_progress.read() == '100%'
-            ),
+            lambda: (job_status_view.status.read()['In Progress'] != 1),
             timeout=300,
             delay=10,
             logger=view.logger,
         )
-        return job_status_view.overview.read()
+        return job_status_view.read()
 
     def search_applicable_hosts(self, entity_name, errata_id):
         """Check for search URI in Host Collection errata view.
@@ -176,17 +177,14 @@ class HostCollectionEntity(BaseEntity):
             job_create_view.submit.click()
 
         # After this step the user is redirected to job status view.
-        job_status_view = JobInvocationStatusView(view.browser)
+        job_status_view = NewJobInvocationStatusView(view.browser)
         wait_for(
-            lambda: (
-                job_status_view.overview.job_status.read() != 'Pending'
-                and job_status_view.overview.job_status_progress.read() == '100%'
-            ),
+            lambda: (job_status_view.status.read()['In Progress'] != 1),
             timeout=300,
             delay=10,
             logger=view.logger,
         )
-        return job_status_view.overview.read()
+        return job_status_view.read()
 
     def manage_module_streams(
         self,


### PR DESCRIPTION
New job details page started appearing since stream 120.
Some changes were need to fix several tests.


`test_positive_end_to_end_bulk_update`
<img width="369" height="60" alt="image" src="https://github.com/user-attachments/assets/59af0399-02b4-472e-96aa-577470903066" />

`test_positive_install_package_group`
<img width="231" height="40" alt="image" src="https://github.com/user-attachments/assets/99130e63-f586-4f40-8936-99c2796f5915" />

`test_positive_install_errata`
<img width="231" height="40" alt="image" src="https://github.com/user-attachments/assets/e58235a2-b019-4c8a-ba06-30f78aaee995" />


### PRT Examples


```
trigger: test-robottelo
pytest: tests/foreman/ui/test_hostcollection.py -k "test_positive_install_errata or test_positive_install_package_group"
```

```
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k "test_positive_end_to_end_bulk_update"
```

## Summary by Sourcery

Adapt HostCollectionEntity methods to support the new JobDetailsPage by switching to the updated status view and adjusting job wait logic and read calls.

Bug Fixes:
- Replace JobInvocationStatusView with NewJobInvocationStatusView in manage_packages and install_errata methods to align with the new job details page
- Update wait_for predicate to check the new status.read() API and adjust return calls from overview.read() to read()