### PR TITLE
Cloud billing details on all host details page

### DIFF
--- a/airgun/views/host_new.py
+++ b/airgun/views/host_new.py
@@ -369,9 +369,11 @@ class NewHostDetailsView(BaseLoggedInView):
 
         @View.nested
         class cloud_billing_details(Card):
-            ROOT = ('//div[contains(@data-ouia-component-id, "card-template-GCP") '
-                    'or contains(@data-ouia-component-id, "card-template-AWS") '
-                    'or contains(@data-ouia-component-id, "card-template-Azure")]')
+            ROOT = (
+                '//div[contains(@data-ouia-component-id, "card-template-GCP") '
+                'or contains(@data-ouia-component-id, "card-template-AWS") '
+                'or contains(@data-ouia-component-id, "card-template-Azure")]'
+            )
 
             details = HostDetailsCard()
 


### PR DESCRIPTION
Automation for card: https://issues.redhat.com/browse/SAT-39185
Added nested view for reading Cloud billing details card on host details page
This changes require for https://github.com/SatelliteQE/robottelo/pull/20338