### PR TITLE
Update Insights HostDetails Tab

### DIFF
--- a/airgun/entities/host_new.py
+++ b/airgun/entities/host_new.py
@@ -912,6 +912,7 @@ class NewHostEntity(HostEntity):
         view = self.navigate_to(self, 'NewDetails', entity_name=entity_name)
         view.wait_displayed()
         self.browser.plugin.ensure_page_safe()
+        wait_for(lambda: view.insights.recommendations_table.is_displayed, timeout=10)
         return view.insights.read()
 
     def remediate_with_insights(

--- a/airgun/views/host_new.py
+++ b/airgun/views/host_new.py
@@ -735,6 +735,8 @@ class NewHostDetailsView(BaseLoggedInView):
     class insights(PF5Tab):
         ROOT = './/div'
 
+        TAB_NAME = 'Red Hat Lightspeed'
+
         search_bar = SearchInput(locator='.//input[contains(@class, "pf-v5-c-text-input")]')
         remediate = PF5Button(locator='.//button[text()="Remediate"]')
         insights_dropdown = Dropdown(locator='.//div[contains(@class, "insights-dropdown")]')
@@ -745,7 +747,7 @@ class NewHostDetailsView(BaseLoggedInView):
         )
 
         recommendations_table = PF5OUIATable(
-            component_id='OUIA-Generated-Table-2',
+            component_id='rh-cloud-recommendations-table',
             column_widgets={
                 0: Checkbox(locator='.//input[@type="checkbox"]'),
                 'Recommendation': Text('.//td[2]'),


### PR DESCRIPTION
Rename is needed,
I also made the `get_insights` more robust.

now it just unstuck some tests, thus not running PRT.

## Summary by Sourcery

Update the Insights tab on the host details view to use a custom name, stable identifiers, and improved loading robustness.

Bug Fixes:
- Add an explicit wait to get_insights to ensure the recommendations table is displayed before reading

Enhancements:
- Assign 'Red Hat Lightspeed' as the display name for the Insights tab
- Update the recommendations table component ID to 'rh-cloud-recommendations-table'