### PR TITLE
[6.16.z] [pre-commit.ci] pre-commit autoupdate

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,7 +9,7 @@ repos:
   hooks:
   - id: black
 - repo: https://github.com/astral-sh/ruff-pre-commit
-  rev: v0.12.12
+  rev: v0.13.0
   hooks:
     - id: ruff
       args: [--fix, --exit-non-zero-on-fix]


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/airgun/pull/2034

<!--pre-commit.ci start-->
updates:
- [github.com/astral-sh/ruff-pre-commit: v0.12.12 → v0.13.0](https://github.com/astral-sh/ruff-pre-commit/compare/v0.12.12...v0.13.0)
<!--pre-commit.ci end-->

## Summary by Sourcery

Build:
- Bump ruff pre-commit hook from v0.12.12 to v0.13.0