### PR TITLE
[6.18.z] Fix host status locator  which was broken due to earlier changes

### DIFF
--- a/airgun/views/host_new.py
+++ b/airgun/views/host_new.py
@@ -179,7 +179,7 @@ class NewHostDetailsView(BaseLoggedInView):
         class host_status(Card):
             ROOT = './/div[@data-ouia-component-id="card-aggregate-status"]'
 
-            status = Text('.//div[contains(@class, "pf-v5-c-card__title")]')
+            status = Text('.//div[contains(@class, "pf-v5-c-empty-state__title")]')
             manage_all_statuses = Text('.//a[normalize-space(.)="Manage all statuses"]')
 
             status_success = Text('.//a[.//span[@class="status-success"]]')


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/airgun/pull/2060

Fix host status locator  which was broken due to earlier changes
verified by running earlier as well as broken test cases