### PR TITLE
[6.18.z] Make hostcollection.install_errata() entity more stable

### DIFF
--- a/airgun/entities/hostcollection.py
+++ b/airgun/entities/hostcollection.py
@@ -177,6 +177,7 @@ class HostCollectionEntity(BaseEntity):
 
         # After this step the user is redirected to job status view.
         job_status_view = JobInvocationStatusView(view.browser)
+        wait_for(lambda: job_status_view.is_displayed, timeout=30, delay=5)
         wait_for(
             lambda: (job_status_view.status.read()['In Progress'] != 1),
             timeout=300,


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/airgun/pull/2085

Make `host collection.install_errata()` entity more stable.

### PRT Example
``` 
trigger: test-robottelo
pytest: tests/foreman/ui/test_hostcollection.py -k "test_positive_install_errata or test_positive_install_modular_errata" 
```

