### PR TITLE
[6.18.z] Host Group view extension

### DIFF
--- a/airgun/views/hostgroup.py
+++ b/airgun/views/hostgroup.py
@@ -1,6 +1,10 @@
 from widgetastic.widget import ConditionalSwitchableView, Table, Text, TextInput, View
 from widgetastic_patternfly import BreadCrumb
-from widgetastic_patternfly5 import Button as PF5Button, Pagination as PF5Pagination
+from widgetastic_patternfly5 import (
+    Button as PF5Button,
+    ChipGroup as PF5ChipGroup,
+    Pagination as PF5Pagination,
+)
 from widgetastic_patternfly5.ouia import Select as PF5OUIASelect
 
 from airgun.views.common import BaseLoggedInView, SatTab, SearchableViewMixinPF4
@@ -133,6 +137,9 @@ class HostGroupCreateView(BaseLoggedInView):
     class activation_keys(SatTab):
         TAB_NAME = 'Activation Keys'
         activation_keys = PF5OUIASelect(component_id='ak-select')
+        ak_chip_group = PF5ChipGroup(
+            locator='//div[@aria-label="Chip group category" and @data-ouia-component-type="PF5/ChipGroup"]'
+        )
 
 
 class HostGroupEditView(HostGroupCreateView):


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/airgun/pull/2021

Add AK chip group.
A similar change is needed in 6.17.z but it uses PF4 so I will do it manually.

## Summary by Sourcery

New Features:
- Add PF5 ChipGroup component for activation keys in the HostGroup view

## Summary by Sourcery

New Features:
- Add PF5 ChipGroup component for activation keys in the HostGroup view