### PR TITLE
[6.17.z] Make job invocation view more stable as PRT was failng

### DIFF
--- a/airgun/entities/contenthost.py
+++ b/airgun/entities/contenthost.py
@@ -135,6 +135,7 @@ class ContentHostEntity(BaseEntity):
             query = module_name
         else:
             query = f'name = {module_name} and stream = {stream_version}'
+        view.wait_displayed()
         view.module_streams.search(query, status)
         return view.module_streams.table.read()
 

--- a/airgun/entities/contenthost.py
+++ b/airgun/entities/contenthost.py
@@ -106,6 +106,7 @@ class ContentHostEntity(BaseEntity):
         if customize_values is None:
             customize_values = {}
         view = self.navigate_to(self, 'Edit', entity_name=entity_name)
+        view.wait_displayed()
         view.module_streams.search(f'name = {module_name} and stream = {stream_version}')
         action_type = {'is_customize': customize, 'action': action_type}
         view.module_streams.table.row(name=module_name, stream=stream_version)['Actions'].fill(
@@ -116,6 +117,7 @@ class ContentHostEntity(BaseEntity):
             view.fill(customize_values)
             view.submit.click()
         view = JobInvocationStatusView(view.browser)
+        view.wait_displayed()
         view.wait_for_result()
         return view.read()
 


### PR DESCRIPTION
Make job invocation view more stable  by adding view.wait_displayed as PRT was failng for robotello PR https://github.com/SatelliteQE/robottelo/pull/19747