### PR TITLE
PF5 changes for Audit

### DIFF
--- a/airgun/views/audit.py
+++ b/airgun/views/audit.py
@@ -6,25 +6,21 @@ from airgun.widgets import SatTableWithoutHeaders
 
 
 class AuditEntry(View):
-    ROOT = ".//div[@id='audit-list']/div/div[contains(@class, 'list-group-item')]"
+    ROOT = ".//div[@id='audit-list']/ul/li"
     user = Text(".//a[@class='user-info']")
-    action_type = Text(".//div[@class='list-group-item-text' and normalize-space(.)]")
-    resource_type = Text(".//div[@class='list-view-pf-additional-info-item'][1]")
-    resource_name = Text(".//div[@class='list-view-pf-additional-info-item'][2]")
-    created_at = Text(".//div[@class='list-view-pf-actions']/span")
-    expander = Text(".//div[contains(@class, 'list-view-pf-expand')]/span")
-    affected_organization = Text(
-        ".//div[normalize-space(.) = 'Affected Organizations']/following-sibling::div"
-    )
-    affected_location = Text(
-        ".//div[normalize-space(.) = 'Affected Locations']/following-sibling::div"
-    )
+    action_type = Text(".//div[contains(@class, 'pf-v5-c-data-list__cell')][2]")
+    resource_type = Text(".//div[contains(@class, 'item-name')]")
+    resource_name = Text(".//div[contains(@class, 'item-resource')]")
+    created_at = Text(".//div[contains(@class, 'audits-list-actions')]/span")
+    expander = Text(".//*[@aria-label='Details']")
+    affected_organization = Text("(.//a[@data-ouia-component-id='taxonomy-inline-btn'])[1]")
+    affected_location = Text("(.//a[@data-ouia-component-id='taxonomy-inline-btn'])[2]")
     action_summary = SatTableWithoutHeaders('.//table')
     comment = Text(".//p[@class='comment-desc']")
 
     @property
     def expanded(self):
-        return 'fa-angle-down' in self.browser.classes(self.expander)
+        return self.browser.get_attribute('aria-expanded', self.expander) == 'true'
 
     def read(self):
         if not self.expanded:


### PR DESCRIPTION
## Summary by Sourcery

Adapt the AuditEntry view to PatternFly 5 by replacing outdated XPaths and using aria-expanded for expansion state

Enhancements:
- Update root and field XPaths (action type, resource type/name, created at, expander, affected organization/location) to align with PF5 markup
- Use aria-expanded attribute instead of CSS class to determine whether an entry is expanded