### PR TITLE
[6.18.z] Added refresh as job status for perticular hosts is not getting updated by itself

### DIFF
--- a/airgun/entities/contenthost.py
+++ b/airgun/entities/contenthost.py
@@ -106,6 +106,7 @@ class ContentHostEntity(BaseEntity):
         if customize_values is None:
             customize_values = {}
         view = self.navigate_to(self, 'Edit', entity_name=entity_name)
+        view.wait_displayed()
         view.module_streams.search(f'name = {module_name} and stream = {stream_version}')
         action_type = {'is_customize': customize, 'action': action_type}
         view.module_streams.table.row(name=module_name, stream=stream_version)['Actions'].fill(

--- a/airgun/views/job_invocation.py
+++ b/airgun/views/job_invocation.py
@@ -208,6 +208,7 @@ class JobInvocationStatusView(BaseLoggedInView):
             delay=1,
             logger=self.logger,
         )
+        self.browser.refresh()
 
     @View.nested
     class overall_status(DonutCircle):


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/airgun/pull/2000

### Problem statement 
Job status for specific host is not getting updated once job got completed successfully.

### Solution 
We need to refresh page before reading job status of host otherwise it return existing status i.e **Pending**

Note: This is dependent on https://github.com/SatelliteQE/robottelo/pull/19348

## Summary by Sourcery

Add explicit browser refresh and UI wait to ensure job statuses and module streams load correctly before interaction

Bug Fixes:
- Refresh the browser before reading job invocation results to prevent stale Pending status

Enhancements:
- Wait for the content host Edit view to be displayed before searching module streams