### PR TITLE
[6.18.z] Add view/entities for Hosts->vulnerabilities tab and vulnerability list page

### DIFF
--- a/airgun/entities/cloud_vulnerabilities.py
+++ b/airgun/entities/cloud_vulnerabilities.py
@@ -2,6 +2,7 @@ from airgun.entities.base import BaseEntity
 from airgun.navigation import NavigateStep, navigator
 from airgun.utils import retry_navigation
 from airgun.views.cloud_vulnerabilities import CloudVulnerabilityView, CVEDetailsView
+from airgun.views.host_new import NewHostDetailsView
 
 
 class CloudVulnerabilityEntity(BaseEntity):
@@ -11,6 +12,13 @@ class CloudVulnerabilityEntity(BaseEntity):
         view = self.navigate_to(self, 'All')
         return view.vulnerabilities_table.read()
 
+    def _navigate_to_cve_details(self, cve_id):
+        """Helper method to navigate to CVE details page"""
+        view = self.navigate_to(self, 'All')
+        view.wait_displayed()
+        view.search_bar.fill(cve_id)
+        view.browser.element(f'.//a[contains(@href, "{cve_id}")]').click()
+
     def get_cve_details(self, cve_id):
         """
         Read CVE details from CVE details page
@@ -18,12 +26,40 @@ class CloudVulnerabilityEntity(BaseEntity):
         Args:
             cve_id (str): CVE ID to get details
         """
-        view = self.navigate_to(self, 'All')
-        view.wait_displayed()
-        view.search_bar.fill(cve_id)
-        view.vulnerabilities_table.row(cve_id)['CVE ID'].click()
+        self._navigate_to_cve_details(cve_id)
         view = CVEDetailsView(self.browser)
         return view.read()
+
+    def get_affected_hosts_by_cve(self, cve_id):
+        """
+        Get list of affected hosts for a specific CVE
+
+        Args:
+            cve_id (str): CVE ID to get affected hosts for
+        """
+        self._navigate_to_cve_details(cve_id)
+        cve_details_view = CVEDetailsView(self.browser)
+        return cve_details_view.affected_hosts_table.read()
+
+    def validate_cve_to_host_details_flow(self, cve_id, hostname=None):
+        """
+        Complete flow: CVE details -> affected hosts -> click host -> host details page
+
+        Args:
+            cve_id (str): CVE ID to test
+            hostname (str, optional): Specific host name to click on.
+        """
+        self._navigate_to_cve_details(cve_id)
+        cve_details_view = CVEDetailsView(self.browser)
+        cve_details_view.search_bar.fill(hostname)
+        cve_details_view.browser.element(f'.//a[contains(text(), "{hostname}")]').click()
+        host_details_view = NewHostDetailsView(self.browser)
+        host_details_view.breadcrumb.wait_displayed()
+        vulnerabilities = getattr(host_details_view.vulnerabilities, 'vulnerabilities_table', None)
+        if vulnerabilities is not None:
+            return vulnerabilities.read()
+        else:
+            return []
 
 
 @navigator.register(CloudVulnerabilityEntity, 'All')

--- a/airgun/entities/cloud_vulnerabilities.py
+++ b/airgun/entities/cloud_vulnerabilities.py
@@ -15,10 +15,10 @@ class CloudVulnerabilityEntity(BaseEntity):
 
 @navigator.register(CloudVulnerabilityEntity, 'All')
 class ShowVulnerabilityListView(NavigateStep):
-    """Navigate to main Insights -> Vulnerabilities page"""
+    """Navigate to main Red Hat Lightspeed -> Vulnerability page"""
 
     VIEW = CloudVulnerabilityView
 
     @retry_navigation
     def step(self, *args, **kwargs):
-        self.view.menu.select('Insights', 'Vulnerabilities')
+        self.view.menu.select('Red Hat Lightspeed', 'Vulnerability')

--- a/airgun/entities/cloud_vulnerabilities.py
+++ b/airgun/entities/cloud_vulnerabilities.py
@@ -1,7 +1,7 @@
 from airgun.entities.base import BaseEntity
 from airgun.navigation import NavigateStep, navigator
 from airgun.utils import retry_navigation
-from airgun.views.cloud_vulnerabilities import CloudVulnerabilityView
+from airgun.views.cloud_vulnerabilities import CloudVulnerabilityView, CVEDetailsView
 
 
 class CloudVulnerabilityEntity(BaseEntity):
