### PR TITLE
Add RH Flatpak info alert to the Create modal

### DIFF
--- a/airgun/entities/flatpak.py
+++ b/airgun/entities/flatpak.py
@@ -83,6 +83,52 @@ class FlatpakRemotesEntity(BaseEntity):
         view = FlatpakRemoteDetailsView(self.browser)
         view.wait_displayed(delay=3)
 
+    def create_redhat_remote(self, values):
+        """Create a Red Hat Flatpak remote using the info alert action.
+
+        This method clicks the 'Add Red Hat flatpak remote' button from the
+        info alert instead of manually filling the URL.
+
+        :param dict values: values to create the remote with
+        """
+        view = self.navigate_to(self, 'All')
+        view.wait_displayed()
+        view.create_new_btn.click()
+        create_modal = CreateFlatpakRemoteModal(self.browser)
+        create_modal.wait_displayed()
+        create_modal.fill(values)
+
+        if create_modal.info_alert.is_displayed:
+            create_modal.add_rh_fr.click()
+        else:
+            raise ValueError('Red Hat Flatpak remote info alert is not displayed')
+
+        create_modal.create_btn.click()
+        view = FlatpakRemoteDetailsView(self.browser)
+        view.wait_displayed(delay=3)
+
+    def read_create_modal_alert(self):
+        """Read the info alert from the Create Flatpak Remote modal.
+
+        :return: dict with alert information or None if alert not displayed
+        """
+        view = self.navigate_to(self, 'All')
+        view.wait_displayed()
+        view.create_new_btn.click()
+        create_modal = CreateFlatpakRemoteModal(self.browser)
+        create_modal.wait_displayed()
+
+        if create_modal.info_alert.is_displayed:
+            alert_info = {
+                'title': create_modal.info_alert.title,
+                'body': create_modal.info_alert.body,
+            }
+            create_modal.cancel_btn.click()
+            return alert_info
+
+        create_modal.cancel_btn.click()
+        return None
+
     def edit(self, entity_name, values):
         """Edit a Flatpak remote.
 

--- a/airgun/views/flatpak.py
+++ b/airgun/views/flatpak.py
@@ -1,5 +1,6 @@
 from widgetastic.widget import Text
 from widgetastic_patternfly5 import (
+    Alert as PF5Alert,
     Button as PF5Button,
     Menu as PF5Menu,
     Modal as PF5Modal,
@@ -72,6 +73,9 @@ class CreateFlatpakRemoteModal(PF5Modal):
     ROOT = './/div[@data-ouia-component-id="create-flatpak-modal"]'
 
     title = Text("//span[normalize-space(.)='Create Flatpak Remote']")
+
+    info_alert = PF5Alert(locator='.//div[@data-ouia-component-id="flatpak-remote-info-alert"]')
+    add_rh_fr = PF5Button('Add Red Hat flatpak remote')
 
     name = PF5OUIATextInput('input_name')
     url = PF5OUIATextInput('input_url')


### PR DESCRIPTION
"Add Red Hat Flatpak remote" has been added to the Create Flatpak Remote modal to ease the creation.
<img width="824" height="238" alt="image" src="https://github.com/user-attachments/assets/85739c12-9f8c-4c40-9fcb-47787187d2f5" />

This PR adds it to the view and entities.

Robottelo PR will follow.