### PR TITLE
[6.18.z] [RFE][IOP] Add recommendations views for iop

### DIFF
--- a/airgun/entities/cloud_insights.py
+++ b/airgun/entities/cloud_insights.py
@@ -1,7 +1,18 @@
+import time
+
+from wait_for import wait_for
+
 from airgun.entities.base import BaseEntity
 from airgun.navigation import NavigateStep, navigator
 from airgun.utils import retry_navigation
-from airgun.views.cloud_insights import CloudInsightsView, CloudTokenView
+from airgun.views.cloud_insights import (
+    CloudInsightsView,
+    CloudTokenView,
+    RecommendationsDetailsView,
+    RecommendationsTabView,
+    RemediateSummary,
+)
+from airgun.views.job_invocation import JobInvocationStatusView
 
 
 class CloudInsightsEntity(BaseEntity):
@@ -49,6 +60,92 @@ class CloudInsightsEntity(BaseEntity):
         view.fill(values)
 
 
+class RecommendationsTabEntity(BaseEntity):
+    endpoint_path = '/foreman_rh_cloud/insights_cloud'
+
+    def search(self, value):
+        """Search for 'query' and return matched hostnames/recommendations.
+
+        :param value: text to filter (default: no filter)
+        """
+        view = self.navigate_to(self, 'All Recommendations')
+        time.sleep(5)
+        view.clear_button.click()
+        view.search_field.fill(value)
+        time.sleep(5)
+        return view.table.read()
+
+    def remediate_affected_system(self, recommendation_name, hostname):
+        """Open Affected systems, filter by hostname, select it, and click Remediate.
+
+        Returns the details view contents after remediation click.
+        """
+        # Use navigator to open the Affected Systems details view
+        view = self.navigate_to(self, 'Affected Systems', recommendation_name=recommendation_name)
+        view.search_field.wait_displayed()
+        # Filter by hostname and apply recommendation
+        view.search_field.fill(hostname)
+        wait_for(lambda: view.table.row(name=hostname), handle_exception=True, timeout=20)
+        time.sleep(15)
+        view.table[0][0].widget.click()
+        view.remediate.click()
+        self.browser.plugin.ensure_page_safe(timeout='30s')
+        modal = RemediateSummary(self.browser)
+        wait_for(lambda: modal.is_displayed, handle_exception=True, timeout=20)
+        modal.remediate.click()
+        view = JobInvocationStatusView(view.browser)
+        view.wait_for_result()
+        return view.read()
+
+    def bulk_remediate_affected_systems(self, recommendation_name):
+        """Open Affected systems, bulk select affected systems, and click Remediate.
+
+        Returns the details view contents after remediation click.
+        """
+        # Use navigator to open the Affected Systems details view
+        view = self.navigate_to(self, 'Affected Systems', recommendation_name=recommendation_name)
+        wait_for(lambda: view.table.row(), handle_exception=True, timeout=20)
+        time.sleep(5)
+        view.bulk_select.select_all()
+        view.remediate.click()
+        self.browser.plugin.ensure_page_safe(timeout='30s')
+        modal = RemediateSummary(self.browser)
+        wait_for(lambda: modal.is_displayed, handle_exception=True, timeout=20)
+        modal.remediate.click()
+        view = JobInvocationStatusView(view.browser)
+        view.wait_for_result()
+        return view.read()
+
+    def read(self, widget_names=None):
+        """Read all values."""
+        view = self.navigate_to(self, 'All')
+        self.browser.plugin.ensure_page_safe(timeout='10s')
+        view.wait_displayed()
+        return view.read(widget_names=widget_names)
+
+
+@navigator.register(RecommendationsTabEntity, 'Affected Systems')
+class NavigateToAffectedSystems(NavigateStep):
+    """Navigate from Recommendations tab to the Affected Systems details view."""
+
+    VIEW = RecommendationsDetailsView
+
+    def prerequisite(self, *args, **kwargs):
+        # Ensure we are on the Recommendations tab first
+        return self.navigate_to(self.obj, 'All Recommendations')
+
+    def step(self, *args, **kwargs):
+        recommendation_name = kwargs.get('recommendation_name')
+        # Filter by recommendation name and open its expanded content
+        time.sleep(5)
+        self.parent.clear_button.click()
+        self.parent.search_field.fill(recommendation_name)
+        time.sleep(5)
+        row, _ = wait_for(lambda: self.parent.table.row(name=recommendation_name), timeout=5)
+        row.expand()
+        row.content.affected_systems_url.click()
+
+
 @navigator.register(CloudInsightsEntity, 'Token')
 class SaveCloudTokenView(NavigateStep):
     """Navigate to main Red Hat Lightspeed page"""
