### PR TITLE
Remove auto_attach mentions from airgun

### DIFF
--- a/airgun/views/contenthost.py
+++ b/airgun/views/contenthost.py
@@ -28,7 +28,6 @@ from airgun.widgets import (
     ActionsDropdown,
     ConfirmationDialog,
     EditableEntry,
-    EditableEntryCheckbox,
     EditableEntrySelect,
     Pagination,
     ReadOnlyEntry,


### PR DESCRIPTION
See https://github.com/SatelliteQE/robottelo/pull/19931#issuecomment-3487146701 for reference.
TLDR, auto_attach is being removed.