@@ -10,6 +10,20 @@ class CloudVulnerabilityEntity(BaseEntity):
     def read(self, entity_name=None, widget_names=None):
         view = self.navigate_to(self, 'All')
         return view.vulnerabilities_table.read()
+
+    def get_cve_details(self, cve_id):
+        """
+        Read CVE details from CVE details page
+
+        Args:
+            cve_id (str): CVE ID to get details
+        """
+        view = self.navigate_to(self, 'All')
+        view.wait_displayed()
+        view.search_bar.fill(cve_id)
+        view.vulnerabilities_table.row(cve_id)['CVE ID'].click()
+        view = CVEDetailsView(self.browser)
+        return view.read()
 
 
 @navigator.register(CloudVulnerabilityEntity, 'All')

--- a/airgun/entities/cloud_vulnerabilities.py
+++ b/airgun/entities/cloud_vulnerabilities.py
@@ -1,0 +1,24 @@
+from airgun.entities.base import BaseEntity
+from airgun.navigation import NavigateStep, navigator
+from airgun.utils import retry_navigation
+from airgun.views.cloud_vulnerabilities import CloudVulnerabilityView
+
+
+class CloudVulnerabilityEntity(BaseEntity):
+    endpoint_path = '/foreman_rh_cloud/insights_vulnerability'
+
+    def read(self, entity_name=None, widget_names=None):
+        view = self.navigate_to(self, 'All')
+        result = view.read(widget_names=widget_names)
+        return result
+
+
+@navigator.register(CloudVulnerabilityEntity, 'All')
+class ShowVulnerabilityListView(NavigateStep):
+    """Navigate to main Insights -> Vulnerabilities page"""
+
+    VIEW = CloudVulnerabilityView
+
+    @retry_navigation
+    def step(self, *args, **kwargs):
+        self.view.menu.select('Insights', 'Vulnerabilities')

--- a/airgun/entities/cloud_vulnerabilities.py
+++ b/airgun/entities/cloud_vulnerabilities.py
@@ -9,8 +9,7 @@ class CloudVulnerabilityEntity(BaseEntity):
 
     def read(self, entity_name=None, widget_names=None):
         view = self.navigate_to(self, 'All')
-        result = view.read(widget_names=widget_names)
-        return result
+        return view.vulnerabilities_table.read()
 
 
 @navigator.register(CloudVulnerabilityEntity, 'All')

--- a/airgun/entities/host_new.py
+++ b/airgun/entities/host_new.py
@@ -916,6 +916,12 @@ class NewHostEntity(HostEntity):
         wait_for(lambda: view.insights.recommendations_table.is_displayed, timeout=10)
         return view.insights.read()
 
+    def get_cves(self, entity_name):
+        view = self.navigate_to(self, 'NewDetails', entity_name=entity_name)
+        view.wait_displayed()
+        self.browser.plugin.ensure_page_safe()
+        return view.cves.read()
+
     def remediate_with_insights(
         self, entity_name, recommendation_to_remediate=None, remediate_all=False
     ):

--- a/airgun/entities/host_new.py
+++ b/airgun/entities/host_new.py
@@ -916,11 +916,11 @@ class NewHostEntity(HostEntity):
         wait_for(lambda: view.insights.recommendations_table.is_displayed, timeout=10)
         return view.insights.read()
 
-    def get_cves(self, entity_name):
+    def get_vulnerabilities(self, entity_name):
         view = self.navigate_to(self, 'NewDetails', entity_name=entity_name)
         view.wait_displayed()
         self.browser.plugin.ensure_page_safe()
