### PR TITLE
Add searchbar_dropdown locator to HostsView

### DIFF
--- a/airgun/views/host.py
+++ b/airgun/views/host.py
@@ -23,11 +23,11 @@ from widgetastic_patternfly4.ouia import (
 from widgetastic_patternfly5.components.tabs import Tab
 from widgetastic_patternfly5.ouia import (
     Button as PF5Button,
+    Dropdown as PF5OUIADropdown,
     FormSelect as PF5FormSelect,
     PatternflyTable as PF5OUIATable,
     Select as PF5OUIASelect,
     TextInput as PF5OUIATextInput,
-    Dropdown as PF5OUIADropdown,
 )
 
 from airgun.views.common import BaseLoggedInView, SatTab, SearchableViewMixinPF4


### PR DESCRIPTION
**Problem statement:**
Due to recent change  in PR https://github.com/SatelliteQE/airgun/pull/2155 some test cases started failing with error `searchbar_dropdown` locator not found in HostsView

**Solution:**
Added searchbar_dropdown locator to HostsView