### PR TITLE
[6.18.z] read recommended repositories by it types

### DIFF
--- a/airgun/entities/redhat_repository.py
+++ b/airgun/entities/redhat_repository.py
@@ -21,15 +21,20 @@ class RedHatRepositoryEntity(BaseEntity):
         wait_for(lambda: view.search_box.is_displayed, timeout=10, delay=1)
         return view.search(value, category=category, types=types)
 
-    def read(self, entity_name=None, category='Available', recommended_repo=None):
+    def read(self, entity_name=None, category='Available', recommended_repo=None, filter_type=None):
         """Read RH Repositories values.
 
         :param entity_name: The repository name
         :param category: The repository category to search, options: Available, Enabled
         :param recommended_repo: on/off RH recommended repositories
+        :param filter_type: repository type such as RPM, Kickstart
         """
         view = self.navigate_to(self, 'All')
         view.wait_displayed()
+
+        view.search_by_filter_type.select('')
+        if filter_type:
+            view.search_by_filter_type.select(filter_type)
 
         if recommended_repo:
             current_value = self.browser.get_attribute(

--- a/airgun/views/redhat_repository.py
+++ b/airgun/views/redhat_repository.py
@@ -217,6 +217,7 @@ class RedHatRepositoriesView(BaseLoggedInView):
         '//*[@id="redhatRepositoriesPage"]//following::button[@aria-label="Search"]'
     )
     search_types = RepositorySearchTypes(".//div[button[@data-id='formControlsSelectMultiple']]")
+    search_by_filter_type = RepositorySearchTypes(".//div[button[@aria-owns='bs-select-2']]")
     search_clear = Text(".//span[@class = 'fa fa-times']")
     recommended_repos = Text(".//div[contains(@class, 'bootstrap-switch wrapper')]")
 


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/airgun/pull/2049

**Problem Statement**
No support presented for `recommended kickstart repositories` in airgun entities & in views.

**Solution**
Update `RedHatRepositoryEntity` read method and `RedHatRepositoriesView` with required changes.

**Related robottelo PR**
https://github.com/SatelliteQE/robottelo/pull/19676