-        return view.cves.read()
+        return view.vulnerabilities.vulnerabilities_table.read()
 
     def remediate_with_insights(
         self, entity_name, recommendation_to_remediate=None, remediate_all=False

--- a/airgun/entities/host_new.py
+++ b/airgun/entities/host_new.py
@@ -920,7 +920,11 @@ class NewHostEntity(HostEntity):
         view = self.navigate_to(self, 'NewDetails', entity_name=entity_name)
         view.wait_displayed()
         self.browser.plugin.ensure_page_safe()
-        return view.vulnerabilities.vulnerabilities_table.read()
+        vulnerabilities = getattr(view.vulnerabilities, 'vulnerabilities_table', None)
+        if vulnerabilities is not None:
+            return vulnerabilities.read()
+        else:
+            return []
 
     def remediate_with_insights(
         self, entity_name, recommendation_to_remediate=None, remediate_all=False

--- a/airgun/entities/host_new.py
+++ b/airgun/entities/host_new.py
@@ -920,6 +920,7 @@ class NewHostEntity(HostEntity):
         view = self.navigate_to(self, 'NewDetails', entity_name=entity_name)
         view.wait_displayed()
         self.browser.plugin.ensure_page_safe()
+        wait_for(lambda: view.vulnerabilities.vulnerabilities_table.is_displayed, timeout=30)
         vulnerabilities = getattr(view.vulnerabilities, 'vulnerabilities_table', None)
         if vulnerabilities is not None:
             return vulnerabilities.read()

--- a/airgun/session.py
+++ b/airgun/session.py
@@ -23,6 +23,7 @@ from airgun.entities.bootc import BootcEntity
 from airgun.entities.capsule import CapsuleEntity
 from airgun.entities.cloud_insights import CloudInsightsEntity
 from airgun.entities.cloud_inventory import CloudInventoryEntity
+from airgun.entities.cloud_vulnerabilities import CloudVulnerabilityEntity
 from airgun.entities.computeprofile import ComputeProfileEntity
 from airgun.entities.computeresource import ComputeResourceEntity
 from airgun.entities.config_report import ConfigReportEntity
@@ -398,6 +399,11 @@ class Session:
     def cloudinsights(self):
         """Instance of Insights entity."""
         return self._open(CloudInsightsEntity)
+
+    @cached_property
+    def cloudvulnerability(self):
+        """Instance of Insights entity."""
+        return self._open(CloudVulnerabilityEntity)
 
     @cached_property
     def computeprofile(self):

--- a/airgun/views/cloud_vulnerabilities.py
+++ b/airgun/views/cloud_vulnerabilities.py
@@ -33,11 +33,11 @@ class CloudVulnerabilityView(BaseLoggedInView):
         component_id='OUIA-Generated-Table-1',
         column_widgets={
             0: PF5Button(locator='.//button[@aria-label="Details"]'),
-            'CVE ID': Text('.//td[contains(@data-label, "CVE ID")]'),
-            'Publish date': Text('.//td[contains(@data-label, "Publish date")]'),
-            'Severity': Text('.//td[contains(@data-label, "Severity")]'),
-            'CVSS base score': Text('.//td[contains(@data-label, "CVSS base score")]'),
-            'Affected hosts': Text('.//td[contains(@data-label, "Affected hosts")]'),
+            'CVE ID': Text('.//td[@data-label="CVE ID"]'),
+            'Publish date': Text('.//td[@data-label="Publish date"]'),
+            'Severity': Text('.//td[@data-label="Severity"]'),
+            'CVSS base score': Text('.//td[@data-label="CVSS base score"]'),
+            'Affected hosts': Text('.//td[@data-label="Affected hosts"]'),
         },
     )
     pagination = PF5Pagination()
@@ -47,12 +47,12 @@ class CloudVulnerabilityView(BaseLoggedInView):
         return self.browser.wait_for_element(self.title, exception=False) is not None
 
 
-class CVEDetailsView:
+class CVEDetailsView(BaseLoggedInView):
     """Class that describes the Vulnerabilities Details page"""
 
     title = Text('.//h1[@data-ouia-component-type="RHI/Header"]')
     description = Text('.//div[@class="pf-v5-c-content"]')
-
+    search_bar = SearchInput(locator='.//input[contains(@aria-label, "search-field")]')
     affected_hosts_table = PF5OUIAPatternflyTable(
         component_id='OUIA-Generated-Table-1',
         column_widgets={

--- a/airgun/views/cloud_vulnerabilities.py
+++ b/airgun/views/cloud_vulnerabilities.py
@@ -1,0 +1,13 @@
+from widgetastic.widget import Text
+
+from airgun.views.common import BaseLoggedInView
+
+
+class CloudVulnerabilityView(BaseLoggedInView):
+    """Main Insights Vulnerabilities view."""
+
+    title = Text('//h1[normalize-space(.)="Vulnerabilities"]')
+
+    @property
+    def is_displayed(self):
+        return self.browser.wait_for_element(self.title, exception=False) is not None

--- a/airgun/views/cloud_vulnerabilities.py
+++ b/airgun/views/cloud_vulnerabilities.py
@@ -1,6 +1,6 @@
 from widgetastic.widget import Text
 from widgetastic_patternfly5 import Button as PF5Button, Pagination as PF5Pagination
-from widgetastic_patternfly5.ouia import PatternflyTable as PF5OUIATable
+from widgetastic_patternfly5.ouia import ExpandableTable as PF5OUIAExpandableTable
 
 from airgun.views.common import BaseLoggedInView
 from airgun.widgets import SearchInput
@@ -26,8 +26,8 @@ class CloudVulnerabilityView(BaseLoggedInView):
     cve_menu_toggle = PF5Button('.//button[contains(@class, "pf-v5-c-menu-toggle")]')
     no_cves_found_message = Text('.//h5[contains(@class, "pf-v5-c-empty-state__title-text")]')
 
-    vulnerabilities_table = PF5OUIATable(
-        locator='.//table[@data-ouia-component-type="PF5/Table"]',
+    vulnerabilities_table = PF5OUIAExpandableTable(
+        component_id='OUIA-Generated-Table-1',
         column_widgets={
             0: PF5Button(locator='.//button[@aria-label="Details"]'),
             'CVE ID': Text('.//td[contains(@data-label, "CVE ID")]'),

--- a/airgun/views/cloud_vulnerabilities.py
+++ b/airgun/views/cloud_vulnerabilities.py
@@ -1,6 +1,9 @@
 from widgetastic.widget import Text
 from widgetastic_patternfly5 import Button as PF5Button, Pagination as PF5Pagination
-from widgetastic_patternfly5.ouia import ExpandableTable as PF5OUIAExpandableTable
+from widgetastic_patternfly5.ouia import (
+    ExpandableTable as PF5OUIAExpandableTable,
+    PatternflyTable as PF5OUIAPatternflyTable,
+)
 
 from airgun.views.common import BaseLoggedInView
 from airgun.widgets import SearchInput
@@ -38,6 +41,26 @@ class CloudVulnerabilityView(BaseLoggedInView):
         },
     )
     pagination = PF5Pagination()
+
+    @property
+    def is_displayed(self):
+        return self.browser.wait_for_element(self.title, exception=False) is not None
+
+
+class CVEDetailsView:
+    """Class that describes the Vulnerabilities Details page"""
+
+    title = Text('.//h1[@data-ouia-component-type="RHI/Header"]')
+    description = Text('.//div[@class="pf-v5-c-content"]')
+
+    affected_hosts_table = PF5OUIAPatternflyTable(
+        component_id='OUIA-Generated-Table-1',
+        column_widgets={
+            'Name': Text('./a'),
+            'OS': Text('.//td[contains(@data-label, "OS")]'),
+            'Last seen': Text('.//td[contains(@data-label, "Last seen")]'),
+        },
+    )
 
     @property
     def is_displayed(self):

--- a/airgun/views/cloud_vulnerabilities.py
+++ b/airgun/views/cloud_vulnerabilities.py
@@ -1,12 +1,43 @@
 from widgetastic.widget import Text
+from widgetastic_patternfly5 import Button as PF5Button, Pagination as PF5Pagination
+from widgetastic_patternfly5.ouia import PatternflyTable as PF5OUIATable
 
 from airgun.views.common import BaseLoggedInView
+from airgun.widgets import SearchInput
 
 
 class CloudVulnerabilityView(BaseLoggedInView):
     """Main Insights Vulnerabilities view."""
 
     title = Text('//h1[normalize-space(.)="Vulnerabilities"]')
+    cves_with_known_exploits_card = PF5Button(
+        '//div[@data-ouia-component-type="PF5/Card"][.//b[text()="CVEs with known exploits"]]'
+    )
+    cves_with_security_rules_card = PF5Button(
+        '//div[@data-ouia-component-type="PF5/Card"][.//b[text()="CVEs with security rules"]]'
+    )
+    cves_with_critical_severity_card = PF5Button(
+        '//div[@data-ouia-component-type="PF5/Card"][.//b[text()="CVEs with critical severity"]]'
+    )
+    cves_with_important_severity_card = PF5Button(
+        '//div[@data-ouia-component-type="PF5/Card"][.//b[text()="CVEs with important severity"]]'
+    )
+    search_bar = SearchInput(locator='.//input[contains(@aria-label, "search-field")]')
+    cve_menu_toggle = PF5Button('.//button[contains(@class, "pf-v5-c-menu-toggle")]')
+    no_cves_found_message = Text('.//h5[contains(@class, "pf-v5-c-empty-state__title-text")]')
+
+    vulnerabilities_table = PF5OUIATable(
+        locator='.//table[@data-ouia-component-type="PF5/Table"]',
+        column_widgets={
+            0: PF5Button(locator='.//button[@aria-label="Details"]'),
+            'CVE ID': Text('.//td[contains(@data-label, "CVE ID")]'),
+            'Publish date': Text('.//td[contains(@data-label, "Publish date")]'),
+            'Severity': Text('.//td[contains(@data-label, "Severity")]'),
+            'CVSS base score': Text('.//td[contains(@data-label, "CVSS base score")]'),
+            'Affected hosts': Text('.//td[contains(@data-label, "Affected hosts")]'),
+        },
+    )
+    pagination = PF5Pagination()
 
     @property
     def is_displayed(self):

--- a/airgun/views/cloud_vulnerabilities.py
+++ b/airgun/views/cloud_vulnerabilities.py
@@ -1,7 +1,13 @@
 from widgetastic.widget import Text
-from widgetastic_patternfly5 import Button as PF5Button, Pagination as PF5Pagination
-from widgetastic_patternfly5.ouia import (
+
+# from widgetastic_patternfly5.ouia import (
+#     ExpandableTable as PF5OUIAExpandableTable,
+#     PatternflyTable as PF5OUIAPatternflyTable,
+# )
+from widgetastic_patternfly5 import (
+    Button as PF5Button,
     ExpandableTable as PF5OUIAExpandableTable,
+    Pagination as PF5Pagination,
     PatternflyTable as PF5OUIAPatternflyTable,
 )
 
@@ -30,7 +36,8 @@ class CloudVulnerabilityView(BaseLoggedInView):
     no_cves_found_message = Text('.//h5[contains(@class, "pf-v5-c-empty-state__title-text")]')
 
     vulnerabilities_table = PF5OUIAExpandableTable(
-        component_id='OUIA-Generated-Table-1',
+        # component_id='OUIA-Generated-Table-1',
+        locator='.//table[contains(@class, "pf-v5-c-table")]',
         column_widgets={
             0: PF5Button(locator='.//button[@aria-label="Details"]'),
             'CVE ID': Text('.//td[@data-label="CVE ID"]'),
@@ -54,7 +61,8 @@ class CVEDetailsView(BaseLoggedInView):
     description = Text('.//div[@class="pf-v5-c-content"]')
     search_bar = SearchInput(locator='.//input[contains(@aria-label, "search-field")]')
     affected_hosts_table = PF5OUIAPatternflyTable(
-        component_id='OUIA-Generated-Table-1',
+        # component_id='OUIA-Generated-Table-1',
+        locator='.//table[contains(@class, "pf-v5-c-table")]',
         column_widgets={
             'Name': Text('./a'),
             'OS': Text('.//td[contains(@data-label, "OS")]'),

--- a/airgun/views/host_new.py
+++ b/airgun/views/host_new.py
@@ -759,6 +759,16 @@ class NewHostDetailsView(BaseLoggedInView):
         )
         pagination = PF5Pagination()
 
+    @View.nested
+    class cves(PF5Tab):
+        ROOT = './/div'
+
+        title = Text('//h1[contains(text(), "CVEs tab for host:")]')
+
+        @property
+        def is_displayed(self):
+            return self.title.wait_displayed()
+
 
 class InstallPackagesView(View):
     """Install packages modal"""

--- a/airgun/views/host_new.py
+++ b/airgun/views/host_new.py
@@ -767,8 +767,8 @@ class NewHostDetailsView(BaseLoggedInView):
         cve_menu_toggle = PF5Button(".//button[contains(@class, 'pf-v5-c-menu-toggle')]")
         no_cves_found_message = Text('.//h5[contains(@class, "pf-v5-c-empty-state__title-text")]')
 
-        vulnerabilities_table = PF5OUIATable(
-            locator='.//table[@data-ouia-component-type="PF5/Table"]',
+        vulnerabilities_table = PF5OUIAExpandableTable(
+            component_id='OUIA-Generated-Table-2',
             column_widgets={
                 0: PF5Button(locator='.//button[@aria-label="Details"]'),
                 'CVE ID': Text('.//td[contains(@data-label, "CVE ID")]'),
@@ -781,7 +781,12 @@ class NewHostDetailsView(BaseLoggedInView):
 
         @property
         def is_displayed(self):
-            return self.vulnerabilities_table.wait_displayed()
+            table_displayed = self.vulnerabilities_table.wait_displayed(exception=False)
+            no_cves_message_displayed = (
+                self.browser.wait_for_element(self.no_cves_found_message, exception=False)
+                is not None
+            )
+            return table_displayed or no_cves_message_displayed
 
 
 class InstallPackagesView(View):

--- a/airgun/views/host_new.py
+++ b/airgun/views/host_new.py
@@ -760,14 +760,28 @@ class NewHostDetailsView(BaseLoggedInView):
         pagination = PF5Pagination()
 
     @View.nested
-    class cves(PF5Tab):
+    class vulnerabilities(PF5Tab):
         ROOT = './/div'
 
-        title = Text('//h1[contains(text(), "CVEs tab for host:")]')
+        search_bar = SearchInput(locator='.//input[contains(@aria-label, "search-field")]')
+        cve_menu_toggle = PF5Button(".//button[contains(@class, 'pf-v5-c-menu-toggle')]")
+        no_cves_found_message = Text('.//h5[contains(@class, "pf-v5-c-empty-state__title-text")]')
+
+        vulnerabilities_table = PF5OUIATable(
+            locator='.//table[@data-ouia-component-type="PF5/Table"]',
+            column_widgets={
+                0: PF5Button(locator='.//button[@aria-label="Details"]'),
+                'CVE ID': Text('.//td[contains(@data-label, "CVE ID")]'),
+                'Publish date': Text('.//td[contains(@data-label, "Publish date")]'),
+                'Severity': Text('.//td[contains(@data-label, "Severity")]'),
+                'CVSS base score': Text('.//td[contains(@data-label, "CVSS base score")]'),
+            },
+        )
+        pagination = PF5Pagination()
 
         @property
         def is_displayed(self):
-            return self.title.wait_displayed()
+            return self.vulnerabilities_table.wait_displayed()
 
 
 class InstallPackagesView(View):

--- a/airgun/views/host_new.py
+++ b/airgun/views/host_new.py
@@ -19,6 +19,7 @@ from widgetastic_patternfly4.ouia import (
 from widgetastic_patternfly5 import (
     Button as PF5Button,
     Dropdown as PF5Dropdown,
+    ExpandableTable as pf5OUIAExpandableTable,
     Menu as PF5Menu,
     Pagination as PF5Pagination,
     Tab as PF5Tab,
@@ -767,8 +768,9 @@ class NewHostDetailsView(BaseLoggedInView):
         cve_menu_toggle = PF5Button(".//button[contains(@class, 'pf-v5-c-menu-toggle')]")
         no_cves_found_message = Text('.//h5[contains(@class, "pf-v5-c-empty-state__title-text")]')
 
-        vulnerabilities_table = PF5OUIAExpandableTable(
-            component_id='OUIA-Generated-Table-2',
+        vulnerabilities_table = pf5OUIAExpandableTable(
+            # component_id='OUIA-Generated-Table-2',
+            locator='.//table[contains(@class, "pf-v5-c-table")]',
             column_widgets={
                 0: PF5Button(locator='.//button[@aria-label="Details"]'),
                 'CVE ID': Text('.//td[contains(@data-label, "CVE ID")]'),


### PR DESCRIPTION
Manual cherrypick of https://github.com/SatelliteQE/airgun/pull/1978

## Summary by Sourcery

Add support for vulnerabilities in both host and cloud contexts by introducing new UI views, session properties, and entity methods for listing, viewing, and navigating CVEs.

New Features:
- Add nested vulnerabilities tab to host details view with search and expandable table
- Implement get_vulnerabilities method on host entity to retrieve host CVEs
- Register cloudvulnerability session property to access CloudVulnerabilityEntity
- Introduce CloudVulnerabilityView and CVEDetailsView for listing and viewing CVE details
- Add CloudVulnerabilityEntity with methods for reading vulnerabilities, fetching CVE details, affected hosts, and validating navigation flow
- Register navigation step to reach the main Vulnerability page

Related PR https://github.com/SatelliteQE/robottelo/pull/19531