### PR TITLE
Update for PF5 and test EditorModal

### DIFF
--- a/airgun/views/common.py
+++ b/airgun/views/common.py
@@ -557,9 +557,21 @@ class TemplateEditor(View):
     ROOT = ".//div[@id='editor-container']"
     rendering_options = ItemsList(".//div[contains(@class,'navbar-editor')]/ul")
     import_template = Button(id='import-btn')
-    fullscreen = Button(id='fullscreen-btn')
+    fullscreen = Text(locator=".//button[@id='fullscreen-btn']")
+    fullscreen_close = Text(
+        locator="//button[@data-ouia-component-id='editor-modal-component-ModalBoxCloseButton']"
+    )
+    fullscreen_textarea = TextInput(locator="//div[@id='editor']/textarea")
     error = Text(".//div[@id='preview_error_toast']")
     editor = ACEEditor()
+
+    def fill(self, values):
+        if values.pop('fullscreen', False):
+            fullscreen_data = values.pop('editor')
+            self.fullscreen.click()
+            self.fullscreen_textarea.fill(fullscreen_data)
+            self.fullscreen_close.click()
+        super().fill(values)
 
 
 class SearchableViewMixin(WTMixin):

--- a/airgun/views/partitiontable.py
+++ b/airgun/views/partitiontable.py
@@ -12,10 +12,10 @@ from airgun.views.common import (
     BaseLoggedInView,
     SatTab,
     SearchableViewMixinPF4,
+    TemplateEditor,
     TemplateInputItem,
 )
 from airgun.widgets import (
-    ACEEditor,
     ActionsDropdown,
     FilteredDropdown,
     MultiSelect,
@@ -58,7 +58,7 @@ class PartitionTableEditView(BaseLoggedInView):
         class OSFamilyOption(View):
             os_family = FilteredDropdown(id='ptable_os_family')
 
-        template_editor = ACEEditor()
+        template_editor = TemplateEditor()
         audit_comment = TextInput(id='ptable_audit_comment')
 
     @View.nested


### PR DESCRIPTION
## Summary by Sourcery

Enhance TemplateEditor to support filling content via its fullscreen modal and replace inline ACEEditor with the new TemplateEditor in partition table views

Enhancements:
- Convert fullscreen button to a Text element and add locators for modal close button and textarea
- Implement a custom fill method to optionally open the editor in fullscreen, populate the textarea, and close the modal
- Swap out direct ACEEditor usage for TemplateEditor in partitiontable views