### PR TITLE
[6.18.z] Limit widgetastic.core dependency to versions >=1.1,<2.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ setup(
         'wait_for',
         'webdriver-kaifuku',
         'selenium==4.21.0',
-        'widgetastic.core',
+        'widgetastic.core>=1.1,<2.0',
         'widgetastic.patternfly',
         'widgetastic.patternfly4',
         'widgetastic.patternfly5',


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/airgun/pull/2050

This PR updates the `widgetastic.core` dependency constraint in `setup.py` to limit it to version 1.1 or greater, but less than 2.0.

## Changes Made

- Updated `setup.py` line 26: `'widgetastic.core'` → `'widgetastic.core>=1.1,<2.0'`

## Rationale

This change ensures:
- **Forward compatibility**: Maintains compatibility with the current version (1.1.0) and any future 1.x patch releases
- **Breaking change protection**: Prevents automatic installation of potentially breaking changes that may be introduced in version 2.0
- **Dependency stability**: Provides a clear version boundary for the core widgetastic functionality that airgun depends on

The constraint follows semantic versioning best practices by allowing patch and minor updates within the 1.x series while protecting against major version changes that could introduce breaking API changes.

## Validation

- Python syntax validation passed
- Version constraint syntax validated with `pkg_resources`
- Linting checks pass
- `setup.py` execution verified

<!-- START COPILOT CODING AGENT TIPS -->
---

💬 Share your feedback on Copilot coding agent for the chance to win a $200 gift card! Click [here](https://survey3.medallia.com/?EAHeSx-AP01bZqG0Ld9QLQ) to start the survey.