### PR TITLE
[6.18.z] Small refactor of host's expand_all and adding entity to open legacy ui

### DIFF
--- a/airgun/entities/host.py
+++ b/airgun/entities/host.py
@@ -602,6 +602,9 @@ class HostsManageColumns(NavigateStep):
 
     def step(self, *args, **kwargs):
         """Open the Manage columns dialog"""
+        self.parent.browser.plugin.ensure_page_safe()
+        self.parent.wait_displayed()
+        self.parent.manage_columns.wait_displayed()
         self.parent.manage_columns.click()
 
 

--- a/airgun/entities/host_new.py
+++ b/airgun/entities/host_new.py
@@ -7,6 +7,7 @@ from airgun.entities.host import HostEntity
 from airgun.navigation import NavigateStep, navigator
 from airgun.utils import retry_navigation
 from airgun.views.fact import HostFactView
+from airgun.views.host import HostsView as LegacyHostsView
 from airgun.views.host_new import (
     AllAssignedRolesView,
     EditAnsibleRolesView,
@@ -1027,6 +1028,15 @@ class NewHostEntity(HostEntity):
         view = self.navigate_to(self, 'NewDetails', entity_name=entity_name)
         value = view.ansible.variables.table.row(name=key)['Value'].read()
         return value
+
+    def show_hosts_legacy_ui(self):
+        """Switch to legacy Hosts UI"""
+        view = self.navigate_to(self, 'NewUIAll')
+        view.actions.item_select('Legacy UI')
+        legacy_view = LegacyHostsView(self.browser)
+        legacy_view.wait_displayed()
+        self.browser.plugin.ensure_page_safe()
+        return legacy_view
 
 
 @navigator.register(HostEntity, 'NewUIAll')


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/airgun/pull/2042

Expand all did not work for the tree that was already fully or partially expanded.
This PR fixes this issue by checking which tree leaves are expanded and which are not, and then deciding which to expand.
This PR also adds an entity that can navigate to legacy ui.
### PRT Example
``` 
trigger: test-robottelo
pytest: tests/foreman/ui/test_host.py -k "test_all_hosts_manage_columns" 
```

