### PR TITLE
[6.18.z] PF4 to PF5 conversion of dialog windows

### DIFF
--- a/airgun/views/host_new.py
+++ b/airgun/views/host_new.py
@@ -41,7 +41,7 @@ from airgun.widgets import (
     CheckboxGroup,
     ItemsList,
     Pf4ActionsDropdown,
-    Pf4ConfirmationDialog,
+    Pf5ConfirmationDialog,
     SatTableWithoutHeaders,
     SearchInput,
 )
@@ -916,12 +916,12 @@ class EditAnsibleRolesView(View):
     unselectRoles = PF5Button(locator='.//button[@aria-label="Remove selected"]')
 
 
-class ModuleStreamDialog(Pf4ConfirmationDialog):
+class ModuleStreamDialog(Pf5ConfirmationDialog):
     confirm_dialog = PF5Button(locator='.//button[@aria-label="confirm-module-action"]')
     cancel_dialog = PF5Button(locator='.//button[@aria-label="cancel-module-action"]')
 
 
-class RecurringJobDialog(Pf4ConfirmationDialog):
+class RecurringJobDialog(Pf5ConfirmationDialog):
     confirm_dialog = PF5Button(locator='.//button[@data-ouia-component-id="btn-modal-confirm"]')
     cancel_dialog = PF5Button(locator='.//button[@data-ouia-component-id="btn-modal-cancel"]')
 


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/airgun/pull/2118

PF4 to PF5 conversion of dialog windows.
Fixes `test_positive_crud_module_streams`.
Needed by https://github.com/SatelliteQE/robottelo/pull/19803 PRT passed here