### PR TITLE
[6.18.z] Fix for search function as its landing on old UI page

### DIFF
--- a/airgun/entities/host_new.py
+++ b/airgun/entities/host_new.py
@@ -44,6 +44,8 @@ def navigate_to_edit_view(func):
 
 
 class NewHostEntity(HostEntity):
+    endpoint_path = '/new/hosts'
+
     def create(self, values):
         """Create new host entity"""
         view = self.navigate_to(self, 'New')
@@ -62,8 +64,6 @@ class NewHostEntity(HostEntity):
         view = self.navigate_to(self, 'NewDetails', entity_name=entity_name)
         view.wait_displayed()
         self.browser.plugin.ensure_page_safe()
-        # Run this read twice to navigate to the page and load it before reading
-        view.read(widget_names=widget_names)
         return view.read(widget_names=widget_names)
 
     def run_bootc_job(self, entity_name, job_name, job_options=None):

--- a/airgun/views/host_new.py
+++ b/airgun/views/host_new.py
@@ -506,7 +506,7 @@ class NewHostDetailsView(BaseLoggedInView):
         cancel_addition = Button(locator='.//td[5]//button[1]')
         confirm_addition = Button(locator='.//td[5]//button[2]')
 
-        table_header = PatternflyTable(locator='.//table[@data-ouia-component-type="PF4/Table"]')
+        table_header = PF5OUIATable(component_id='parameters-table')
         parameters_table = Table(
             locator='.//table[@aria-label="Parameters table"]',
             column_widgets={


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/airgun/pull/1980

### Problem Statement
Search function was landing on old UI page due to this all cases wherever we were just searching first were failing .   

### Solution
Added  endpoint_path = '/new/hosts'  in NewHostEntity  to fix issue

### Related Issues

## Summary by Sourcery

Fix the search navigation and update UI element references for the new hosts entity

Bug Fixes:
- Ensure search navigates to the new hosts UI by setting endpoint_path in NewHostEntity

Enhancements:
- Switch table_header to use PF5OUIATable for better component handling
- Remove redundant initial read call in get_details to streamline page loading