### PR TITLE
[6.17.z] Add Python 3.14 for PR checks in GHA

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.11', '3.12', '3.13']
+        python-version: ['3.12', '3.13', '3.14']
     steps:
       - name: Checkout Airgun
         uses: actions/checkout@v5
@@ -53,7 +53,7 @@ jobs:
     needs: codechecks
     strategy:
       matrix:
-        python-version: ['3.13']
+        python-version: ['3.14']
     steps:
       - name: Checkout Airgun
         uses: actions/checkout@v5

--- a/setup.py
+++ b/setup.py
@@ -39,8 +39,8 @@ setup(
         'Natural Language :: English',
         'Operating System :: POSIX :: LinuxProgramming Language :: Python',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.11',
         'Programming Language :: Python :: 3.12',
         'Programming Language :: Python :: 3.13',
+        'Programming Language :: Python :: 3.14',
     ],
 )


### PR DESCRIPTION
(cherry picked from commit d798e167d3558eed9ed3ae7c1579b59eeb8a2ee4)

Fixes https://github.com/SatelliteQE/airgun/issues/2187
Failed Auto-CherryPick for https://github.com/SatelliteQE/airgun/pull/2175

### Problem Statement
Python 3.14 was released on October 7, 2025, and we're not covering this in the PR checks in GHA yet

### Solution
Add Python 3.14 for PR checks in GHA and bump Py3.12 as new required Python version to match CI