@@ -65,6 +162,17 @@ class ShowCloudInsightsView(NavigateStep):
     """Navigate to main Red Hat Lightspeed page"""
 
     VIEW = CloudInsightsView
+
+    @retry_navigation
+    def step(self, *args, **kwargs):
+        self.view.menu.select('Red Hat Lightspeed', 'Recommendations')
+
+
+@navigator.register(RecommendationsTabEntity, 'All Recommendations')
+class ShowRecommendationsView(NavigateStep):
+    """Navigate to main Red Hat Lightspeed page"""
+
+    VIEW = RecommendationsTabView
 
     @retry_navigation
     def step(self, *args, **kwargs):

--- a/airgun/entities/host_new.py
+++ b/airgun/entities/host_new.py
@@ -6,6 +6,7 @@ from wait_for import wait_for
 from airgun.entities.host import HostEntity
 from airgun.navigation import NavigateStep, navigator
 from airgun.utils import retry_navigation
+from airgun.views.cloud_insights import RemediateSummary
 from airgun.views.fact import HostFactView
 from airgun.views.host import HostsView as LegacyHostsView
 from airgun.views.host_new import (
@@ -23,7 +24,7 @@ from airgun.views.host_new import (
     RemediationView,
 )
 from airgun.views.hostgroup import HostGroupEditView
-from airgun.views.job_invocation import JobInvocationCreateView
+from airgun.views.job_invocation import JobInvocationCreateView, JobInvocationStatusView
 
 available_param_types = ['string', 'boolean', 'integer', 'real', 'array', 'hash', 'yaml', 'json']
 
@@ -928,6 +929,55 @@ class NewHostEntity(HostEntity):
             return vulnerabilities.read()
         else:
             return []
+
+    def get_recommendations(self, entity_name):
+        view = self.navigate_to(self, 'NewDetails', entity_name=entity_name)
+        view.wait_displayed()
+        self.browser.plugin.ensure_page_safe()
+        wait_for(lambda: view.iop_recommendations.recommendations_table.is_displayed, timeout=30)
+        return view.iop_recommendations.recommendations_table.read()
+
+    def remediate_host_recommendation(self, entity_name, recommendation):
+        """Function that can remediate an iop recommendation from the host page"""
+        view = self.navigate_to(self, 'NewDetails', entity_name=entity_name)
+        view.wait_displayed()
+        self.browser.plugin.ensure_page_safe()
+        wait_for(lambda: view.iop_recommendations.is_displayed, timeout=30)
+        view.iop_recommendations.search_field.fill(recommendation)
+        wait_for(lambda: view.iop_recommendations.recommendations_table.is_displayed, timeout=30)
+        wait_for(
+            lambda: view.iop_recommendations.recommendations_table.row(description=recommendation),
+            handle_exception=True,
+            timeout=30,
+        )
+        row = view.iop_recommendations.recommendations_table.row(description=recommendation)
+        row[1].widget.fill(True)
+        view.iop_recommendations.remediate.wait_displayed()
+        view.iop_recommendations.remediate.click()
+        self.browser.plugin.ensure_page_safe(timeout='30s')
+        modal = RemediateSummary(self.browser)
+        wait_for(lambda: modal.is_displayed, handle_exception=True, timeout=20)
+        modal.remediate.click()
+        view = JobInvocationStatusView(view.browser)
+        view.wait_for_result()
+        return view.read()
+
+    def bulk_remediate_host_recommendation(self, entity_name):
+        """Function that can bulk remediate an iop recommendation from the host page"""
+        view = self.navigate_to(self, 'NewDetails', entity_name=entity_name)
+        view.wait_displayed()
+        self.browser.plugin.ensure_page_safe()
+        wait_for(lambda: view.iop_recommendations.is_displayed, timeout=30)
+        view.iop_recommendations.bulk_select.select_all()
+        view.iop_recommendations.remediate.wait_displayed()
+        view.iop_recommendations.remediate.click()
+        self.browser.plugin.ensure_page_safe(timeout='30s')
+        modal = RemediateSummary(self.browser)
+        wait_for(lambda: modal.is_displayed, handle_exception=True, timeout=20)
+        modal.remediate.click()
+        view = JobInvocationStatusView(view.browser)
+        view.wait_for_result()
+        return view.read()
 
     def remediate_with_insights(
         self, entity_name, recommendation_to_remediate=None, remediate_all=False

--- a/airgun/session.py
+++ b/airgun/session.py
@@ -21,7 +21,7 @@ from airgun.entities.audit import AuditEntity
 from airgun.entities.bookmark import BookmarkEntity
 from airgun.entities.bootc import BootcEntity
 from airgun.entities.capsule import CapsuleEntity
-from airgun.entities.cloud_insights import CloudInsightsEntity
+from airgun.entities.cloud_insights import CloudInsightsEntity, RecommendationsTabEntity
 from airgun.entities.cloud_inventory import CloudInventoryEntity
 from airgun.entities.cloud_vulnerabilities import CloudVulnerabilityEntity
 from airgun.entities.computeprofile import ComputeProfileEntity
@@ -394,6 +394,11 @@ class Session:
     def cloudinventory(self):
         """Instance of Insights Inventory Upload entity."""
         return self._open(CloudInventoryEntity)
+
+    @cached_property
+    def recommendationstab(self):
+        """Instance of Recommendations entity."""
+        return self._open(RecommendationsTabEntity)
 
     @cached_property
     def cloudinsights(self):

--- a/airgun/views/cloud_insights.py
+++ b/airgun/views/cloud_insights.py
@@ -1,13 +1,18 @@
 from widgetastic.widget import Checkbox, Text, TextInput, View
 from widgetastic_patternfly5 import (
     Button as PF5Button,
+    ExpandableTable as PF5ExpandableTable,
+    Menu as PF5Menu,
     Pagination as PF5Pagination,
+    PatternflyTable as PF5Table,
+    Title as PF5Title,
 )
 from widgetastic_patternfly5.ouia import (
     Dropdown as PF5OUIADropdown,
     Modal as PF5OUIAModal,
     PatternflyTable as PF5OUIAPatternflyTable,
     Switch as PF5OUIASwitch,
+    TextInput as PF5OUIATextInput,
 )
 
 from airgun.views.common import BaseLoggedInView, SearchableViewMixinPF4
@@ -71,3 +76,118 @@ class CloudInsightsView(BaseLoggedInView, SearchableViewMixinPF4):
     @property
     def is_displayed(self):
         return self.browser.wait_for_element(self.title, exception=False) is not None
+
+
+class BulkSelectMenuToggle(PF5Menu):
+    """
+    A menu toggle component that combines a checkbox with a dropdown menu.
+    Used for bulk selection operations with additional menu options.
+    Usage example (view.bulk_select = BulkSelectMenuToggle()):
+    view.bulk_select.select_all() -> to select all items using the checkbox
+    view.bulk_select.deselect_all() -> to deselect all items using the checkbox
+    view.bulk_select.is_all_selected -> to check if all items are selected
+    view.bulk_select.items -> to access the menu items
+    (['Select none', 'Select page (1 items)', 'Select all (1 items)'])
+    view.bulk_select.item_select('Select none') -> to select a specific item by name
+    """
+
+    IS_ALWAYS_OPEN = False
+    BUTTON_LOCATOR = './/button[@data-ouia-component-id="BulkSelect"]'
+    ROOT = f'{BUTTON_LOCATOR}/..'
+    ITEMS_LOCATOR = './/ul[contains(@class, "pf-v5-c-menu__list")]/li'
+    ITEM_LOCATOR = (
+        '//*[contains(@class, "pf-v5-c-menu__item") and .//*[contains(normalize-space(.), {})]]'
+    )
+    # Checkbox element within the menu toggle
+    checkbox = Checkbox(locator='.//input[@data-ouia-component-id="BulkSelectCheckbox"]')
+
+    def select_all(self):
+        """Select all items using the checkbox."""
+        if not self.checkbox.selected:
+            self.checkbox.click()
+
+    def deselect_all(self):
+        """Deselect all items using the checkbox."""
+        if self.checkbox.selected:
+            self.checkbox.click()
+
+    @property
+    def is_all_selected(self):
+        """Return True if the select all checkbox is checked."""
+        return self.checkbox.selected
+
+
+class RemediateSummary(PF5OUIAModal):
+    """Models the Remediation summary page and button"""
+
+    title = PF5Title('Remediation summary')
+    remediate = PF5Button('Remediate')
+
+
+class RecommendationsDetailsView(BaseLoggedInView):
+    """Models everything in the recommendations details views execpt the affected system link"""
+
+    title = PF5Title('Affected Systems')
+    clear_button = PF5Button('Reset filters')
+    remediate = PF5Button('Remediate')
+    download_playbook = PF5Button('Download playbook')
+    search_field = TextInput(locator=('.//input[@aria-label="text input"]'))
+    bulk_select = BulkSelectMenuToggle()
+    table = PF5Table(
+        locator='.//table[contains(@aria-label, "Host inventory")]',
+        column_widgets={
+            0: Checkbox(locator='.//input[@type="checkbox"]'),
+            'Name': Text('.//a'),
+            'OS': Text('.//span'),
+            'Last seen': Text('.//span'),
+            'First impacted': Text('.//span'),
+        },
+    )
+
+    @property
+    def is_displayed(self):
+        return self.browser.wait_for_element(self.table, exception=False) is not None
+
+
+class RecommendationsTableExpandedRowView(RecommendationsDetailsView):
+    """View that models the recommendation expandable row content"""
+
+    affected_systems_url = Text(
+        locator='.//*[contains(@class, "ins-c-rule-details__view-affected")]//a'
+    )
+
+    @property
+    def is_displayed(self):
+        """Check that the row is displayed."""
+        return self.affected_systems_url.is_displayed
+
+
+class RecommendationsTabView(BaseLoggedInView):
+    """View representing the Recommendations Tab."""
+
+    title = PF5Title('Recommendations')
+    search_field = TextInput(locator=('.//input[@aria-label="text input"]'))
+    clear_button = PF5Button('Reset filters')
+    incidents = Text(locator='.//a[@data-testid="Incidents"]')
+    critical_recommendations = Text(locator='.//a[@data-testid="Critical recommendations"]')
+    important_recommendations = Text(locator='.//a[@data-testid="Important recommendations"]')
+    conditional_filter_dropdown = PF5OUIATextInput('ConditionalFilter')
+    table = PF5ExpandableTable(
+        locator='.//table[contains(@aria-label, "rule-table")]',
+        content_view=RecommendationsTableExpandedRowView,
+        column_widgets={
+            'Name': Text('.//a'),
+            'Modified': Text('.//span'),
+            'Category': Text('.//span'),
+            'Total risk': Text('.//span'),
+            'Systems': Text('.//div'),
+            'Remediation type': Text('.//span'),
+        },
+    )
+
+    @property
+    def is_displayed(self):
+        return (
+            self.browser.wait_for_element(self.table, exception=False) is not None
+            and self.browser.wait_for_element(self.clear_button, exception=False) is not None
+        )

--- a/airgun/views/host_new.py
+++ b/airgun/views/host_new.py
@@ -20,7 +20,7 @@ from widgetastic_patternfly5 import (
     Button as PF5Button,
     CompactPagination as PF5Pagination,
     Dropdown as PF5Dropdown,
-    ExpandableTable as pf5OUIAExpandableTable,
+    ExpandableTable as PF5ExpandableTable,
     Menu as PF5Menu,
     Tab as PF5Tab,
 )
@@ -34,6 +34,7 @@ from widgetastic_patternfly5.ouia import (
     Select as PF5OUIASelect,
 )
 
+from airgun.views.cloud_insights import BulkSelectMenuToggle
 from airgun.views.common import BaseLoggedInView
 from airgun.widgets import (
     Accordion,
@@ -761,6 +762,41 @@ class NewHostDetailsView(BaseLoggedInView):
         pagination = PF5Pagination()
 
     @View.nested
+    class iop_recommendations(PF5Tab):
+        ROOT = './/div'
+
+        TAB_NAME = 'Recommendations'
+
+        search_field = TextInput(locator=('.//input[@aria-label="text input"]'))
+        conditional_filter_dropdown = PF5Button(
+            './/button[@data-ouia-component-id="ConditionalFilterToggle"]'
+        )
+        remediate = PF5Button('Remediate')
+        download_playbook = PF5Button('Download playbook')
+        bulk_select = BulkSelectMenuToggle()
+
+        recommendations_table = PF5ExpandableTable(
+            locator='.//table[contains(@aria-label, "report-table")]',
+            column_widgets={
+                0: PF5Button('.//button[@aria-label="Details"]'),
+                1: Checkbox(locator='.//input[@type="checkbox"]'),
+                'Description': Text('.//span'),
+                'Modified': Text('.//span'),
+                'First impacted': Text('.//span'),
+                'Total risk': Text('.//span'),
+                'Remediation type': Text('.//span'),
+            },
+        )
+        pagination = PF5Pagination()
+
+        @property
+        def is_displayed(self):
+            return (
+                self.browser.wait_for_element(self.recommendations_table, exception=False)
+                is not None
+            )
+
+    @View.nested
     class vulnerabilities(PF5Tab):
         ROOT = './/div'
 
@@ -768,7 +804,7 @@ class NewHostDetailsView(BaseLoggedInView):
         cve_menu_toggle = PF5Button(".//button[contains(@class, 'pf-v5-c-menu-toggle')]")
         no_cves_found_message = Text('.//h5[contains(@class, "pf-v5-c-empty-state__title-text")]')
 
-        vulnerabilities_table = pf5OUIAExpandableTable(
+        vulnerabilities_table = PF5ExpandableTable(
             # component_id='OUIA-Generated-Table-2',
             locator='.//table[contains(@class, "pf-v5-c-table")]',
             column_widgets={


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/airgun/pull/1983

Draft state of IOP Recommendations view/entities

## Summary by Sourcery

Introduce a draft implementation of IOP Recommendations by modeling the Recommendations tab UI, wiring up navigation, session access, and basic search/read interactions for recommendation entries under Red Hat Lightspeed.

New Features:
- Add view classes for Recommendations (RecommendationsDetails, RecommendationsTableExpandedRowView, RecommendationsTabView, RecommendationsDetailsView)
- Implement RecommendationsTabEntity with search, affected_systems, and read actions
- Register ShowRecommendationsView navigation step and expose recommendationstab session property

Enhancements:
- Integrate PF5ExpandableTable for expandable recommendation rows with column widget mappings