### PR TITLE
Cherrypick : Add in entities and views to accomodate test cases based…

### DIFF
--- a/airgun/entities/computeresource.py
+++ b/airgun/entities/computeresource.py
@@ -4,6 +4,8 @@ from airgun.entities.base import BaseEntity
 from airgun.navigation import NavigateStep, navigator
 from airgun.utils import retry_navigation
 from airgun.views.computeresource import (
+    ComputeResourceLibvirtImageCreateView,
+    ComputeResourceLibvirtImageEditView,
     ComputeResourceRHVImageCreateView,
     ComputeResourceRHVImageEditView,
     ComputeResourcesView,
@@ -301,6 +303,7 @@ class ComputeResourceImageCreate(ComputeResourceImageProvider):
     PROVIDER_VIEWS = {
         'RHV': ComputeResourceRHVImageCreateView,
         'VMware': ComputeResourceVMwareImageCreateView,
+        'Libvirt': ComputeResourceLibvirtImageCreateView,
     }
 
     def step(self, *args, **kwargs):
@@ -312,6 +315,7 @@ class ComputeResourceImageEdit(ComputeResourceImageProvider):
     PROVIDER_VIEWS = {
         'RHV': ComputeResourceRHVImageEditView,
         'VMware': ComputeResourceVMwareImageEditView,
+        'Libvirt': ComputeResourceLibvirtImageEditView,
     }
 
     def step(self, *args, **kwargs):

--- a/airgun/views/computeresource.py
+++ b/airgun/views/computeresource.py
@@ -534,3 +534,19 @@ class ComputeResourceVMwareImageEditView(
     ComputeResourceVMwareImageCreateView, ComputeResourceGenericImageEditViewMixin
 ):
     """VMWare ComputeResource Image edit View"""
+
+
+class ComputeResourceLibvirtImageCreateView(ComputeResourceGenericImageCreateView):
+    """Libvirt ComputeResource Image create View"""
+
+    image = None
+    image_path = TextInput(id='image_uuid')
+
+
+class ComputeResourceLibvirtImageEditView(
+    ComputeResourceLibvirtImageCreateView, ComputeResourceGenericImageEditViewMixin
+):
+    """Libvirt ComputeResource Image edit View"""
+
+    image = None
+    image_path = TextInput(id='image_uuid')


### PR DESCRIPTION
… on image for Libvirt (#1981)

## Summary by Sourcery

Add support for Libvirt compute resource image create and edit operations by introducing corresponding views and registering them in the provider mappings.

New Features:
- Introduce ComputeResourceLibvirtImageCreateView and ComputeResourceLibvirtImageEditView for Libvirt image operations.

Enhancements:
- Register Libvirt image create/edit views under the 'Libvirt' provider in ComputeResourceImageCreate and ComputeResourceImageEdit entities.