### PR TITLE
Add in entities and views to accommodate test cases based on image for…

### DIFF
--- a/airgun/entities/computeresource.py
+++ b/airgun/entities/computeresource.py
@@ -4,6 +4,8 @@ from airgun.entities.base import BaseEntity
 from airgun.navigation import NavigateStep, navigator
 from airgun.utils import retry_navigation
 from airgun.views.computeresource import (
+    ComputeResourceLibvirtImageCreateView,
+    ComputeResourceLibvirtImageEditView,
     ComputeResourcesView,
     ComputeResourceVMwareImageCreateView,
     ComputeResourceVMwareImageEditView,
@@ -299,6 +301,7 @@ class ComputeResourceImageProvider(NavigateStep):
 class ComputeResourceImageCreate(ComputeResourceImageProvider):
     PROVIDER_VIEWS = {
         'VMware': ComputeResourceVMwareImageCreateView,
+        'Libvirt': ComputeResourceLibvirtImageCreateView,
     }
 
     def step(self, *args, **kwargs):
@@ -309,6 +312,7 @@ class ComputeResourceImageCreate(ComputeResourceImageProvider):
 class ComputeResourceImageEdit(ComputeResourceImageProvider):
     PROVIDER_VIEWS = {
         'VMware': ComputeResourceVMwareImageEditView,
+        'Libvirt': ComputeResourceLibvirtImageEditView,
     }
 
     def step(self, *args, **kwargs):

--- a/airgun/views/computeresource.py
+++ b/airgun/views/computeresource.py
@@ -456,3 +456,19 @@ class ComputeResourceVMwareImageEditView(
     ComputeResourceVMwareImageCreateView, ComputeResourceGenericImageEditViewMixin
 ):
     """VMWare ComputeResource Image edit View"""
+
+
+class ComputeResourceLibvirtImageCreateView(ComputeResourceGenericImageCreateView):
+    """Libvirt ComputeResource Image create View"""
+
+    image = None
+    image_path = TextInput(id='image_uuid')
+
+
+class ComputeResourceLibvirtImageEditView(
+    ComputeResourceLibvirtImageCreateView, ComputeResourceGenericImageEditViewMixin
+):
+    """Libvirt ComputeResource Image edit View"""
+
+    image = None
+    image_path = TextInput(id='image_uuid')


### PR DESCRIPTION
## Summary by Sourcery

Add support for Libvirt compute resource images by defining new create and edit views and integrating them into the entity provider mappings

New Features:
- Introduce ComputeResourceLibvirtImageCreateView and ComputeResourceLibvirtImageEditView to handle Libvirt image creation and editing

Enhancements:
- Register Libvirt image views in the ComputeResourceImageCreate and ComputeResourceImageEdit provider mappings