### PR TITLE
Fixed All Hosts page edit functionality to support patternfly5 changes

### DIFF
--- a/airgun/entities/host.py
+++ b/airgun/entities/host.py
@@ -139,7 +139,7 @@ class HostEntity(BaseEntity):
         """Delete host from the system"""
         view = self.navigate_to(self, 'All')
         view.search(entity_name)
-        view.table.row(name=entity_name)['Actions'].widget.fill('Delete')
+        view.table.row(name=entity_name)[6].widget.item_select('Delete')
         self.browser.handle_alert()
         wait_for(
             lambda: view.flash.assert_message(
@@ -522,7 +522,7 @@ class EditHost(NavigateStep):
     def step(self, *args, **kwargs):
         entity_name = kwargs.get('entity_name')
         self.parent.search(entity_name)
-        self.parent.table.row(name=entity_name)['Actions'].widget.fill('Edit')
+        self.parent.table.row(name=entity_name)[6].widget.item_select('Edit')
         self.view.wait_displayed()
 
 

--- a/airgun/views/host.py
+++ b/airgun/views/host.py
@@ -24,12 +24,13 @@ from widgetastic_patternfly5.components.tabs import Tab
 from widgetastic_patternfly5.ouia import (
     Button as PF5Button,
     FormSelect as PF5FormSelect,
+    PatternflyTable as PF5OUIATable,
     Select as PF5OUIASelect,
     TextInput as PF5OUIATextInput,
-    PatternflyTable as PF5OUIATable,
 )
-from airgun.views.host_new import MenuToggleButtonMenu
+
 from airgun.views.common import BaseLoggedInView, SatTab, SearchableViewMixinPF4
+from airgun.views.host_new import MenuToggleButtonMenu
 from airgun.views.job_invocation import JobInvocationCreateView, JobInvocationStatusView
 from airgun.views.task import TaskDetailsView
 from airgun.widgets import (

--- a/airgun/views/host.py
+++ b/airgun/views/host.py
@@ -26,8 +26,9 @@ from widgetastic_patternfly5.ouia import (
     FormSelect as PF5FormSelect,
     Select as PF5OUIASelect,
     TextInput as PF5OUIATextInput,
+    PatternflyTable as PF5OUIATable,
 )
-
+from airgun.views.host_new import MenuToggleButtonMenu
 from airgun.views.common import BaseLoggedInView, SatTab, SearchableViewMixinPF4
 from airgun.views.job_invocation import JobInvocationCreateView, JobInvocationStatusView
 from airgun.views.task import TaskDetailsView
@@ -226,17 +227,15 @@ class HostsView(BaseLoggedInView, SearchableViewMixinPF4):
     register = PF4Button('OUIA-Generated-Button-secondary-2')
     new_ui_button = Text(".//a[contains(@class, 'btn')][contains(@href, 'new/hosts')]")
     select_all = Checkbox(locator="//input[@id='check_all']")
-    table = SatTable(
-        './/table',
+    table = PF5OUIATable(
+        component_id='table',
         column_widgets={
-            0: Checkbox(locator=".//input[@type='checkbox']"),
+            0: Checkbox(locator='.//input[@type="checkbox"]'),
             'Name': Text(
                 ".//a[contains(@href, '/new/hosts/') and not(contains(@href, 'Red Hat Lightspeed'))]"
             ),
             'Recommendations': Text("./a"),
-            'Actions': ActionsDropdown(
-                ".//button[contains(@class, 'pf-v5-c-menu-toggle pf-m-plain') and @aria-label='Kebab toggle']"
-            ),
+            6: MenuToggleButtonMenu(),
         },
     )
     displayed_table_headers = ".//table/thead/tr/th[not(@hidden)]"


### PR DESCRIPTION
Problem Statement:
Currently, on All Hosts page edit functionality is not working due to patternfly5 changes.

Solution
Added the locator for ToggleButtonMenu to select Edit option from menu

Note: There were some issue with previous PR #1959 . Created New PR and closing old one

trigger: test-robottelo
pytest: tests/foreman/ui/test_host.py -k test_positive_read_from_edit_page

## Summary by Sourcery

Update All Hosts page to support PatternFly 5 by switching to the new PF5 table component and updating row action locators, and adjust host entity methods to use the new item_select API for Delete and Edit actions.

Enhancements:
- Replace SatTable with PF5OUIATable in HostsView and update checkbox locator to use double-quoted attributes
- Swap ActionsDropdown for MenuToggleButtonMenu as the row actions widget
- Update host entity delete and edit methods to select actions via widget.item_select on column index 6