### PR TITLE
Add support for rolling cvs

### DIFF
--- a/airgun/views/contentview_new.py
+++ b/airgun/views/contentview_new.py
@@ -102,6 +102,7 @@ class ContentViewCreateView(BaseLoggedInView):
     solve_dependencies = Checkbox(id='dependencies')
     import_only = Checkbox(id='importOnly')
     composite_tile = Text('//div[contains(@id, "composite")]')
+    rolling_tile = Text('//div[contains(@id, "rolling")]')
     auto_publish = Checkbox(id='autoPublish')
 
     @property


### PR DESCRIPTION
Small Airgun PR adding a locator for the Rolling CV card, and an entity to do a negative test with rolling CV UI features.

## Summary by Sourcery

Enable creation and UI validation of rolling content views by adding a rolling flag in the entity create method, a locator for the rolling CV option in the view, and a read method to assert appropriate UI element visibility.

New Features:
- Allow creating rolling content views via the NewContentViewEntity.create method with a rolling flag
- Add rolling_tile locator in ContentViewCreateView to enable UI selection of rolling CV
- Introduce NewContentViewEntity.rolling_cv_read method to validate UI restrictions for rolling CVs