### PR TITLE
[6.17.z] Add error message handling for failed RHSSO login

### DIFF
--- a/airgun/entities/rhsso_login.py
+++ b/airgun/entities/rhsso_login.py
@@ -22,6 +22,10 @@ class RHSSOLoginEntity(BaseEntity):
                 view = RhssoTotpView(self.browser)
                 view.fill(totp)
                 view.submit.click()
+            # Check if we're still on login page (login failed)
+            login_view = RhssoLoginView(self.browser)
+            if login_view.is_displayed:
+                return login_view.read()
 
     def logout(self):
         view = BaseLoggedInView(self.browser)

--- a/airgun/views/rhsso_login.py
+++ b/airgun/views/rhsso_login.py
@@ -5,6 +5,7 @@ class RhssoLoginView(View, ClickableMixin):
     username = TextInput(id='username')
     password = TextInput(id='password')
     submit = Text('//input[@name="login"]')
+    error_message = Text('//span[@id="input-error"]')
 
     @property
     def is_displayed(self):


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/airgun/pull/2174

The login method now checks if we're still on the login page after submitting credentials. If so, it returns the view data including the error message, allowing callers to verify login failures.

This matches the pattern used by the logout() method and enables proper testing of failed login scenarios without relying on exceptions being raised.