### PR TITLE
Added refresh as job status for perticular hosts is not getting updated by itself

### DIFF
--- a/airgun/entities/contenthost.py
+++ b/airgun/entities/contenthost.py
@@ -69,6 +69,7 @@ class ContentHostEntity(BaseEntity):
         view.packages_actions.perform.click()
         view = JobInvocationStatusView(view.browser)
         view.wait_for_result()
+        view.browser.refresh()
         return view.read()
 
     def bulk_set_syspurpose(self, hosts, values):
@@ -117,6 +118,7 @@ class ContentHostEntity(BaseEntity):
             view.submit.click()
         view = JobInvocationStatusView(view.browser)
         view.wait_for_result()
+        view.browser.refresh()
         return view.read()
 
     def search_package(self, entity_name, package_name):

--- a/airgun/entities/hostcollection.py
+++ b/airgun/entities/hostcollection.py
@@ -221,6 +221,7 @@ class HostCollectionEntity(BaseEntity):
             view.submit.click()
         view = JobInvocationStatusView(view.browser)
         view.wait_for_result()
+        view.browser.refresh()
         return view.read()
 
     def change_assigned_content(self, entity_name, lce, content_view):


### PR DESCRIPTION
### Problem statement 
Job status for specific host is not getting updated once job got completed successfully.

### Solution 
We need to refresh page before reading job status of host otherwise it return existing status i.e **Pending**

Note: This is dependent on https://github.com/SatelliteQE/robottelo/pull/19348 