### PR TITLE
Navigation and search fixes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -112,8 +112,7 @@ Reusable UI components defined in `widgets.py`:
 ```python
 from airgun.widgets import SatTable, Search, LCESelector
 
-class MyView(BaseLoggedInView):
-    searchbox = Search()
+class MyView(BaseLoggedInView, SearchableViewMixin):
     table = SatTable(locator='//table[@id="my-table"]')
     lce_selector = LCESelector()
 ```
@@ -199,8 +198,7 @@ class MyEntity(BaseEntity):
     def search(self, query):
         """Search for entities"""
         view = self.navigate_to(self, 'All')
-        view.searchbox.search(query)
-        return view.table.read()
+        return view.search(query)
     
     def read(self, entity_name):
         """Read entity details"""
@@ -212,15 +210,14 @@ class MyEntity(BaseEntity):
 ### Pattern 2: Searchable View
 
 ```python
-class MyListView(BaseLoggedInView):
+class MyListView(BaseLoggedInView, SearchableViewMixin):
     title = Text('.//h1')
-    searchbox = Search()
     new = Button('Create')
     table = SatTable(locator='//table[@aria-label="my-table"]')
     
     @property
     def is_displayed(self):
-        return self.browser.wait_for_element(self.title, exception=False)
+        return self.title.is_displayed
 ```
 
 ### Pattern 3: Tab page views
@@ -237,29 +234,6 @@ class MyTabsListView(View):
     class content_tab(PF5Tab):
         TAB_NAME = 'content'
         table = SatTable(locator='//table')
-```
-
-### Pattern 4: Wait for UI Stability
-
-```python
-from wait_for import wait_for
-
-def my_action(self):
-    view = self.navigate_to(self, 'All')
-    
-    # Wait for element
-    wait_for(lambda: view.table.is_displayed, timeout=30)
-    
-    # Wait for specific condition
-    wait_for(
-        lambda: len(view.table.read()) > 0,
-        timeout=60,
-        delay=2,
-        handle_exception=True
-    )
-    
-    # Use browser plugin for page safety
-    self.browser.plugin.ensure_page_safe(timeout='10s')
 ```
 
 ---

--- a/airgun/browser.py
+++ b/airgun/browser.py
@@ -420,6 +420,7 @@ class AirgunBrowser(Browser):
         current_url = self.url
         files, _ = wait_for(
             self.browser.get_downloads_list,
+            fail_condition=[],
             timeout=60,
             delay=1,
         )

--- a/airgun/entities/about.py
+++ b/airgun/entities/about.py
@@ -1,6 +1,5 @@
 from airgun.entities.base import BaseEntity
 from airgun.navigation import NavigateStep, navigator
-from airgun.utils import retry_navigation
 from airgun.views.about import AboutView
 
 
@@ -14,6 +13,5 @@ class ShowAboutPage(NavigateStep):
 
     VIEW = AboutView
 
-    @retry_navigation
     def step(self, *args, **kwargs):
         self.view.menu.select('Administer', 'About')

--- a/airgun/entities/activationkey.py
+++ b/airgun/entities/activationkey.py
@@ -2,7 +2,6 @@ from navmazing import NavigateToSibling
 
 from airgun.entities.base import BaseEntity
 from airgun.navigation import NavigateStep, navigator
-from airgun.utils import retry_navigation
 from airgun.views.activationkey import (
     ActivationKeyCreateView,
     ActivationKeyEditView,
@@ -16,7 +15,6 @@ class ActivationKeyEntity(BaseEntity):
     def create(self, values):
         """Create new activation key entity"""
         view = self.navigate_to(self, 'New')
-        view.wait_displayed()
         view.fill(values)
         view.submit.click()
 
@@ -70,8 +68,6 @@ class ActivationKeyEntity(BaseEntity):
             raise ValueError("Host limit must be either string 'unlimited' or an integer")
 
         view = self.navigate_to(self, 'Edit', entity_name=entity_name)
-        view.wait_displayed()
-        self.browser.plugin.ensure_page_safe()
         view.details.host_limit_edit_btn.click()
         view.details.unlimited_content_host_checkbox.fill(host_limit == 'unlimited')
         if host_limit != 'unlimited':
@@ -127,7 +123,6 @@ class ShowAllActivationKeys(NavigateStep):
 
     VIEW = ActivationKeysView
 
-    @retry_navigation
     def step(self, *args, **kwargs):
         self.view.menu.select('Content', 'Lifecycle', 'Activation Keys')
 

--- a/airgun/entities/all_hosts.py
+++ b/airgun/entities/all_hosts.py
@@ -7,7 +7,6 @@ from widgetastic_patternfly5 import DropdownItemDisabled
 
 from airgun.entities.base import BaseEntity
 from airgun.navigation import NavigateStep, navigator
-from airgun.utils import retry_navigation
 from airgun.views.all_hosts import (
     AllHostsManageColumnsView,
     AllHostsTableView,
@@ -37,22 +36,16 @@ class AllHostsEntity(BaseEntity):
     def search(self, host_name):
         """Search for specific Host"""
         view = self.navigate_to(self, 'All')
-        self.browser.plugin.ensure_page_safe(timeout='5s')
-        view.wait_displayed()
         return view.search(host_name)
 
     def read_filled_searchbox(self):
         """Read filled searchbox"""
         view = self.navigate_to(self, 'All')
-        self.browser.plugin.ensure_page_safe(timeout='5s')
-        view.wait_displayed()
         return view.searchbox.read()
 
     def read_table(self):
         """Read All Hosts table"""
         view = self.navigate_to(self, 'All')
-        self.browser.plugin.ensure_page_safe(timeout='5s')
-        view.wait_displayed()
         return view.table.read()
 
     def delete(self, host_name):
@@ -65,8 +58,6 @@ class AllHostsEntity(BaseEntity):
         else:
             raise NoSuchElementException('Delete Modal was not displayed.')
         view = self.navigate_to(self, 'All')
-        self.browser.plugin.ensure_page_safe(timeout='5s')
-        view.wait_displayed()
         view.search(host_name)
         return view.no_results
 
@@ -80,8 +71,6 @@ class AllHostsEntity(BaseEntity):
             delete_modal.confirm_checkbox.fill(True)
             delete_modal.confirm_delete.click()
         view = self.navigate_to(self, 'All')
-        self.browser.plugin.ensure_page_safe(timeout='5s')
-        view.wait_displayed()
         return view.no_results
 
     def build_management(self, reboot=False, rebuild=False):
@@ -114,8 +103,6 @@ class AllHostsEntity(BaseEntity):
             cv (str): CV within that LCE to assign the hosts to.
         """
         view = self.navigate_to(self, 'All')
-        self.browser.plugin.ensure_page_safe(timeout='5s')
-        view.wait_displayed()
         view.select_all.fill(True)
         view.bulk_actions_kebab.click()
         self.browser.move_to_element(view.bulk_actions_menu.item_element('Manage content'))
@@ -143,8 +130,6 @@ class AllHostsEntity(BaseEntity):
         :return list: header names of the hosts table
         """
         view = self.navigate_to(self, 'All')
-        self.browser.plugin.ensure_page_safe(timeout='5s')
-        view.wait_displayed()
         return view.table.headers
 
     def manage_packages_helper(self, view, action_type, packages_to_manage):
@@ -366,7 +351,7 @@ class AllHostsEntity(BaseEntity):
             view.review.manage_via_dropdown.item_select('via customized remote execution')
             view.review.finish_errata_management_btn.click()
             view = JobInvocationCreateView(self.browser)
-            self.browser.plugin.ensure_page_safe(timeout='5s')
+
             wait_for(lambda: view.submit.is_displayed, timeout=10)
             view.submit.click()
 
@@ -445,8 +430,6 @@ class AllHostsEntity(BaseEntity):
                 clear_search_cross_button.click()
             view.select_repository_sets.search_input.fill(search_query.format(repo))
 
-            self.browser.plugin.ensure_page_safe(timeout='5s')
-            view.wait_displayed()
             # For some reason it is needed to read the widget first, it fails, but enables filling in the next step
             try:
                 _ = view.select_repository_sets.table[0]['Status'].widget
@@ -466,8 +449,6 @@ class AllHostsEntity(BaseEntity):
         """Return the text from both the manage packages and manage errata modals review hosts step"""
         # Navigate to All Hosts
         view = self.navigate_to(self, 'All')
-        self.browser.plugin.ensure_page_safe(timeout='5s')
-        view.wait_displayed()
         view.select_all.fill(True)
 
         # Get text from Manage Packages -> Review Hosts
@@ -482,8 +463,6 @@ class AllHostsEntity(BaseEntity):
 
         # Get text from Manage Errata -> Review Hosts
         view = self.navigate_to(self, 'All')
-        self.browser.plugin.ensure_page_safe(timeout='5s')
-        view.wait_displayed()
         view.select_all.fill(True)
 
         # Get text from Manage Packages -> Review Hosts
@@ -553,8 +532,6 @@ class AllHostsEntity(BaseEntity):
             raise ValueError('Must specify either host_names or select_all_hosts.')
 
         view = self.navigate_to(self, 'All')
-        self.browser.plugin.ensure_page_safe(timeout='5s')
-        view.wait_displayed()
 
         # This step ensures deterministic state of the table
         # If 'Select none (0)' is disabled, it means nothing is selected, so we can continue
@@ -740,8 +717,6 @@ class AllHostsEntity(BaseEntity):
         """
 
         view = self.navigate_to(self, 'All')
-        self.browser.plugin.ensure_page_safe(timeout='5s')
-        view.wait_displayed()
         view.search(f'name={host_name}')
 
         # Find the status icon directly from the Name column cell
@@ -931,10 +906,8 @@ class ShowAllHostsScreen(NavigateStep):
 
     VIEW = AllHostsTableView
 
-    @retry_navigation
     def step(self, *args, **kwargs):
         self.view.menu.select('Hosts', 'All Hosts')
-        self.view.wait_displayed()
 
 
 @navigator.register(AllHostsEntity, 'ManageColumns')

--- a/airgun/entities/ansible_role.py
+++ b/airgun/entities/ansible_role.py
@@ -38,7 +38,7 @@ class AnsibleRolesEntity(BaseEntity):
         # Before any roles have been imported, no table or pagination widget are
         # present on the page
         # Applying wait_displayed for the page to get rendered
-        view.wait_displayed()
+
         return int(view.total_imported_roles.read())
 
     def import_all_roles(self):

--- a/airgun/entities/architecture.py
+++ b/airgun/entities/architecture.py
@@ -2,7 +2,6 @@ from navmazing import NavigateToSibling
 
 from airgun.entities.base import BaseEntity
 from airgun.navigation import NavigateStep, navigator
-from airgun.utils import retry_navigation
 from airgun.views.architecture import (
     ArchitectureCreateView,
     ArchitectureDetailsView,
@@ -18,6 +17,7 @@ class ArchitectureEntity(BaseEntity):
         view = self.navigate_to(self, 'New')
         view.fill(values)
         view.submit.click()
+
         view.flash.assert_no_error()
         view.flash.dismiss()
 
@@ -34,8 +34,10 @@ class ArchitectureEntity(BaseEntity):
     def update(self, entity_name, values):
         """Update necessary values for architecture"""
         view = self.navigate_to(self, 'Edit', entity_name=entity_name)
+
         view.fill(values)
         view.submit.click()
+
         view.flash.assert_no_error()
         view.flash.dismiss()
 
@@ -44,6 +46,7 @@ class ArchitectureEntity(BaseEntity):
         view = self.navigate_to(self, 'All')
         view.searchbox.search(entity_name)
         view.table.row(name=entity_name)['Actions'].widget.click(handle_alert=True)
+
         view.flash.assert_no_error()
         view.flash.dismiss()
 
@@ -54,7 +57,6 @@ class ShowAllArchitectures(NavigateStep):
 
     VIEW = ArchitecturesView
 
-    @retry_navigation
     def step(self, *args, **kwargs):
         self.view.menu.select('Hosts', 'Provisioning Setup', 'Architectures')
 

--- a/airgun/entities/audit.py
+++ b/airgun/entities/audit.py
@@ -1,6 +1,5 @@
 from airgun.entities.base import BaseEntity
 from airgun.navigation import NavigateStep, navigator
-from airgun.utils import retry_navigation
 from airgun.views.audit import AuditsView
 
 
@@ -19,6 +18,5 @@ class ShowAllAuditEntries(NavigateStep):
 
     VIEW = AuditsView
 
-    @retry_navigation
     def step(self, *args, **kwargs):
         self.view.menu.select('Monitor', 'Audits')

--- a/airgun/entities/bookmark.py
+++ b/airgun/entities/bookmark.py
@@ -1,6 +1,5 @@
 from airgun.entities.base import BaseEntity
 from airgun.navigation import NavigateStep, navigator
-from airgun.utils import retry_navigation
 from airgun.views.bookmark import BookmarkEditView, BookmarksView
 
 
@@ -57,7 +56,6 @@ class ShowAllBookmarks(NavigateStep):
 
     VIEW = BookmarksView
 
-    @retry_navigation
     def step(self, *args, **kwargs):
         self.view.menu.select('Administer', 'Bookmarks')
 

--- a/airgun/entities/bootc.py
+++ b/airgun/entities/bootc.py
@@ -1,6 +1,5 @@
 from airgun.entities.base import BaseEntity
 from airgun.navigation import NavigateStep, navigator
-from airgun.utils import retry_navigation
 from airgun.views.bootc import BootedContainerImagesView
 
 
@@ -13,7 +12,6 @@ class BootcEntity(BaseEntity):
         with the unexpanded content, and the expanded content
         """
         view = self.navigate_to(self, 'All')
-        self.browser.plugin.ensure_page_safe(timeout='5s')
         view.search(f'bootc_booted_image = {booted_image_name}')
         view.table.row(image_name=booted_image_name).expand()
         row = view.table.row(image_name=booted_image_name).read()
@@ -27,6 +25,5 @@ class BootedImagesScreen(NavigateStep):
 
     VIEW = BootedContainerImagesView
 
-    @retry_navigation
     def step(self, *args, **kwargs):
         self.view.menu.select('Content', 'Booted Container Images')

--- a/airgun/entities/capsule.py
+++ b/airgun/entities/capsule.py
@@ -1,6 +1,5 @@
 from airgun.entities.base import BaseEntity
 from airgun.navigation import NavigateStep, navigator
-from airgun.utils import retry_navigation
 from airgun.views.capsule import (
     CapsuleDetailsView,
     CapsulesView,
@@ -40,7 +39,6 @@ class CapsuleEntity(BaseEntity):
         """
 
         view = self.navigate_to(self, 'Capsules')
-        view.wait_displayed()
         view.searchbox.search(f'name="{capsule_name}"')
         return view.read()
 
@@ -53,7 +51,6 @@ class CapsuleEntity(BaseEntity):
         """
 
         view = self.navigate_to(self, 'Capsules')
-        view.wait_displayed()
         view.searchbox.search(f'name="{capsule_name}"')
         view.table.row(name=capsule_name)['Name'].click()
         view = CapsuleDetailsView(self.browser)
@@ -63,14 +60,12 @@ class CapsuleEntity(BaseEntity):
         """Read all values from Capsules page"""
 
         view = self.navigate_to(self, 'Capsules')
-        view.wait_displayed()
         return view.read()
 
     def view_documentation(self):
         """Opens Capsule documentation page"""
 
         view = self.navigate_to(self, 'Capsules')
-        view.wait_displayed()
         view.documentation.click()
 
     def create(self, values):
@@ -90,7 +85,6 @@ class CapsuleEntity(BaseEntity):
         """
 
         view = self.navigate_to(self, 'Capsules')
-        view.wait_displayed()
         view.create_capsule.click()
         view = CreateCapsuleView(self.browser)
         view.fill(values)
@@ -125,7 +119,6 @@ class CapsuleEntity(BaseEntity):
         """
 
         view = self.navigate_to(self, 'Capsules')
-        view.wait_displayed()
         view.search(f'name="{capsule_name_to_edit}"')
         view.table.row(name=capsule_name_to_edit)['Actions'].widget.fill('Edit')
         view = EditCapsuleView(self.browser)
@@ -199,7 +192,6 @@ class CapsuleEntity(BaseEntity):
         """
 
         view = self.navigate_to(self, 'Capsules')
-        view.wait_displayed()
         view.table.row(name=capsule_name)['Actions'].widget.fill('Refresh')
 
         return self.get_operation_status(view)
@@ -213,7 +205,6 @@ class CapsuleEntity(BaseEntity):
         """
 
         view = self.navigate_to(self, 'Capsules')
-        view.wait_displayed()
         view.table.row(name=capsule_name)['Actions'].widget.fill('Expire logs')
 
     def delete(self, capsule_name):
@@ -227,7 +218,6 @@ class CapsuleEntity(BaseEntity):
         """
 
         view = self.navigate_to(self, 'Capsules')
-        view.wait_displayed()
         view.table.row(name=capsule_name)['Actions'].widget.fill('Delete')
         if view.confirm_deletion.is_displayed:
             view.confirm_deletion.confirm()
@@ -244,7 +234,6 @@ class CapsuleEntity(BaseEntity):
         """
 
         view = self.navigate_to(self, 'Capsules')
-        view.wait_displayed()
         view.searchbox.search(f'name="{capsule_name}"')
         view.table.row(name=capsule_name)['Name'].click()
         view = CapsuleDetailsView(self.browser)
@@ -292,10 +281,9 @@ class CapsuleEntity(BaseEntity):
         """
 
         view = self.navigate_to(self, 'Capsules')
-        view.wait_displayed()
         view.table.row(name=capsule_name)['Name'].click()
         view = CapsuleDetailsView(self.browser)
-        view.wait_displayed()
+
         if not cv_name:
             view.content.top_content_table.row(Environment=lce_name)[3].click()
             view.content.top_content_table.row(Environment=lce_name)[3].widget.item_select(
@@ -315,6 +303,5 @@ class OpenCapsulesPage(NavigateStep):
 
     VIEW = CapsulesView
 
-    @retry_navigation
     def step(self, *args, **kwargs):
         self.view.menu.select('Infrastructure', 'Capsules')

--- a/airgun/entities/cloud_inventory.py
+++ b/airgun/entities/cloud_inventory.py
@@ -1,8 +1,5 @@
-import time
-
 from airgun.entities.base import BaseEntity
 from airgun.navigation import NavigateStep, navigator
-from airgun.utils import retry_navigation
 from airgun.views.cloud_inventory import CloudInventoryListView
 
 
@@ -27,8 +24,6 @@ class CloudInventoryEntity(BaseEntity):
     def get_displayed_settings_options(self):
         """Get displayed settings options on Red Hat Inventory page"""
         view = self.navigate_to(self, 'All')
-        self.browser.plugin.ensure_page_safe(timeout='5s')
-        view.wait_displayed()
         result = {
             'auto_update': view.auto_update.is_displayed,
             'obfuscate_hostnames': view.obfuscate_hostnames.is_displayed,
@@ -41,8 +36,6 @@ class CloudInventoryEntity(BaseEntity):
     def get_displayed_buttons(self):
         """Get displayed buttons on Red Hat Inventory page"""
         view = self.navigate_to(self, 'All')
-        self.browser.plugin.ensure_page_safe(timeout='5s')
-        view.wait_displayed()
         result = {
             'cloud_connector': view.cloud_connector.is_displayed,
             'cloud_connector_text': (
@@ -62,8 +55,6 @@ class CloudInventoryEntity(BaseEntity):
     def get_displayed_descriptions(self):
         """Get displayed descriptions on Red Hat Inventory page"""
         view = self.navigate_to(self, 'All')
-        self.browser.plugin.ensure_page_safe(timeout='5s')
-        view.wait_displayed()
         result = {
             'auto_upload_desc': view.auto_upload_desc.is_displayed,
             'manual_upload_desc': view.manual_upload_desc.is_displayed,
@@ -73,8 +64,6 @@ class CloudInventoryEntity(BaseEntity):
     def get_displayed_inventory_tabs(self):
         """Get displayed inventory tabs on Red Hat Inventory page"""
         view = self.navigate_to(self, 'All')
-        self.browser.plugin.ensure_page_safe(timeout='5s')
-        view.wait_displayed()
         result = {
             'generating': view.inventory_list.generating.is_displayed,
             'uploading': view.inventory_list.uploading.is_displayed,
@@ -106,7 +95,7 @@ class CloudInventoryEntity(BaseEntity):
         view = self.navigate_to(self, 'All')
         view.inventory_list.toggle(entity_name)
         view.browser.click(view.inventory_list.generating.download_report, ignore_ajax=True)
-        time.sleep(3)
+        # If file download fails, browser.save_downloaded_file() should handle waiting
         return self.browser.save_downloaded_file()
 
     def update(self, values):
@@ -121,6 +110,5 @@ class ShowCloudInventoryListView(NavigateStep):
 
     VIEW = CloudInventoryListView
 
-    @retry_navigation
     def step(self, *args, **kwargs):
         self.view.menu.select('Red Hat Lightspeed', 'Inventory Upload')

--- a/airgun/entities/cloud_vulnerabilities.py
+++ b/airgun/entities/cloud_vulnerabilities.py
@@ -2,7 +2,6 @@ from wait_for import wait_for
 
 from airgun.entities.base import BaseEntity
 from airgun.navigation import NavigateStep, navigator
-from airgun.utils import retry_navigation
 from airgun.views.cloud_vulnerabilities import CloudVulnerabilityView, CVEDetailsView
 from airgun.views.host_new import NewHostDetailsView
 
@@ -12,14 +11,11 @@ class CloudVulnerabilityEntity(BaseEntity):
 
     def read(self, entity_name=None, widget_names=None):
         view = self.navigate_to(self, 'All')
-        wait_for(lambda: view.vulnerabilities_table.is_displayed, timeout=30)
         return view.vulnerabilities_table.read()
 
     def _navigate_to_cve_details(self, cve_id):
         """Helper method to navigate to CVE details page"""
         view = self.navigate_to(self, 'All')
-        view.wait_displayed()
-        wait_for(lambda: view.vulnerabilities_table.is_displayed, timeout=30)
         view.search_bar.fill(cve_id)
         view.browser.element(f'.//a[contains(@href, "{cve_id}")]').click()
 
@@ -77,6 +73,5 @@ class ShowVulnerabilityListView(NavigateStep):
 
     VIEW = CloudVulnerabilityView
 
-    @retry_navigation
     def step(self, *args, **kwargs):
         self.view.menu.select('Red Hat Lightspeed', 'Vulnerability')

--- a/airgun/entities/computeprofile.py
+++ b/airgun/entities/computeprofile.py
@@ -2,7 +2,6 @@ from navmazing import NavigateToSibling
 
 from airgun.entities.base import BaseEntity
 from airgun.navigation import NavigateStep, navigator
-from airgun.utils import retry_navigation
 from airgun.views.computeprofile import (
     ComputeProfileCreateView,
     ComputeProfileDetailView,
@@ -58,7 +57,6 @@ class ShowAllComputeProfiles(NavigateStep):
 
     VIEW = ComputeProfilesView
 
-    @retry_navigation
     def step(self, *args, **kwargs):
         self.view.menu.select('Infrastructure', 'Compute Profiles')
 

--- a/airgun/entities/computeresource.py
+++ b/airgun/entities/computeresource.py
@@ -2,7 +2,6 @@ from navmazing import NavigateToSibling
 
 from airgun.entities.base import BaseEntity
 from airgun.navigation import NavigateStep, navigator
-from airgun.utils import retry_navigation
 from airgun.views.computeresource import (
     ComputeResourceLibvirtImageCreateView,
     ComputeResourceLibvirtImageEditView,
@@ -108,9 +107,8 @@ class ComputeResourceEntity(BaseEntity):
         view = self.navigate_to(
             self, 'Profile', entity_name=entity_name, compute_profile=compute_profile
         )
-        with self.browser.ignore_ensure_page_safe_timeout():
-            view.fill(values)
-            view.submit.click()
+        view.fill(values)
+        view.submit.click()
 
     def read_computeprofile(self, entity_name, compute_profile, widget_names=None):
         """Read specific compute profile attributes through CR detail view"""
@@ -176,7 +174,7 @@ class ComputeResourceEntity(BaseEntity):
         view.images.filterbox.fill(image_name)
         view.images.table.row(name=image_name)['Actions'].widget.fill('Destroy')
         self.browser.handle_alert()
-        self.browser.plugin.ensure_page_safe()
+
         view.flash.assert_no_error()
         view.flash.dismiss()
 
@@ -185,7 +183,6 @@ class ComputeResourceEntity(BaseEntity):
 class ShowAllComputeResources(NavigateStep):
     VIEW = ComputeResourcesView
 
-    @retry_navigation
     def step(self, *args, **kwargs):
         self.view.menu.select('Infrastructure', 'Compute Resources')
 

--- a/airgun/entities/config_report.py
+++ b/airgun/entities/config_report.py
@@ -1,6 +1,5 @@
 from airgun.entities.base import BaseEntity
 from airgun.navigation import NavigateStep, navigator
-from airgun.utils import retry_navigation
 from airgun.views.config_report import ConfigReportDetailsView, ConfigReportsView
 
 
@@ -46,7 +45,6 @@ class ShowAllConfigReports(NavigateStep):
 
     VIEW = ConfigReportsView
 
-    @retry_navigation
     def step(self, *args, **kwargs):
         self.view.menu.select('Monitor', 'Reports', 'Config Management')
 

--- a/airgun/entities/configgroup.py
+++ b/airgun/entities/configgroup.py
@@ -2,7 +2,6 @@ from navmazing import NavigateToSibling
 
 from airgun.entities.base import BaseEntity
 from airgun.navigation import NavigateStep, navigator
-from airgun.utils import retry_navigation
 from airgun.views.configgroup import (
     ConfigGroupCreateView,
     ConfigGroupEditView,
@@ -54,7 +53,6 @@ class ShowAllConfigGroups(NavigateStep):
 
     VIEW = ConfigGroupsView
 
-    @retry_navigation
     def step(self, *args, **kwargs):
         self.view.menu.select('Configure', 'Puppet ENC', 'Config Groups')
 

--- a/airgun/entities/containerimages.py
+++ b/airgun/entities/containerimages.py
@@ -3,7 +3,6 @@ from widgetastic.exceptions import NoSuchElementException
 
 from airgun.entities.base import BaseEntity
 from airgun.navigation import NavigateStep, navigator
-from airgun.utils import retry_navigation
 from airgun.views.containerimages import (
     ContainerImagesView,
     ManifestDetailsView,
@@ -106,7 +105,6 @@ class SyncedContainersTab(NavigateStep):
 
     VIEW = ContainerImagesView
 
-    @retry_navigation
     def step(self, *args, **kwargs):
         self.view.menu.select('Content', 'Container Images')
 

--- a/airgun/entities/containerimagetag.py
+++ b/airgun/entities/containerimagetag.py
@@ -1,6 +1,5 @@
 from airgun.entities.base import BaseEntity
 from airgun.navigation import NavigateStep, navigator
-from airgun.utils import retry_navigation
 from airgun.views.containerimagetag import (
     ContainerImageTagDetailsView,
     ContainerImageTagsView,
@@ -35,7 +34,6 @@ class ShowAllContainerImageTags(NavigateStep):
 
     VIEW = ContainerImageTagsView
 
-    @retry_navigation
     def step(self, *args, **kwargs):
         self.view.menu.select('Content', 'Content Types', 'Container Image Tags')
 

--- a/airgun/entities/contentcredential.py
+++ b/airgun/entities/contentcredential.py
@@ -2,7 +2,6 @@ from navmazing import NavigateToSibling
 
 from airgun.entities.base import BaseEntity
 from airgun.navigation import NavigateStep, navigator
-from airgun.utils import retry_navigation
 from airgun.views.contentcredential import (
     ContentCredentialCreateView,
     ContentCredentialEditView,
@@ -65,7 +64,6 @@ class ShowAllContentCredentials(NavigateStep):
 
     VIEW = ContentCredentialsTableView
 
-    @retry_navigation
     def step(self, *args, **kwargs):
         self.view.menu.select('Content', 'Content Credentials')
 

--- a/airgun/entities/contentview.py
+++ b/airgun/entities/contentview.py
@@ -4,7 +4,6 @@ from navmazing import NavigateToSibling
 
 from airgun.entities.base import BaseEntity
 from airgun.navigation import NavigateStep, navigator
-from airgun.utils import retry_navigation
 from airgun.views.contentview import (
     ContentViewCopyView,
     ContentViewCreateView,
@@ -233,7 +232,6 @@ class ShowAllContentViews(NavigateStep):
 
     VIEW = ContentViewTableView
 
-    @retry_navigation
     def step(self, *args, **kwargs):
         current_url = urlparse(self.view.browser.url)
         self.view.browser.url = (

--- a/airgun/entities/contentview_new.py
+++ b/airgun/entities/contentview_new.py
@@ -1,5 +1,3 @@
-import time
-
 from navmazing import NavigateToSibling
 from wait_for import wait_for
 from widgetastic.exceptions import NoSuchElementException
@@ -7,7 +5,6 @@ from widgetastic_patternfly4.dropdown import DropdownItemDisabled
 
 from airgun.entities.base import BaseEntity
 from airgun.navigation import NavigateStep, navigator
-from airgun.utils import retry_navigation
 from airgun.views.contentview_new import (
     AddContentViewModal,
     AddRPMRuleView,
@@ -28,8 +25,6 @@ class NewContentViewEntity(BaseEntity):
     def create(self, values, composite=False, rolling=False):
         """Create a new content view"""
         view = self.navigate_to(self, 'New')
-        self.browser.plugin.ensure_page_safe(timeout='5s')
-        view.wait_displayed()
         if composite:
             view.composite_tile.click()
         if rolling:
@@ -40,8 +35,6 @@ class NewContentViewEntity(BaseEntity):
     def search(self, value):
         """Search for content view"""
         view = self.navigate_to(self, 'All')
-        self.browser.plugin.ensure_page_safe(timeout='5s')
-        view.wait_displayed()
         if not view.table.is_displayed:
             # no table present, no CVs in this Org
             return None
@@ -50,8 +43,6 @@ class NewContentViewEntity(BaseEntity):
     def publish(self, entity_name, values=None, promote=False, lce=None):
         """Publishes new version of CV, optionally allowing for instant promotion"""
         view = self.navigate_to(self, 'Publish', entity_name=entity_name)
-        self.browser.plugin.ensure_page_safe(timeout='5s')
-        view.wait_displayed()
         if values:
             view.fill(values)
         if promote:
@@ -62,8 +53,6 @@ class NewContentViewEntity(BaseEntity):
         view.finish_button.click()
         view.progressbar.wait_for_result()
         view = self.navigate_to(self, 'Edit', entity_name=entity_name)
-        self.browser.plugin.ensure_page_safe(timeout='5s')
-        view.wait_displayed()
         return view.versions.table.read()
 
     def read_flatpak_dependencies_alert(self, entity_name, values=None):
@@ -85,8 +74,6 @@ class NewContentViewEntity(BaseEntity):
     def check_publish_banner(self, cv_name):
         """Check if the needs_publish banner is displayed on the content view index page"""
         view = self.navigate_to(self, 'All')
-        self.browser.plugin.ensure_page_safe(timeout='5s')
-        view.wait_displayed()
         if not view.table.is_displayed:
             # no table present, no CVs in this Org
             return None
@@ -100,10 +87,8 @@ class NewContentViewEntity(BaseEntity):
     def delete(self, entity_name):
         """Deletes the content view by name"""
         view = self.navigate_to(self, 'Edit', entity_name=entity_name)
-        self.browser.plugin.ensure_page_safe(timeout='5s')
-        view.wait_displayed()
         view.cv_actions.item_select('Delete')
-        view.wait_displayed()
+
         # Remove from environment(s) wizard, if it appears
         if view.next_button.is_displayed:
             view.next_button.click()
@@ -123,11 +108,8 @@ class NewContentViewEntity(BaseEntity):
             version=version,
             timeout=60,
         )
-        time.sleep(5)  # 'Loading' widget on page
-        self.browser.plugin.ensure_page_safe(timeout='10s')
-        wait_for(lambda: view.table.is_displayed, timeout=20)
         result = view.version_dropdown.item_select('Delete')
-        view.wait_displayed()
+
         # Remove from environment(s) wizard, if it appears
         if view.next_button.is_displayed:
             view.next_button.click()
@@ -137,8 +119,6 @@ class NewContentViewEntity(BaseEntity):
     def add_content(self, entity_name, content_name):
         """Add specified content to the given Content View"""
         view = self.navigate_to(self, 'Edit', entity_name=entity_name)
-        self.browser.plugin.ensure_page_safe(timeout='5s')
-        view.wait_displayed()
         wait_for(lambda: view.repositories.resources.is_displayed, timeout=10)
         view.repositories.resources.add(content_name)
         return view.repositories.resources.read()
@@ -146,8 +126,6 @@ class NewContentViewEntity(BaseEntity):
     def add_cv(self, ccv_name, cv_name, always_update=False, version=None):
         """Adds selected CV to selected CCV, optionally with support for always_update and specified version"""
         view = self.navigate_to(self, 'Edit', entity_name=ccv_name)
-        self.browser.plugin.ensure_page_safe(timeout='5s')
-        view.wait_displayed()
         view.content_views.resources.add(cv_name)
         view = AddContentViewModal(self.browser)
         if always_update:
@@ -156,16 +134,12 @@ class NewContentViewEntity(BaseEntity):
             view.version_select.item_select(version)
         view.submit_button.click()
         view = self.navigate_to(self, 'Edit', entity_name=ccv_name)
-        self.browser.plugin.ensure_page_safe(timeout='5s')
-        view.wait_displayed()
         wait_for(lambda: view.content_views.resources.is_displayed, timeout=10)
         return view.content_views.resources.read()
 
     def read_cv(self, entity_name, version_name):
         """Reads the table for a specified Content View's specified Version"""
         view = self.navigate_to(self, 'Edit', entity_name=entity_name)
-        self.browser.plugin.ensure_page_safe(timeout='5s')
-        view.wait_displayed()
         view.versions.search(version_name)
         return view.versions.table.row(version=version_name).read()
 
@@ -183,8 +157,7 @@ class NewContentViewEntity(BaseEntity):
             version=version,
             timeout=60,
         )
-        time.sleep(5)
-        self.browser.plugin.ensure_page_safe(timeout='5s')
+
         # This allows dynamic access to the proper table
         wait_for(lambda: getattr(view, tab_name).table.wait_displayed(), timeout=10)
         if search_param:
@@ -194,8 +167,6 @@ class NewContentViewEntity(BaseEntity):
     def rolling_cv_read(self, entity_name):
         """Verify that rolling CVs display only the fields they should"""
         view = self.navigate_to(self, 'Edit', entity_name=entity_name)
-        self.browser.plugin.ensure_page_safe(timeout='5s')
-        view.wait_displayed()
         rolling_cv_acceptable_fields = True
         # Versions tab
         try:
@@ -289,22 +260,16 @@ class NewContentViewEntity(BaseEntity):
     def read_french_lang_cv(self):
         """Navigates to main CV page, when system is set to French, and reads table"""
         view = self.navigate_to(self, 'French')
-        self.browser.plugin.ensure_page_safe(timeout='5s')
-        view.wait_displayed()
         return view.table.read()
 
     def click_version_dropdown(self, entity_name, version, dropdown_option):
         """Clicks a specific dropdown option for a CV Version"""
         view = self.navigate_to(self, 'Version', entity_name=entity_name, version=version)
-        self.browser.plugin.ensure_page_safe(timeout='5s')
-        view.wait_displayed()
         return view.version_dropdown.item_select(dropdown_option)
 
     def republish_metadata_error(self, entity_name, version):
         """Clicks a specific dropdown option for a CV Version, that will throw an error"""
         view = self.navigate_to(self, 'Version', entity_name=entity_name, version=version)
-        self.browser.plugin.ensure_page_safe(timeout='5s')
-        view.wait_displayed()
         try:
             view.version_dropdown.item_select('Republish repository metadata')
         except DropdownItemDisabled as error:
@@ -327,14 +292,13 @@ class NewContentViewEntity(BaseEntity):
                 message = view.flash.read()
                 return message
         view = self.navigate_to(self, 'Edit', entity_name=entity_name)
-        view.wait_displayed()
         view.versions.search(version)
         return view.versions.table.row().read()
 
     def update(self, entity_name, values):
         """Update existing content view"""
         view = self.navigate_to(self, 'Edit', entity_name=entity_name)
-        time.sleep(3)
+
         filled_values = view.fill(values)
         view.flash.assert_no_error()
         view.flash.dismiss()
@@ -347,7 +311,6 @@ class ShowAllContentViewsScreen(NavigateStep):
 
     VIEW = ContentViewTableView
 
-    @retry_navigation
     def step(self, *args, **kwargs):
         self.view.menu.select('Content', 'Lifecycle', 'Content Views')
 
@@ -358,7 +321,6 @@ class ShowAllContentViewsScreenFrench(NavigateStep):
 
     VIEW = ContentViewTableView
 
-    @retry_navigation
     def step(self, *args, **kwargs):
         self.view.menu.select('Contenu', 'Lifecycle', 'Content Views')
 

--- a/airgun/entities/contentviewfilter.py
+++ b/airgun/entities/contentviewfilter.py
@@ -1,7 +1,6 @@
 from airgun.entities.base import BaseEntity
 from airgun.entities.contentview import ContentViewEntity
 from airgun.navigation import NavigateStep, navigator
-from airgun.utils import retry_navigation
 from airgun.views.contentviewfilter import (
     ACTIONS_COLUMN,
     ContentViewFiltersView,
@@ -307,7 +306,6 @@ class ShowAllContentViewFilters(NavigateStep):
         cv_name = kwargs.get('cv_name')
         return self.navigate_to(ContentViewEntity, 'Edit', entity_name=cv_name)
 
-    @retry_navigation
     def step(self, *args, **kwargs):
         self.parent.filters.select()
 

--- a/airgun/entities/dashboard.py
+++ b/airgun/entities/dashboard.py
@@ -1,8 +1,5 @@
-import time
-
 from airgun.entities.base import BaseEntity
 from airgun.navigation import NavigateStep, navigator
-from airgun.utils import retry_navigation
 from airgun.views.dashboard import DashboardView
 
 
@@ -19,7 +16,7 @@ class DashboardEntity(BaseEntity):
         view = self.navigate_to(self, 'All')
         if widget_name not in view.widget_names:
             raise ValueError('Provide correct widget name to be read')
-        time.sleep(3)
+
         return getattr(view, widget_name).read()
 
     def read_all(self):
@@ -41,7 +38,6 @@ class OpenDashboard(NavigateStep):
 
     VIEW = DashboardView
 
-    @retry_navigation
     def step(self, *args, **kwargs):
         self.view.menu.select('Monitor', 'Dashboard')
 

--- a/airgun/entities/discoveredhosts.py
+++ b/airgun/entities/discoveredhosts.py
@@ -2,7 +2,6 @@ from wait_for import wait_for
 
 from airgun.entities.base import BaseEntity
 from airgun.navigation import NavigateStep, navigator
-from airgun.utils import retry_navigation
 from airgun.views.discoveredhosts import (
     DiscoveredHostDetailsView,
     DiscoveredHostEditProvisioningView,
@@ -102,7 +101,7 @@ class DiscoveredHostsEntity(BaseEntity):
                 discovered_host_edit_view.operating_system.disable_passwd.click()
             discovered_host_edit_view.fill(host_values)
             self.browser.click(discovered_host_edit_view.submit, ignore_ajax=True)
-            self.browser.plugin.ensure_page_safe(timeout='120s')
+
         view.flash.assert_no_error()
         view.flash.dismiss()
 
@@ -139,7 +138,6 @@ class ShowAllDiscoveredHosts(NavigateStep):
 
     VIEW = DiscoveredHostsView
 
-    @retry_navigation
     def step(self, *args, **kwargs):
         self.view.menu.select('Hosts', 'Discovered Hosts')
 

--- a/airgun/entities/discoveryrule.py
+++ b/airgun/entities/discoveryrule.py
@@ -3,7 +3,6 @@ from widgetastic.exceptions import NoSuchElementException
 
 from airgun.entities.base import BaseEntity
 from airgun.navigation import NavigateStep, navigator
-from airgun.utils import retry_navigation
 from airgun.views.discoveredhosts import DiscoveredHostsView
 from airgun.views.discoveryrule import (
     DiscoveryRuleCreateView,
@@ -132,7 +131,6 @@ class ShowAllDiscoveryRules(NavigateStep):
 
     VIEW = DiscoveryRulesView
 
-    @retry_navigation
     def step(self, *args, **kwargs):
         self.view.menu.select('Configure', 'Discovery Rules')
 

--- a/airgun/entities/domain.py
+++ b/airgun/entities/domain.py
@@ -2,7 +2,6 @@ from navmazing import NavigateToSibling
 
 from airgun.entities.base import BaseEntity
 from airgun.navigation import NavigateStep, navigator
-from airgun.utils import retry_navigation
 from airgun.views.domain import DomainCreateView, DomainEditView, DomainListView
 
 
@@ -84,7 +83,6 @@ class ShowAllDomains(NavigateStep):
 
     VIEW = DomainListView
 
-    @retry_navigation
     def step(self, *args, **kwargs):
         self.view.menu.select('Infrastructure', 'Domains')
 

--- a/airgun/entities/errata.py
+++ b/airgun/entities/errata.py
@@ -1,7 +1,6 @@
 from airgun import ERRATA_REGEXP
 from airgun.entities.base import BaseEntity
 from airgun.navigation import NavigateStep, navigator
-from airgun.utils import retry_navigation
 from airgun.views.errata import (
     ErrataDetailsView,
     ErrataInstallationConfirmationView,
@@ -98,7 +97,7 @@ class ErrataEntity(BaseEntity):
         view.content_hosts.apply.click()
         # brought to confirmation page
         view = ErrataInstallationConfirmationView(view.browser)
-        view.wait_displayed()
+
         view.confirm.click()
         # wait for redirect to task details page
         view = JobInvocationStatusView(view.browser)
@@ -130,7 +129,6 @@ class ShowAllErratum(NavigateStep):
 
     VIEW = ErratumView
 
-    @retry_navigation
     def step(self, *args, **kwargs):
         self.view.menu.select('Content', 'Content Types', 'Errata')
 

--- a/airgun/entities/fact_value.py
+++ b/airgun/entities/fact_value.py
@@ -1,6 +1,5 @@
 from airgun.entities.base import BaseEntity
 from airgun.navigation import NavigateStep, navigator
-from airgun.utils import retry_navigation
 from airgun.views.fact import HostFactView
 
 
@@ -14,6 +13,5 @@ class ShowFactValuePage(NavigateStep):
 
     VIEW = HostFactView
 
-    @retry_navigation
     def step(self, *args, **kwargs):
         self.view.menu.select('Monitor', 'Facts')

--- a/airgun/entities/file.py
+++ b/airgun/entities/file.py
@@ -1,6 +1,5 @@
 from airgun.entities.base import BaseEntity
 from airgun.navigation import NavigateStep, navigator
-from airgun.utils import retry_navigation
 from airgun.views.file import FileDetailsView, FilesView
 
 
@@ -26,7 +25,6 @@ class ShowAllFiles(NavigateStep):
 
     VIEW = FilesView
 
-    @retry_navigation
     def step(self, *args, **kwargs):
         self.view.menu.select('Content', 'Content Types', 'Files')
 

--- a/airgun/entities/filter.py
+++ b/airgun/entities/filter.py
@@ -8,10 +8,9 @@ class FilterEntity(BaseEntity):
     def create(self, role_name, values):
         """Create new filter for specific role"""
         view = self.navigate_to(self, 'New', role_name=role_name)
-        view.wait_displayed()
         # we need to wait explicitly for this element for some reason
         view.resource_type.wait_displayed()
-        self.browser.plugin.ensure_page_safe()
+
         view.fill(values)
         view.submit.click()
         view.flash.assert_no_error()

--- a/airgun/entities/flatpak.py
+++ b/airgun/entities/flatpak.py
@@ -1,10 +1,7 @@
-from time import sleep
-
 from widgetastic.exceptions import NoSuchElementException
 
 from airgun.entities.base import BaseEntity
 from airgun.navigation import NavigateStep, navigator
-from airgun.utils import retry_navigation
 from airgun.views.flatpak import (
     CreateFlatpakRemoteModal,
     EditFlatpakRemoteModal,
@@ -28,7 +25,6 @@ class FlatpakRemotesEntity(BaseEntity):
         :rtype: list
         """
         view = self.navigate_to(self, 'All')
-        view.wait_displayed()
         return view.search(value)
 
     def read(self, widget_names=None):
@@ -39,7 +35,6 @@ class FlatpakRemotesEntity(BaseEntity):
         :rtype: dict
         """
         view = self.navigate_to(self, 'All')
-        view.wait_displayed()
         return view.read(widget_names=widget_names)
 
     def read_table(self):
@@ -49,7 +44,6 @@ class FlatpakRemotesEntity(BaseEntity):
         :rtype: list
         """
         view = self.navigate_to(self, 'All')
-        view.wait_displayed()
         return view.table.read()
 
     def read_remote_details(self, name, repo_search=None):
@@ -61,11 +55,10 @@ class FlatpakRemotesEntity(BaseEntity):
             repo_search (str, optional): Name of scanned remote repository to be searched
         """
         view = self.navigate_to(self, 'All')
-        view.wait_displayed()
         view.search(name)
         view.table.row(name=name)['Name'].widget.click()
         view = FlatpakRemoteDetailsView(self.browser)
-        view.wait_displayed()
+
         if repo_search:
             view.search(repo_search)
             self.browser.plugin.ensure_page_safe()
@@ -77,10 +70,9 @@ class FlatpakRemotesEntity(BaseEntity):
         :param dict values: values to create the remote with
         """
         view = self.navigate_to(self, 'All')
-        view.wait_displayed()
         view.create_new_btn.click()
         create_modal = CreateFlatpakRemoteModal(self.browser)
-        create_modal.wait_displayed()
+
         create_modal.fill(values)
         create_modal.create_btn.click()
         view = FlatpakRemoteDetailsView(self.browser)
@@ -95,10 +87,9 @@ class FlatpakRemotesEntity(BaseEntity):
         :param dict values: values to create the remote with
         """
         view = self.navigate_to(self, 'All')
-        view.wait_displayed()
         view.create_new_btn.click()
         create_modal = CreateFlatpakRemoteModal(self.browser)
-        create_modal.wait_displayed()
+
         create_modal.fill(values)
 
         if create_modal.info_alert.is_displayed:
@@ -116,10 +107,8 @@ class FlatpakRemotesEntity(BaseEntity):
         :return: dict with alert information or None if alert not displayed
         """
         view = self.navigate_to(self, 'All')
-        view.wait_displayed()
         view.create_new_btn.click()
         create_modal = CreateFlatpakRemoteModal(self.browser)
-        create_modal.wait_displayed()
 
         if create_modal.info_alert.is_displayed:
             alert_info = {
@@ -139,11 +128,10 @@ class FlatpakRemotesEntity(BaseEntity):
         :param dict values: values to update the remote with
         """
         view = self.navigate_to(self, 'All')
-        view.wait_displayed()
         view.table.row(name=entity_name)[2].click()
         view.table.row(name=entity_name)[2].widget.item_select('Edit')
         edit_modal = EditFlatpakRemoteModal(self.browser)
-        edit_modal.wait_displayed()
+
         edit_modal.fill(values)
         edit_modal.update_btn.click()
         view = FlatpakRemoteDetailsView(self.browser)
@@ -155,14 +143,12 @@ class FlatpakRemotesEntity(BaseEntity):
         :param str entity_name: name of the remote to delete
         """
         view = self.navigate_to(self, 'All')
-        view.wait_displayed()
         view.table.row(name=entity_name)[2].click()
         view.table.row(name=entity_name)[2].widget.item_select('Delete')
         delete_modal = FlatpakRemoteDeleteModal(self.browser)
-        delete_modal.wait_displayed()
+
         delete_modal.delete_btn.click()
-        sleep(3)
-        self.browser.plugin.ensure_page_safe()
+
         view = FlatpakRemotesView(self.browser)
         view.wait_displayed(delay=3)
 
@@ -172,7 +158,6 @@ class FlatpakRemotesEntity(BaseEntity):
         :param str entity_name: name of the remote to scan
         """
         view = self.navigate_to(self, 'All')
-        view.wait_displayed()
         view.table.row(name=entity_name)[2].click()
         view.table.row(name=entity_name)[2].widget.item_select('Scan')
         view.flash.assert_no_error()
@@ -191,11 +176,10 @@ class FlatpakRemotesEntity(BaseEntity):
     def open_mirror_modal(self, remote, repo):
         """Open the Mirror Repository modal for a given remote repository."""
         view = self.navigate_to(self, 'All')
-        view.wait_displayed()
         view.search(remote)
         view.table.row(name=remote)['Name'].widget.click()
         view = FlatpakRemoteDetailsView(self.browser)
-        view.wait_displayed()
+
         view.search(repo)  # in case of many repos
         view.table.row(name=repo)['Mirror'].widget.click()
         mirror_modal = MirrorFlatpakRemoteModal(self.browser)
@@ -219,12 +203,6 @@ class FlatpakRemotesEntity(BaseEntity):
         """Submit mirror modal, optionally selecting dependency repositories."""
         for dependency in dependencies or []:
             mirror_modal.select_dependency(dependency)
-        mirror_modal.searchbar.fill(product.name)
-        self.browser.plugin.ensure_page_safe()
-        mirror_modal.mirror_btn.click()
-        view = FlatpakRemoteDetailsView(self.browser)
-        view.wait_displayed(delay=3)
-        return view
 
 
 @navigator.register(FlatpakRemotesEntity, 'All')
@@ -233,6 +211,5 @@ class ShowAllFlatpakRemotes(NavigateStep):
 
     VIEW = FlatpakRemotesView
 
-    @retry_navigation
     def step(self, *args, **kwargs):
         self.view.menu.select('Content', 'Flatpak Remotes')

--- a/airgun/entities/global_parameter.py
+++ b/airgun/entities/global_parameter.py
@@ -1,6 +1,5 @@
 from airgun.entities.base import BaseEntity
 from airgun.navigation import NavigateStep, navigator
-from airgun.utils import retry_navigation
 from airgun.views.global_parameter import GlobalParameterView
 
 
@@ -14,6 +13,5 @@ class ShowGlobalParameters(NavigateStep):
 
     VIEW = GlobalParameterView
 
-    @retry_navigation
     def step(self, *args, **kwargs):
         self.view.menu.select('Configure', 'Global Parameters')

--- a/airgun/entities/hardware_model.py
+++ b/airgun/entities/hardware_model.py
@@ -2,7 +2,6 @@ from navmazing import NavigateToSibling
 
 from airgun.entities.base import BaseEntity
 from airgun.navigation import NavigateStep, navigator
-from airgun.utils import retry_navigation
 from airgun.views.hardware_model import (
     HardwareModelCreateView,
     HardwareModelEditView,
@@ -64,7 +63,6 @@ class ShowAllHardwareModels(NavigateStep):
 
     VIEW = HardwareModelsView
 
-    @retry_navigation
     def step(self, *args, **kwargs):
         self.view.menu.select('Hosts', 'Provisioning Setup', 'Hardware Models')
 

--- a/airgun/entities/hostcollection.py
+++ b/airgun/entities/hostcollection.py
@@ -1,11 +1,8 @@
-import time
-
 from navmazing import NavigateToSibling
 from wait_for import wait_for
 
 from airgun.entities.base import BaseEntity
 from airgun.navigation import NavigateStep, navigator
-from airgun.utils import retry_navigation
 from airgun.views.hostcollection import (
     HostCollectionActionRemoteExecutionJobCreate,
     HostCollectionChangeAssignedContentView,
@@ -110,12 +107,12 @@ class HostCollectionEntity(BaseEntity):
             # After this step the user is redirected to remote execution job
             # create view.
             job_create_view = HostCollectionActionRemoteExecutionJobCreate(view.browser)
-            self.browser.plugin.ensure_page_safe(timeout='5s')
+
             job_create_view.fill(job_values)
             job_create_view.submit.click()
 
         # wait for the job deatils to load
-        time.sleep(3)
+
         # After this step the user is redirected to job status view.
         job_status_view = JobInvocationStatusView(view.browser)
         wait_for(
@@ -248,7 +245,6 @@ class HostCollectionEntity(BaseEntity):
 class ShowAllHostCollections(NavigateStep):
     VIEW = HostCollectionsView
 
-    @retry_navigation
     def step(self, *args, **kwargs):
         self.view.menu.select('Hosts', 'Host Collections')
 

--- a/airgun/entities/hostgroup.py
+++ b/airgun/entities/hostgroup.py
@@ -4,7 +4,6 @@ from widgetastic.exceptions import NoSuchElementException
 
 from airgun.entities.base import BaseEntity
 from airgun.navigation import NavigateStep, navigator
-from airgun.utils import retry_navigation
 from airgun.views.hostgroup import (
     HostGroupCreateView,
     HostGroupEditView,
@@ -66,7 +65,6 @@ class HostGroupEntity(BaseEntity):
         view.submit.click()
         view.flash.assert_no_error()
         view.flash.dismiss()
-        self.browser.plugin.ensure_page_safe()
 
     def total_no_of_assigned_role(self, entity_name):
         """Count of assigned role to the host group"""
@@ -110,7 +108,6 @@ class ShowAllHostGroups(NavigateStep):
 
     VIEW = HostGroupsView
 
-    @retry_navigation
     def step(self, *args, **kwargs):
         self.view.menu.select('Configure', 'Host Groups')
         self.view.wait_displayed()

--- a/airgun/entities/http_proxy.py
+++ b/airgun/entities/http_proxy.py
@@ -2,7 +2,6 @@ from navmazing import NavigateToSibling
 
 from airgun.entities.base import BaseEntity
 from airgun.navigation import NavigateStep, navigator
-from airgun.utils import retry_navigation
 from airgun.views.http_proxy import (
     HTTPProxyCreateView,
     HTTPProxyEditView,
@@ -73,7 +72,6 @@ class ShowAllHTTPProxy(NavigateStep):
 
     VIEW = HTTPProxyView
 
-    @retry_navigation
     def step(self, *args, **kwargs):
         self.view.menu.select('Infrastructure', 'HTTP proxies')
 

--- a/airgun/entities/job_invocation.py
+++ b/airgun/entities/job_invocation.py
@@ -1,11 +1,8 @@
-import time
-
 from navmazing import NavigateToSibling
 from wait_for import wait_for
 
 from airgun.entities.base import BaseEntity
 from airgun.navigation import NavigateStep, navigator
-from airgun.utils import retry_navigation
 from airgun.views.dynflowconsole import DynflowConsoleView
 from airgun.views.job_invocation import (
     JobInvocationCreateView,
@@ -50,16 +47,16 @@ class JobInvocationEntity(BaseEntity):
 
     def submit_prefilled_view(self):
         """This entity loads pre filled job invocation view and submits it."""
-        time.sleep(3)
+
         view = JobInvocationCreateView(self.browser)
-        time.sleep(3)
+
         view.submit.click()
 
     def get_job_category_and_template(self):
         """Reads selected job category and template for job invocation."""
-        time.sleep(3)
+
         view = JobInvocationCreateView(self.browser)
-        time.sleep(3)
+
         read_values = {
             'job_category': view.category_and_template.job_category.read(),
             'job_template': view.category_and_template.job_template_text_input.read(),
@@ -68,9 +65,9 @@ class JobInvocationEntity(BaseEntity):
 
     def get_targeted_hosts(self):
         """Read targeted hosts for job invocation."""
-        time.sleep(3)
+
         view = JobInvocationCreateView(self.browser)
-        time.sleep(3)
+
         return view.target_hosts_and_inputs.read()
 
     def read_hostgroups(self):
@@ -121,7 +118,6 @@ class ShowAllJobs(NavigateStep):
 
     VIEW = JobInvocationsView
 
-    @retry_navigation
     def step(self, *args, **kwargs):
         self.view.menu.select('Monitor', 'Jobs')
 

--- a/airgun/entities/job_template.py
+++ b/airgun/entities/job_template.py
@@ -3,7 +3,6 @@ from wait_for import wait_for
 
 from airgun.entities.base import BaseEntity
 from airgun.navigation import NavigateStep, navigator
-from airgun.utils import retry_navigation
 from airgun.views.job_template import (
     JobTemplateCreateView,
     JobTemplateEditView,
@@ -74,7 +73,6 @@ class ShowAllTemplates(NavigateStep):
 
     VIEW = JobTemplatesView
 
-    @retry_navigation
     def step(self, *args, **kwargs):
         self.view.menu.select('Hosts', 'Templates', 'Job Templates')
 

--- a/airgun/entities/ldap_authentication.py
+++ b/airgun/entities/ldap_authentication.py
@@ -3,7 +3,6 @@ from widgetastic.exceptions import NoSuchElementException, RowNotFound
 
 from airgun.entities.base import BaseEntity
 from airgun.navigation import NavigateStep, navigator
-from airgun.utils import retry_navigation
 from airgun.views.ldapauthentication import (
     LDAPAuthenticationCreateView,
     LDAPAuthenticationEditView,
@@ -73,7 +72,6 @@ class ShowAllLDAPSources(NavigateStep):
 
     VIEW = LDAPAuthenticationsView
 
-    @retry_navigation
     def step(self, *args, **kwargs):
         self.view.menu.select('Administer', 'Authentication Sources')
 
@@ -86,7 +84,6 @@ class AddNewLDAPSource(NavigateStep):
 
     prerequisite = NavigateToSibling('All')
 
-    @retry_navigation
     def step(self, *args, **kwargs):
         self.parent.ldap.select_kebab.item_select('Create')
 

--- a/airgun/entities/lifecycleenvironment.py
+++ b/airgun/entities/lifecycleenvironment.py
@@ -2,7 +2,6 @@ from navmazing import NavigateToSibling
 
 from airgun.entities.base import BaseEntity
 from airgun.navigation import NavigateStep, navigator
-from airgun.utils import retry_navigation
 from airgun.views.lifecycleenvironment import LCECreateView, LCEEditView, LCEView
 
 
@@ -82,7 +81,6 @@ class ShowAllLCE(NavigateStep):
 
     VIEW = LCEView
 
-    @retry_navigation
     def step(self, *args, **kwargs):
         self.view.menu.select('Content', 'Lifecycle', 'Lifecycle Environments')
 

--- a/airgun/entities/location.py
+++ b/airgun/entities/location.py
@@ -2,7 +2,6 @@ from navmazing import NavigateToSibling
 
 from airgun.entities.base import BaseEntity
 from airgun.navigation import NavigateStep, navigator
-from airgun.utils import retry_navigation
 from airgun.views.common import BaseLoggedInView
 from airgun.views.location import LocationCreateView, LocationsEditView, LocationsView
 
@@ -56,7 +55,6 @@ class ShowAllLocations(NavigateStep):
 
     VIEW = LocationsView
 
-    @retry_navigation
     def step(self, *args, **kwargs):
         self.view.menu.select('Administer', 'Locations')
 

--- a/airgun/entities/media.py
+++ b/airgun/entities/media.py
@@ -2,7 +2,6 @@ from navmazing import NavigateToSibling
 
 from airgun.entities.base import BaseEntity
 from airgun.navigation import NavigateStep, navigator
-from airgun.utils import retry_navigation
 from airgun.views.media import MediaCreateView, MediaEditView, MediumView
 
 
@@ -48,7 +47,6 @@ class ShowAllMedium(NavigateStep):
 
     VIEW = MediumView
 
-    @retry_navigation
     def step(self, *args, **kwargs):
         self.view.menu.select('Hosts', 'Provisioning Setup', 'Installation Media')
 

--- a/airgun/entities/modulestream.py
+++ b/airgun/entities/modulestream.py
@@ -2,7 +2,6 @@ from wait_for import wait_for
 
 from airgun.entities.base import BaseEntity
 from airgun.navigation import NavigateStep, navigator
-from airgun.utils import retry_navigation
 from airgun.views.modulestream import ModuleStreamsDetailsView, ModuleStreamView
 
 
@@ -37,7 +36,6 @@ class ShowAllModuleStreams(NavigateStep):
 
     VIEW = ModuleStreamView
 
-    @retry_navigation
     def step(self, *args, **kwargs):
         self.view.menu.select('Content', 'Content Types', 'Module Streams')
 

--- a/airgun/entities/os.py
+++ b/airgun/entities/os.py
@@ -2,7 +2,6 @@ from navmazing import NavigateToSibling
 
 from airgun.entities.base import BaseEntity
 from airgun.navigation import NavigateStep, navigator
-from airgun.utils import retry_navigation
 from airgun.views.os import (
     OperatingSystemCreateView,
     OperatingSystemEditView,
@@ -55,7 +54,6 @@ class ShowAllOperatingSystems(NavigateStep):
 
     VIEW = OperatingSystemsView
 
-    @retry_navigation
     def step(self, *args, **kwargs):
         self.view.menu.select('Hosts', 'Provisioning Setup', 'Operating Systems')
 

--- a/airgun/entities/oscapcontent.py
+++ b/airgun/entities/oscapcontent.py
@@ -2,7 +2,6 @@ from navmazing import NavigateToSibling
 
 from airgun.entities.base import BaseEntity
 from airgun.navigation import NavigateStep, navigator
-from airgun.utils import retry_navigation
 from airgun.views.oscapcontent import (
     SCAPContentCreateView,
     SCAPContentEditView,
@@ -22,7 +21,7 @@ class OSCAPContentEntity(BaseEntity):
         view = self.navigate_to(self, 'New')
         view.fill(values)
         self.browser.click(view.submit, ignore_ajax=True)
-        self.browser.plugin.ensure_page_safe(timeout='60s')
+
         view.validations.assert_no_errors()
         view.flash.assert_no_error()
         view.flash.dismiss()
@@ -76,7 +75,6 @@ class ShowAllSCAPContents(NavigateStep):
 
     VIEW = SCAPContentsView
 
-    @retry_navigation
     def step(self, *args, **kwargs):
         self.view.menu.select('Hosts', 'Compliance', 'SCAP contents')
 

--- a/airgun/entities/oscappolicy.py
+++ b/airgun/entities/oscappolicy.py
@@ -2,7 +2,6 @@ from navmazing import NavigateToSibling
 
 from airgun.entities.base import BaseEntity
 from airgun.navigation import NavigateStep, navigator
-from airgun.utils import retry_navigation
 from airgun.views.oscappolicy import (
     SCAPPoliciesView,
     SCAPPolicyCreateView,
@@ -87,7 +86,6 @@ class ShowAllSCAPPolicies(NavigateStep):
 
     VIEW = SCAPPoliciesView
 
-    @retry_navigation
     def step(self, *args, **kwargs):
         self.view.menu.select('Hosts', 'Compliance', 'Policies')
 

--- a/airgun/entities/oscapreport.py
+++ b/airgun/entities/oscapreport.py
@@ -2,7 +2,6 @@ from wait_for import wait_for
 
 from airgun.entities.base import BaseEntity
 from airgun.navigation import NavigateStep, navigator
-from airgun.utils import retry_navigation
 from airgun.views.oscapreport import (
     RemediateModal,
     SCAPReportDetailsView,
@@ -42,8 +41,7 @@ class OSCAPReportEntity(BaseEntity):
         view = self.navigate_to(self, 'Details', search_string=search_string)
         view.table.row(resource=resource).actions.fill('Remediation')
         view = RemediateModal(self.browser)
-        view.wait_displayed()
-        self.browser.plugin.ensure_page_safe()
+
         wait_for(lambda: view.title.is_displayed, timeout=10, delay=1)
         view.fill({'select_remediation_method.snippet': 'Ansible'})
         view.select_capsule.run.click()
@@ -55,7 +53,6 @@ class ShowAllSCAPReports(NavigateStep):
 
     VIEW = SCAPReportView
 
-    @retry_navigation
     def step(self, *args, **kwargs):
         self.view.menu.select('Hosts', 'Compliance', 'Reports')
 

--- a/airgun/entities/oscaptailoringfile.py
+++ b/airgun/entities/oscaptailoringfile.py
@@ -2,7 +2,6 @@ from navmazing import NavigateToSibling
 
 from airgun.entities.base import BaseEntity
 from airgun.navigation import NavigateStep, navigator
-from airgun.utils import retry_navigation
 from airgun.views.oscaptailoringfile import (
     SCAPTailoringFileCreateView,
     SCAPTailoringFileEditView,
@@ -75,7 +74,6 @@ class ShowAllSCAPTailoringFiles(NavigateStep):
 
     VIEW = SCAPTailoringFilesView
 
-    @retry_navigation
     def step(self, *args, **kwargs):
         self.view.menu.select('Hosts', 'Compliance', 'Tailoring Files')
 

--- a/airgun/entities/package.py
+++ b/airgun/entities/package.py
@@ -1,6 +1,5 @@
 from airgun.entities.base import BaseEntity
 from airgun.navigation import NavigateStep, navigator
-from airgun.utils import retry_navigation
 from airgun.views.package import PackageDetailsView, PackagesView
 
 
@@ -49,7 +48,6 @@ class ShowAllPackages(NavigateStep):
 
     VIEW = PackagesView
 
-    @retry_navigation
     def step(self, *args, **kwargs):
         self.view.menu.select('Content', 'Content Types', 'Packages')
 

--- a/airgun/entities/partitiontable.py
+++ b/airgun/entities/partitiontable.py
@@ -2,7 +2,6 @@ from navmazing import NavigateToSibling
 
 from airgun.entities.base import BaseEntity
 from airgun.navigation import NavigateStep, navigator
-from airgun.utils import retry_navigation
 from airgun.views.partitiontable import (
     PartitionTableCreateView,
     PartitionTableEditView,
@@ -83,7 +82,6 @@ class ShowAllPartitionTables(NavigateStep):
 
     VIEW = PartitionTablesView
 
-    @retry_navigation
     def step(self, *args, **kwargs):
         self.view.menu.select('Hosts', 'Templates', 'Partition Tables')
 

--- a/airgun/entities/product.py
+++ b/airgun/entities/product.py
@@ -2,7 +2,6 @@ from navmazing import NavigateToSibling
 
 from airgun.entities.base import BaseEntity
 from airgun.navigation import NavigateStep, navigator
-from airgun.utils import retry_navigation
 from airgun.views.product import (
     ProductAdvancedSync,
     ProductCreateView,
@@ -148,7 +147,6 @@ class ShowAllProducts(NavigateStep):
 
     VIEW = ProductsTableView
 
-    @retry_navigation
     def step(self, *args, **kwargs):
         self.view.menu.select('Content', 'Products')
 

--- a/airgun/entities/provisioning_template.py
+++ b/airgun/entities/provisioning_template.py
@@ -3,7 +3,6 @@ from widgetastic.exceptions import NoSuchElementException
 
 from airgun.entities.base import BaseEntity
 from airgun.navigation import NavigateStep, navigator
-from airgun.utils import retry_navigation
 from airgun.views.provisioning_template import (
     ProvisioningTemplateCreateView,
     ProvisioningTemplateDetailsView,
@@ -103,7 +102,6 @@ class ShowAllProvisioningTemplates(NavigateStep):
 
     VIEW = ProvisioningTemplatesView
 
-    @retry_navigation
     def step(self, *args, **kwargs):
         self.view.menu.select('Hosts', 'Templates', 'Provisioning Templates')
 

--- a/airgun/entities/puppet_class.py
+++ b/airgun/entities/puppet_class.py
@@ -1,6 +1,5 @@
 from airgun.entities.base import BaseEntity
 from airgun.navigation import NavigateStep, navigator
-from airgun.utils import retry_navigation
 from airgun.views.puppet_class import PuppetClassDetailsView, PuppetClassesView
 
 
@@ -47,7 +46,6 @@ class ShowAllPuppetClasses(NavigateStep):
 
     VIEW = PuppetClassesView
 
-    @retry_navigation
     def step(self, *args, **kwargs):
         self.view.menu.select('Configure', 'Puppet ENC', 'Classes')
 

--- a/airgun/entities/puppet_environment.py
+++ b/airgun/entities/puppet_environment.py
@@ -2,7 +2,6 @@ from navmazing import NavigateToSibling
 
 from airgun.entities.base import BaseEntity
 from airgun.navigation import NavigateStep, navigator
-from airgun.utils import retry_navigation
 from airgun.views.puppet_environment import (
     PuppetEnvironmentCreateView,
     PuppetEnvironmentImportView,
@@ -61,7 +60,6 @@ class ShowAllPuppetEnvironmentsView(NavigateStep):
 
     VIEW = PuppetEnvironmentTableView
 
-    @retry_navigation
     def step(self, *args, **kwargs):
         self.view.menu.select('Configure', 'Puppet ENC', 'Environments')
 

--- a/airgun/entities/redhat_repository.py
+++ b/airgun/entities/redhat_repository.py
@@ -1,8 +1,5 @@
-from wait_for import wait_for
-
 from airgun.entities.base import BaseEntity
 from airgun.navigation import NavigateStep, navigator
-from airgun.utils import retry_navigation
 from airgun.views.redhat_repository import RedHatRepositoriesView
 
 
@@ -18,7 +15,6 @@ class RedHatRepositoryEntity(BaseEntity):
             eg: RPM, OSTree ...
         """
         view = self.navigate_to(self, 'All')
-        wait_for(lambda: view.search_box.is_displayed, timeout=10, delay=1)
         return view.search(value, category=category, types=types)
 
     def read(self, entity_name=None, category='Available', recommended_repo=None, filter_type=None):
@@ -30,7 +26,6 @@ class RedHatRepositoryEntity(BaseEntity):
         :param filter_type: repository type such as RPM, Kickstart
         """
         view = self.navigate_to(self, 'All')
-        view.wait_displayed()
 
         view.search_by_filter_type.select('')
         if filter_type:
@@ -59,7 +54,6 @@ class RedHatRepositoryEntity(BaseEntity):
                     If custom_query is used, set entity_name to None when calling this function!!!
         """
         view = self.navigate_to(self, 'All')
-        wait_for(lambda: view.search_box.is_displayed, timeout=10, delay=1)
         custom_query = f'name = "{entity_name}"' if custom_query is None else custom_query
         view.search(custom_query, category='Available')
         arch_version = f'{arch} {version}' if version else arch
@@ -74,7 +68,6 @@ class RedHatRepositoryEntity(BaseEntity):
         :param bool orphaned: Whether the repository is Orphaned
         """
         view = self.navigate_to(self, 'All')
-        view.wait_displayed()
         view.search(f'name = "{entity_name}"', category='Enabled')
         entity_text = f'{entity_name} (Orphaned)' if orphaned else entity_name
         view.enabled.items(name=entity_text)[0].disable()
@@ -88,6 +81,5 @@ class ShowAllRepositories(NavigateStep):
 
     VIEW = RedHatRepositoriesView
 
-    @retry_navigation
     def step(self, *args, **kwargs):
         self.view.menu.select('Content', 'Red Hat Repositories')

--- a/airgun/entities/report_template.py
+++ b/airgun/entities/report_template.py
@@ -3,7 +3,6 @@ from wait_for import wait_for
 
 from airgun.entities.base import BaseEntity
 from airgun.navigation import NavigateStep, navigator
-from airgun.utils import retry_navigation
 from airgun.views.report_template import (
     ReportTemplateCreateView,
     ReportTemplateDetailsView,
@@ -87,7 +86,7 @@ class ReportTemplateEntity(BaseEntity):
         view.submit.click()
         view.flash.assert_no_error()
         view = ReportTemplateGeneratedView(self.browser)
-        view.wait_displayed()
+
         wait_for(
             lambda: view.download_button.is_displayed,
             timeout=300,
@@ -126,7 +125,6 @@ class ShowAllReportTemplates(NavigateStep):
 
     VIEW = ReportTemplatesView
 
-    @retry_navigation
     def step(self, *args, **kwargs):
         self.view.menu.select('Monitor', 'Reports', 'Report Templates')
 

--- a/airgun/entities/repository.py
+++ b/airgun/entities/repository.py
@@ -8,7 +8,6 @@ from airgun.entities.base import BaseEntity
 from airgun.entities.product import ProductEntity
 from airgun.entities.settings import SettingsEntity
 from airgun.navigation import NavigateStep, navigator
-from airgun.utils import retry_navigation
 from airgun.views.product import ProductTaskDetailsView
 from airgun.views.repository import (
     RepositoriesView,
@@ -153,7 +152,6 @@ class ShowAllRepositories(NavigateStep):
         product_name = kwargs.get('product_name')
         return self.navigate_to(ProductEntity, 'Edit', entity_name=product_name)
 
-    @retry_navigation
     def step(self, *args, **kwargs):
         self.parent.repositories.click()
 

--- a/airgun/entities/rhai/plan.py
+++ b/airgun/entities/rhai/plan.py
@@ -64,7 +64,7 @@ class PlanEntity(BaseEntity):
         """
         view = self.navigate_to(self, 'Details', entity_name=entity_name).plan(entity_name)
         view.ansible_actions.fill('Download Playbook')
-        self.browser.plugin.ensure_page_safe()
+
         return self.browser.save_downloaded_file()
 
     def export_csv(self, entity_name):
@@ -74,7 +74,7 @@ class PlanEntity(BaseEntity):
         """
         view = self.navigate_to(self, 'Details', entity_name=entity_name).plan(entity_name)
         view.export_csv.click()
-        self.browser.plugin.ensure_page_safe()
+
         return self.browser.save_downloaded_file()
 
 

--- a/airgun/entities/role.py
+++ b/airgun/entities/role.py
@@ -2,7 +2,6 @@ from navmazing import NavigateToSibling
 
 from airgun.entities.base import BaseEntity
 from airgun.navigation import NavigateStep, navigator
-from airgun.utils import retry_navigation
 from airgun.views.role import RoleCloneView, RoleCreateView, RoleEditView, RolesView
 
 
@@ -58,7 +57,6 @@ class ShowAllRoles(NavigateStep):
 
     VIEW = RolesView
 
-    @retry_navigation
     def step(self, *args, **kwargs):
         self.view.menu.select('Administer', 'Roles')
 

--- a/airgun/entities/settings.py
+++ b/airgun/entities/settings.py
@@ -1,6 +1,5 @@
 from airgun.entities.base import BaseEntity
 from airgun.navigation import NavigateStep, navigator
-from airgun.utils import retry_navigation
 from airgun.views.common import BaseLoggedInView
 from airgun.views.settings import SettingsView
 
@@ -46,6 +45,5 @@ class ShowAllSettings(NavigateStep):
 
     VIEW = SettingsView
 
-    @retry_navigation
     def step(self, *args, **kwargs):
         self.view.menu.select('Administer', 'Settings')

--- a/airgun/entities/smart_class_parameter.py
+++ b/airgun/entities/smart_class_parameter.py
@@ -1,6 +1,5 @@
 from airgun.entities.base import BaseEntity
 from airgun.navigation import NavigateStep, navigator
-from airgun.utils import retry_navigation
 from airgun.views.smart_class_parameter import (
     SmartClassParameterEditView,
     SmartClassParametersView,
@@ -37,7 +36,6 @@ class ShowAllSmartClassParameters(NavigateStep):
 
     VIEW = SmartClassParametersView
 
-    @retry_navigation
     def step(self, *args, **kwargs):
         self.view.menu.select('Configure', 'Puppet ENC', 'Smart Class Parameters')
 

--- a/airgun/entities/subnet.py
+++ b/airgun/entities/subnet.py
@@ -2,7 +2,6 @@ from navmazing import NavigateToSibling
 
 from airgun.entities.base import BaseEntity
 from airgun.navigation import NavigateStep, navigator
-from airgun.utils import retry_navigation
 from airgun.views.subnet import SubnetCreateView, SubnetEditView, SubnetsView
 
 
@@ -48,7 +47,6 @@ class ShowAllSubnets(NavigateStep):
 
     VIEW = SubnetsView
 
-    @retry_navigation
     def step(self, *args, **kwargs):
         self.view.menu.select('Infrastructure', 'Subnets')
 

--- a/airgun/entities/subscription.py
+++ b/airgun/entities/subscription.py
@@ -3,7 +3,6 @@ from wait_for import TimedOutError, wait_for
 
 from airgun.entities.base import BaseEntity
 from airgun.navigation import NavigateStep, navigator
-from airgun.utils import retry_navigation
 from airgun.views.subscription import (
     AddSubscriptionView,
     DeleteManifestConfirmationView,
@@ -248,7 +247,6 @@ class SubscriptionList(SubscriptionNavigationStep):
 
     VIEW = SubscriptionListView
 
-    @retry_navigation
     def step(self, *args, **kwargs):
         self.view.menu.select('Content', 'Subscriptions')
 

--- a/airgun/entities/sync_status.py
+++ b/airgun/entities/sync_status.py
@@ -2,7 +2,6 @@ from wait_for import wait_for
 
 from airgun.entities.base import BaseEntity
 from airgun.navigation import NavigateStep, navigator
-from airgun.utils import retry_navigation
 from airgun.views.sync_status import SyncStatusView
 
 
@@ -55,6 +54,5 @@ class SyncStatusEntity(BaseEntity):
 class ShowAllHostCollections(NavigateStep):
     VIEW = SyncStatusView
 
-    @retry_navigation
     def step(self, *args, **kwargs):
         self.view.menu.select('Content', 'Sync Status')

--- a/airgun/entities/sync_templates.py
+++ b/airgun/entities/sync_templates.py
@@ -2,7 +2,6 @@ from wait_for import wait_for
 
 from airgun.entities.base import BaseEntity
 from airgun.navigation import NavigateStep, navigator
-from airgun.utils import retry_navigation
 from airgun.views.sync_templates import SyncTemplatesView, TemplatesReportView
 
 
@@ -14,7 +13,7 @@ class SyncTemplatesEntity(BaseEntity):
         view = self.navigate_to(self, 'Sync')
         view.fill(values)
         view.submit.click()
-        self.browser.plugin.ensure_page_safe()
+
         if view.validations.messages:
             raise AssertionError(
                 f'Validation Errors are present on Page. Messages are {view.validations.messages}'
@@ -35,7 +34,6 @@ class SyncMainPageNavigation(NavigateStep):
 
     VIEW = SyncTemplatesView
 
-    @retry_navigation
     def step(self, *args, **kwargs):
         self.view.menu.select('Hosts', 'Templates', 'Sync Templates')
 

--- a/airgun/entities/syncplan.py
+++ b/airgun/entities/syncplan.py
@@ -2,7 +2,6 @@ from navmazing import NavigateToSibling
 
 from airgun.entities.base import BaseEntity
 from airgun.navigation import NavigateStep, navigator
-from airgun.utils import retry_navigation
 from airgun.views.syncplan import SyncPlanCreateView, SyncPlanEditView, SyncPlansView
 
 
@@ -74,7 +73,6 @@ class ShowAllSyncPlans(NavigateStep):
 
     VIEW = SyncPlansView
 
-    @retry_navigation
     def step(self, *args, **kwargs):
         self.view.menu.select('Content', 'Sync Plans')
 

--- a/airgun/entities/task.py
+++ b/airgun/entities/task.py
@@ -1,8 +1,5 @@
-import time
-
 from airgun.entities.base import BaseEntity
 from airgun.navigation import NavigateStep, navigator
-from airgun.utils import retry_navigation
 from airgun.views.task import TaskDetailsView, TasksView
 
 
@@ -24,7 +21,7 @@ class TaskEntity(BaseEntity):
     def read(self, entity_name, widget_names=None):
         """Read specific task values from details page"""
         view = self.navigate_to(self, 'Details', entity_name=entity_name)
-        time.sleep(3)
+
         return view.read(widget_names=widget_names)
 
     def set_chart_filter(self, chart_name, index=None):
@@ -53,7 +50,6 @@ class ShowAllTasks(NavigateStep):
 
     VIEW = TasksView
 
-    @retry_navigation
     def step(self, *args, **kwargs):
         product = (
             'Foreman' if self.view.product.is_displayed else 'Satellite'

--- a/airgun/entities/upgrade.py
+++ b/airgun/entities/upgrade.py
@@ -1,6 +1,5 @@
 from airgun.entities.base import BaseEntity
 from airgun.navigation import NavigateStep, navigator
-from airgun.utils import retry_navigation
 from airgun.views.upgrade import UpgradeView
 
 
@@ -18,6 +17,5 @@ class Upgrade(NavigateStep):
 
     VIEW = UpgradeView
 
-    @retry_navigation
     def step(self, *args, **kwargs):
         self.view.menu.select('Administer', 'Satellite Upgrade')

--- a/airgun/entities/user.py
+++ b/airgun/entities/user.py
@@ -3,7 +3,6 @@ from wait_for import wait_for
 
 from airgun.entities.base import BaseEntity
 from airgun.navigation import NavigateStep, navigator
-from airgun.utils import retry_navigation
 from airgun.views.user import UserCreateView, UserDetailsView, UsersView
 
 
@@ -67,7 +66,6 @@ class ShowAllUsers(NavigateStep):
 
     VIEW = UsersView
 
-    @retry_navigation
     def step(self, *args, **kwargs):
         self.view.menu.select('Administer', 'Users')
 

--- a/airgun/entities/usergroup.py
+++ b/airgun/entities/usergroup.py
@@ -3,7 +3,6 @@ from widgetastic.exceptions import NoSuchElementException
 
 from airgun.entities.base import BaseEntity
 from airgun.navigation import NavigateStep, navigator
-from airgun.utils import retry_navigation
 from airgun.views.usergroup import (
     UserGroupCreateView,
     UserGroupDetailsView,
@@ -62,7 +61,6 @@ class ShowAllUserGroups(NavigateStep):
 
     VIEW = UserGroupsView
 
-    @retry_navigation
     def step(self, *args, **kwargs):
         self.view.menu.select('Administer', 'User Groups')
 

--- a/airgun/entities/virtwho_configure.py
+++ b/airgun/entities/virtwho_configure.py
@@ -2,7 +2,6 @@ from navmazing import NavigateToSibling
 
 from airgun.entities.base import BaseEntity
 from airgun.navigation import NavigateStep, navigator
-from airgun.utils import retry_navigation
 from airgun.views.virtwho_configure import (
     VirtwhoConfigureCreateView,
     VirtwhoConfigureDetailsView,
@@ -97,7 +96,6 @@ class ShowAllVirtwhoConfigures(NavigateStep):
 
     VIEW = VirtwhoConfiguresView
 
-    @retry_navigation
     def step(self, *args, **kwargs):
         self.view.menu.select('Infrastructure', 'Virt-who Configurations')
 

--- a/airgun/entities/webhook.py
+++ b/airgun/entities/webhook.py
@@ -2,7 +2,6 @@ from navmazing import NavigateToSibling
 
 from airgun.entities.base import BaseEntity
 from airgun.navigation import NavigateStep, navigator
-from airgun.utils import retry_navigation
 from airgun.views.webhook import (
     DeleteWebhookConfirmationView,
     WebhookCreateView,
@@ -76,7 +75,6 @@ class ShowAllWebhooks(NavigateStep):
 
     VIEW = WebhooksView
 
-    @retry_navigation
     def step(self, *args, **kwargs):
         self.view.menu.select('Administer', 'Webhook', 'Webhooks')
 

--- a/airgun/navigation.py
+++ b/airgun/navigation.py
@@ -2,7 +2,9 @@
 
 from cached_property import cached_property
 import navmazing
+from navmazing import NavigationTriesExceeded
 from selenium.common.exceptions import NoSuchElementException
+from wait_for import TimedOutError, wait_for
 
 
 class NavigateStep(navmazing.NavigateStep):
@@ -65,28 +67,62 @@ class NavigateStep(navmazing.NavigateStep):
         :return: whether navigator is at requested destination or not.
         :rtype: bool
         """
-        entity_name = kwargs.get('entity_name')
+        # entity_name = kwargs.get('entity_name')
         try:
-            if entity_name and hasattr(self.view, 'breadcrumb'):
-                return self.view.is_displayed and self.view.breadcrumb.locations[1] in (
-                    entity_name,
-                    f'Edit {entity_name}',
-                )
+            # if entity_name and hasattr(self.view, 'breadcrumb'):
+            #     return self.view.is_displayed and self.view.breadcrumb.locations[1] in (
+            #         entity_name,
+            #         f'Edit {entity_name}',
+            #     )
             return self.view.is_displayed
         except (AttributeError, NoSuchElementException):
             return False
 
-    def go(self, _tries=0, *args, **kwargs):
-        """Wrapper around :meth:`navmazing.NavigateStep.go` which returns
-        instance of view after successful navigation flow.
+    def go(self, _tries=None, wait_for_am_i_here=True, wait_timeout=10, *args, **kwargs):
+        """Navigate with built-in retry and post-navigation validation.
 
+        :param _tries: number of navigation attempts (default: 3)
+        :param wait_for_am_i_here: whether to validate navigation succeeded by
+            waiting for am_i_here to return True (default: True)
+        :param wait_timeout: seconds to wait for validation (default: 10)
         :return: view instance if class attribute ``VIEW`` is set or ``None``
             otherwise
         """
-        super().go(*args, _tries=_tries, **kwargs)
-        self.browser.plugin.ensure_page_safe()
-        view = self.view if self.VIEW is not None else None
-        return view
+        __tracebackhide__ = True
+        max_tries = _tries if _tries is not None else getattr(self, '_default_tries', 3)
+
+        for attempt in range(0, max_tries + 1):
+            try:
+                # Call parent class navigation logic
+                super().go(*args, _tries=0, **kwargs)
+
+                # Validate navigation succeeded
+                if wait_for_am_i_here and self.VIEW is not None:
+                    wait_for(
+                        self.am_i_here,
+                        func_args=args,
+                        func_kwargs=kwargs,
+                        num_sec=wait_timeout,
+                        message=f'Waiting for am_i_here of {type(self).__name__}',
+                        handle_exception=True,
+                        raise_original=True,
+                    )
+
+                return self.view if self.VIEW is not None else None
+
+            except (TimedOutError, NoSuchElementException) as e:
+                if attempt < max_tries:
+                    if self.logger:
+                        self.logger.info(
+                            f'Navigation attempt {attempt + 1} failed: {e}, retrying...'
+                        )
+                    continue
+                else:
+                    raise
+
+        raise NavigationTriesExceeded(
+            f'{type(self.obj).__name__}, "{self._name}" - failed after {max_tries} attempts'
+        )
 
 
 class Navigate(navmazing.Navigate):

--- a/airgun/utils.py
+++ b/airgun/utils.py
@@ -1,9 +1,3 @@
-import functools
-import time
-
-from wait_for import TimedOutError
-
-
 def merge_dict(values, new_values):
     """Update dict values with new values from new_values dict
 
@@ -75,22 +69,3 @@ def get_widget_by_name(widget_root, widget_name):
                 )
         widget = getattr(widget, name)
     return widget
-
-
-def retry_navigation(method):
-    """Decorator to invoke method one or more times, if TimedOutError is raised."""
-
-    @functools.wraps(method)
-    def retry_wrapper(*args, **kwargs):
-        attempts = 3
-        for i in range(attempts):
-            try:
-                return method(*args, **kwargs)
-            except TimedOutError:
-                if i < attempts - 1:
-                    args[0].view.parent.browser.refresh()
-                    time.sleep(0.5)
-                else:
-                    raise
-
-    return retry_wrapper

--- a/airgun/views/about.py
+++ b/airgun/views/about.py
@@ -1,11 +1,11 @@
 from widgetastic.widget import Text
 
-from airgun.views.common import BaseLoggedInView, SearchableViewMixinPF4
+from airgun.views.common import BaseLoggedInView, SearchableViewMixin
 
 
-class AboutView(BaseLoggedInView, SearchableViewMixinPF4):
+class AboutView(BaseLoggedInView, SearchableViewMixin):
     title = Text("//h1[normalize-space(.)='About']")
 
     @property
     def is_displayed(self):
-        return self.browser.wait_for_element(self.title, exception=False) is not None
+        return self.title.is_displayed

--- a/airgun/views/acs.py
+++ b/airgun/views/acs.py
@@ -369,7 +369,7 @@ class AlternateContentSourcesView(BaseLoggedInView):
 
     @property
     def is_displayed(self):
-        blank_page = self.browser.wait_for_element(self.blank_page, exception=False) is not None
+        blank_page = self.blank_page.is_displayed
         table = (
             self.browser.wait_for_element(self.acs_drawer.content_table, exception=False)
             is not None

--- a/airgun/views/activationkey.py
+++ b/airgun/views/activationkey.py
@@ -37,7 +37,7 @@ class ActivationKeysView(BaseLoggedInView, SearchableViewMixin):
 
     @property
     def is_displayed(self):
-        return self.browser.wait_for_element(self.title, exception=False) is not None
+        return self.title.is_displayed
 
 
 class ActivationKeyCreateView(BaseLoggedInView):
@@ -53,9 +53,8 @@ class ActivationKeyCreateView(BaseLoggedInView):
 
     @property
     def is_displayed(self):
-        breadcrumb_loaded = self.browser.wait_for_element(self.breadcrumb, exception=False)
         return (
-            breadcrumb_loaded
+            self.breadcrumb.is_displayed
             and self.breadcrumb.locations[0] == 'Activation Keys'
             and self.breadcrumb.read() == 'New Activation Key'
         )
@@ -70,9 +69,8 @@ class ActivationKeyEditView(BaseLoggedInView):
 
     @property
     def is_displayed(self):
-        breadcrumb_loaded = self.browser.wait_for_element(self.breadcrumb, exception=False)
         return (
-            breadcrumb_loaded
+            self.breadcrumb.is_displayed
             and self.breadcrumb.locations[0] == 'Activation Keys'
             and self.breadcrumb.read() != 'New Activation Key'
         )

--- a/airgun/views/all_hosts.py
+++ b/airgun/views/all_hosts.py
@@ -31,7 +31,7 @@ from widgetastic_patternfly5.ouia import (
 from airgun.views.common import (
     BaseLoggedInView,
     PF5LCESelectorGroup,
-    SearchableViewMixinPF4,
+    SearchableViewMixin,
     WizardStepView,
 )
 from airgun.views.host_new import ManageColumnsView, PF5CheckboxTreeView
@@ -81,7 +81,7 @@ class CVESelect(Select):
     DEFAULT_LOCATOR = './/div[contains(@class, "pf-v5-c-select") and @data-ouia-component-id="select-content-view"]'
 
 
-class AllHostsTableView(BaseLoggedInView, SearchableViewMixinPF4):
+class AllHostsTableView(BaseLoggedInView, SearchableViewMixin):
     title = Text('//h1[normalize-space(.)="Hosts"]')
 
     legacy_kebab = PF5Dropdown(locator='.//div[@id="legacy-ui-kebab"]')
@@ -90,6 +90,8 @@ class AllHostsTableView(BaseLoggedInView, SearchableViewMixinPF4):
         locator='.//input[@data-ouia-component-id="select-all-checkbox-dropdown-toggle-checkbox"]'
     )
     searchbar_dropdown = PF5OUIADropdown('selection-checkbox')
+    # searchbox = SearchInput(locator='.//input[@aria-label="Search input"]')
+
     top_bulk_actions = MenuToggleDropdownInTable(locator='.//button[@aria-label="plain kebab"]')
     bulk_actions = AllHostsMenu()
     bulk_actions_kebab = Button(locator='.//button[@aria-label="plain kebab"]')
@@ -103,7 +105,6 @@ class AllHostsTableView(BaseLoggedInView, SearchableViewMixinPF4):
         locator='//li[contains(@class, "pf-v5-c-menu__list-item")]//button[span/span[text()="Change associations"]]/following-sibling::div[contains(@class, "pf-v5-c-menu")]'
     )
 
-    table_loading = Text('//h5[normalize-space(.)="Loading"]')
     no_results = Text('//h5[normalize-space(.)="No Results"]')
     manage_columns = PF5Button('Manage columns')
     table = PF5OUIATable(
@@ -125,10 +126,7 @@ class AllHostsTableView(BaseLoggedInView, SearchableViewMixinPF4):
 
     @property
     def is_displayed(self):
-        return (
-            self.browser.wait_for_element(self.table_loading, exception=False) is None
-            and self.browser.wait_for_element(self.table, exception=False) is not None
-        )
+        return self.table.is_displayed
 
 
 class HostDeleteDialog(View):
@@ -143,7 +141,7 @@ class HostDeleteDialog(View):
 
     @property
     def is_displayed(self):
-        return self.browser.wait_for_element(self.title, exception=False) is not None
+        return self.title.is_displayed
 
 
 class BuildManagementDialog(View):
@@ -164,7 +162,7 @@ class BuildManagementDialog(View):
 
     @property
     def is_displayed(self):
-        return self.browser.wait_for_element(self.title, exception=False) is not None
+        return self.title.is_displayed
 
 
 class BulkHostDeleteDialog(View):
@@ -180,7 +178,7 @@ class BulkHostDeleteDialog(View):
 
     @property
     def is_displayed(self):
-        return self.browser.wait_for_element(self.title, exception=False) is not None
+        return self.title.is_displayed
 
 
 class HostgroupDialog(View):
@@ -198,7 +196,7 @@ class HostgroupDialog(View):
 
     @property
     def is_displayed(self):
-        return self.browser.wait_for_element(self.title, exception=False) is not None
+        return self.title.is_displayed
 
 
 class AllHostsCheckboxTreeView(PF5CheckboxTreeView):
@@ -242,7 +240,7 @@ class ManageCVEModal(PF5Modal):
 
     @property
     def is_displayed(self):
-        return self.browser.wait_for_element(self.title, exception=False) is not None
+        return self.title.is_displayed
 
 
 class ManagePackagesModal(PF5Modal):
@@ -389,7 +387,7 @@ class ManagePackagesModal(PF5Modal):
 
     @property
     def is_displayed(self):
-        return self.browser.wait_for_element(self.title, exception=False) is not None
+        return self.title.is_displayed
 
 
 class ManageErrataModal(PF5Modal):
@@ -488,7 +486,7 @@ class ManageErrataModal(PF5Modal):
 
     @property
     def is_displayed(self):
-        return self.browser.wait_for_element(self.title, exception=False) is not None
+        return self.title.is_displayed
 
 
 class RepositorySetsMenu(PF5Dropdown):
@@ -601,7 +599,7 @@ class ManageRepositorySetsModal(PF5Modal):
 
     @property
     def is_displayed(self):
-        return self.browser.wait_for_element(self.title, exception=False) is not None
+        return self.title.is_displayed
 
 
 class DisassociateHostsModal(PF5Modal):
@@ -620,7 +618,7 @@ class DisassociateHostsModal(PF5Modal):
 
     @property
     def is_displayed(self):
-        return self.browser.wait_for_element(self.title, exception=False) is not None
+        return self.title.is_displayed
 
 
 class MenuToggleSelect(PF5Select):
@@ -676,7 +674,7 @@ class ChangeHostsOwnerModal(PF5Modal):
 
     @property
     def is_displayed(self):
-        return self.browser.wait_for_element(self.title, exception=False) is not None
+        return self.title.is_displayed
 
 
 class BaseChangeOrgLocModal(PF5Modal):
@@ -697,7 +695,7 @@ class BaseChangeOrgLocModal(PF5Modal):
 
     @property
     def is_displayed(self):
-        return self.browser.wait_for_element(self.title, exception=False) is not None
+        return self.title.is_displayed
 
 
 class ChangeOrganizationModal(BaseChangeOrgLocModal):
@@ -769,7 +767,7 @@ class ChangeHostCollectionsModal(PF5Modal):
 
     @property
     def is_displayed(self):
-        return self.browser.wait_for_element(self.title, exception=False) is not None
+        return self.title.is_displayed
 
 
 class ManageTracesModal(PF5Modal):
@@ -811,7 +809,7 @@ class ManageTracesModal(PF5Modal):
 
     @property
     def is_displayed(self):
-        return self.browser.wait_for_element(self.title, exception=False) is not None
+        return self.title.is_displayed
 
 
 class ManageSystemPurposeModal(PF5Modal):
@@ -836,4 +834,4 @@ class ManageSystemPurposeModal(PF5Modal):
 
     @property
     def is_displayed(self):
-        return self.browser.wait_for_element(self.title, exception=False) is not None
+        return self.title.is_displayed

--- a/airgun/views/ansible_variable.py
+++ b/airgun/views/ansible_variable.py
@@ -1,7 +1,7 @@
 from widgetastic.widget import Checkbox, Select, Text, TextInput, View
 from widgetastic_patternfly import BreadCrumb
 
-from airgun.views.common import BaseLoggedInView, SatTable, SearchableViewMixinPF4
+from airgun.views.common import BaseLoggedInView, SatTable, SearchableViewMixin
 from airgun.widgets import (
     CustomParameter,
     FilteredDropdown,
@@ -10,7 +10,7 @@ from airgun.widgets import (
 )
 
 
-class AnsibleVariablesView(BaseLoggedInView, SearchableViewMixinPF4):
+class AnsibleVariablesView(BaseLoggedInView, SearchableViewMixin):
     """Main Ansible Variables view"""
 
     title = Text("//h1[contains(normalize-space(.),'Ansible Variables')]")

--- a/airgun/views/architecture.py
+++ b/airgun/views/architecture.py
@@ -1,11 +1,11 @@
 from widgetastic.widget import Table, Text, TextInput
 from widgetastic_patternfly import BreadCrumb
 
-from airgun.views.common import BaseLoggedInView, SearchableViewMixinPF4
+from airgun.views.common import BaseLoggedInView, SearchableViewMixin
 from airgun.widgets import MultiSelect
 
 
-class ArchitecturesView(BaseLoggedInView, SearchableViewMixinPF4):
+class ArchitecturesView(BaseLoggedInView, SearchableViewMixin):
     title = Text("//h1[normalize-space(.)='Architectures']")
     new = Text("//a[contains(@href, '/architectures/new')]")
     table = Table(
@@ -18,7 +18,7 @@ class ArchitecturesView(BaseLoggedInView, SearchableViewMixinPF4):
 
     @property
     def is_displayed(self):
-        return self.browser.wait_for_element(self.title, exception=False) is not None
+        return self.title.is_displayed
 
 
 class ArchitectureDetailsView(BaseLoggedInView):
@@ -29,9 +29,8 @@ class ArchitectureDetailsView(BaseLoggedInView):
 
     @property
     def is_displayed(self):
-        breadcrumb_loaded = self.browser.wait_for_element(self.breadcrumb, exception=False)
         return (
-            breadcrumb_loaded
+            self.breadcrumb.is_displayed
             and self.breadcrumb.locations[0] == 'Architectures'
             and self.breadcrumb.read().startswith('Edit ')
         )
@@ -40,9 +39,8 @@ class ArchitectureDetailsView(BaseLoggedInView):
 class ArchitectureCreateView(ArchitectureDetailsView):
     @property
     def is_displayed(self):
-        breadcrumb_loaded = self.browser.wait_for_element(self.breadcrumb, exception=False)
         return (
-            breadcrumb_loaded
+            self.breadcrumb.is_displayed
             and self.breadcrumb.locations[0] == 'Architectures'
             and self.breadcrumb.read() == 'Create Architecture'
         )

--- a/airgun/views/audit.py
+++ b/airgun/views/audit.py
@@ -1,7 +1,7 @@
 from widgetastic.widget import Text, View
 
 from airgun.exceptions import ReadOnlyWidgetError
-from airgun.views.common import BaseLoggedInView, SearchableViewMixinPF4
+from airgun.views.common import BaseLoggedInView, SearchableViewMixin
 from airgun.widgets import SatTableWithoutHeaders
 
 
@@ -31,10 +31,10 @@ class AuditEntry(View):
         raise ReadOnlyWidgetError('View is read only, fill is prohibited')
 
 
-class AuditsView(BaseLoggedInView, SearchableViewMixinPF4):
+class AuditsView(BaseLoggedInView, SearchableViewMixin):
     title = Text("//h1[normalize-space(.)='Audits']")
     table = AuditEntry()
 
     @property
     def is_displayed(self):
-        return self.browser.wait_for_element(self.title, exception=False) is not None
+        return self.title.is_displayed

--- a/airgun/views/bookmark.py
+++ b/airgun/views/bookmark.py
@@ -1,11 +1,11 @@
 from widgetastic.widget import Checkbox, Text, TextInput
 from widgetastic_patternfly import BreadCrumb
 
-from airgun.views.common import BaseLoggedInView, SearchableViewMixinPF4
+from airgun.views.common import BaseLoggedInView, SearchableViewMixin
 from airgun.widgets import SatTable
 
 
-class BookmarksView(BaseLoggedInView, SearchableViewMixinPF4):
+class BookmarksView(BaseLoggedInView, SearchableViewMixin):
     title = Text("//h1[normalize-space(.)='Bookmarks']")
     table = SatTable(
         './/table',
@@ -17,7 +17,7 @@ class BookmarksView(BaseLoggedInView, SearchableViewMixinPF4):
 
     @property
     def is_displayed(self):
-        return self.browser.wait_for_element(self.title, exception=False) is not None
+        return self.title.is_displayed
 
 
 class BookmarkEditView(BaseLoggedInView):
@@ -30,9 +30,8 @@ class BookmarkEditView(BaseLoggedInView):
 
     @property
     def is_displayed(self):
-        breadcrumb_loaded = self.browser.wait_for_element(self.breadcrumb, exception=False)
         return (
-            breadcrumb_loaded
+            self.breadcrumb.is_displayed
             and self.breadcrumb.locations[0] == 'Bookmarks'
             and self.breadcrumb.read().startswith('Edit')
         )

--- a/airgun/views/bootc.py
+++ b/airgun/views/bootc.py
@@ -3,11 +3,11 @@ from widgetastic_patternfly4.ouia import ExpandableTable
 
 from airgun.views.common import (
     BaseLoggedInView,
-    SearchableViewMixinPF4,
+    SearchableViewMixin,
 )
 
 
-class BootedContainerImagesView(BaseLoggedInView, SearchableViewMixinPF4):
+class BootedContainerImagesView(BaseLoggedInView, SearchableViewMixin):
     title = Text('.//h1[@data-ouia-component-id="header-text"]')
 
     # This represents the contents of the expanded table rows

--- a/airgun/views/capsule.py
+++ b/airgun/views/capsule.py
@@ -25,7 +25,7 @@ from widgetastic_patternfly5.ouia import (
 from airgun.views.common import (
     BaseLoggedInView,
     SatTab,
-    SearchableViewMixinPF4,
+    SearchableViewMixin,
 )
 from airgun.widgets import (
     ActionsDropdown,
@@ -253,7 +253,7 @@ class CapsuleDetailsView(BaseLoggedInView):
             return result
 
 
-class CapsulesView(BaseLoggedInView, SearchableViewMixinPF4):
+class CapsulesView(BaseLoggedInView, SearchableViewMixin):
     """Class that describes the Capsule Details page"""
 
     title = Text('//h1[normalize-space(.)="Capsules"]')
@@ -278,4 +278,4 @@ class CapsulesView(BaseLoggedInView, SearchableViewMixinPF4):
 
     @property
     def is_displayed(self):
-        return self.browser.wait_for_element(self.title, exception=False) is not None
+        return self.title.is_displayed

--- a/airgun/views/cloud_inventory.py
+++ b/airgun/views/cloud_inventory.py
@@ -139,7 +139,7 @@ class CloudInventoryListView(BaseLoggedInView):
 
     @property
     def is_displayed(self):
-        return self.browser.wait_for_element(self.title, exception=False) is not None
+        return self.title.is_displayed
 
     def read(self, widget_names=None):
         final_dict = {

--- a/airgun/views/cloud_vulnerabilities.py
+++ b/airgun/views/cloud_vulnerabilities.py
@@ -51,7 +51,7 @@ class CloudVulnerabilityView(BaseLoggedInView):
 
     @property
     def is_displayed(self):
-        return self.browser.wait_for_element(self.title, exception=False) is not None
+        return self.title.is_displayed
 
 
 class CVEDetailsView(BaseLoggedInView):
@@ -72,4 +72,4 @@ class CVEDetailsView(BaseLoggedInView):
 
     @property
     def is_displayed(self):
-        return self.browser.wait_for_element(self.title, exception=False) is not None
+        return self.title.is_displayed

--- a/airgun/views/common.py
+++ b/airgun/views/common.py
@@ -1,4 +1,8 @@
+from contextlib import contextmanager
+import time
+
 from selenium.common.exceptions import ElementNotInteractableException
+from wait_for import wait_for
 from widgetastic.widget import (
     Checkbox,
     ConditionalSwitchableView,
@@ -13,7 +17,10 @@ from widgetastic.widget import (
 from widgetastic_patternfly import BreadCrumb, Tab, TabWithDropdown
 from widgetastic_patternfly4 import Button
 from widgetastic_patternfly4.navigation import Navigation
-from widgetastic_patternfly5 import Dropdown as PF5Dropdown
+from widgetastic_patternfly5 import (
+    Button as PF5Button,
+    Dropdown,
+)
 from widgetastic_patternfly5.ouia import (
     Dropdown as PF5OUIADropdown,
     PatternflyTable,
@@ -29,7 +36,6 @@ from airgun.widgets import (
     ItemsList,
     LCESelector,
     Pf4ConfirmationDialog,
-    PF4Search,
     PF5LCECheckSelector,
     PF5LCESelector,
     PF5NavSearch,
@@ -148,7 +154,7 @@ class WrongContextAlert(View):
 
     @property
     def is_displayed(self):
-        return self.browser.wait_for_element(self.message, exception=False) is not None
+        return self.message.is_displayed
 
 
 class SatTab(Tab):
@@ -349,7 +355,7 @@ class PF5LCECheckSelectorGroup(PF5LCESelectorGroup):
 
 
 # PF5 kebab menu present in table rows
-class TableRowKebabMenu(PF5Dropdown):
+class TableRowKebabMenu(Dropdown):
     """Dropdown for PF5 kebab menus used in table rows."""
 
     ROOT = '.'
@@ -371,11 +377,112 @@ class PF5LCEGroup(ParametrizedLocator):
     )
 
 
-class ListRemoveTab(SatSecondaryTab):
+class SearchableViewMixin(WTMixin):
+    """Enhanced searchable table mixin with debounce delay for PatternFly UIs.
+
+    Adds explicit SEARCH_DELAY to handle delay between search input and query before updating table.
+
+    This mixin requires views to have:
+    - table attribute (any table widget)
+    - searchbox attribute (Search or custom search widget)
+
+    Optional attributes:
+    - clear_button: Button widget for "Reset filters" or "Clear filters"
+
+    Configuration flags:
+    - SEARCH_DELAY: Debounce delay in seconds (default: 0)
+
+    Usage:
+        class MyView(BaseLoggedInView, SearchableViewMixin):
+            SEARCH_DELAY = 1
+
+            searchbox = Search()  # or any search widget
+            table = Table(...)
+            clear_button = Button('Reset filters')  # optional
+    """
+
+    SEARCH_DELAY = 0  # Default debounce delay after last user input, if search is immediate
+
+    # PatternFly loading indicators
+    LOADING = (
+        './/table[@aria-label="Loading"] | '  # legacy pattern
+        './/div[contains(@class, "pf-v5-c-skeleton")] | '  # PF5 skeleton component
+        './/td[contains(@class, "pf-v5-c-skeleton")]'  # PF5 skeleton table cells
+    )
+    TABLE_EMPTY_STATE = './/div[contains(@class, "-c-empty-state")]'
+
+    # root locator for the search toolbar
+    TOOLBAR = (
+        '(.//div[contains(@class, "foreman-search-bar")] | '
+        './/div[@data-ouia-component-id="table-toolbar"] | '
+        './/div[contains(@class, "toolbar-pf")] | '
+        './/div[@id="ins-primary-data-toolbar"])'
+    )
+
+    column_selector = Dropdown(
+        locator=f'{TOOLBAR}//div[contains(@class, "ins-c-conditional-filter")]'
+    )
+
+    searchbox = Search()
+
+    _reset_filters = PF5Button('Reset filters')
+    _clear_filters = PF5Button('Clear filters')
+
+    @property
+    def table(self):
+        """
+        You must define the table widget in any View that inherits this
+        """
+        raise NotImplementedError
+
+    def search(self, query):
+        """Fill search component with the given query."""
+
+        fill_widget = self.searchbox
+        fill_value = query
+
+        fill_widget.wait_displayed()
+        current_value = fill_widget.read()
+
+        if current_value == fill_value:
+            self.logger.debug(
+                'Search input field already matches the given query. Leaving it unchanged.'
+            )
+            return
+
+        with self.ensure_table_reloads():
+            fill_widget.search(fill_value)
+
+        # TODO find better fix to dismiss the query dropdown, like click 'Esc'
+        # if hasattr(self, 'title'):
+        #     self.title.click()
+
+        return self.table.read()
+
+    def _wait_for_table_load(self, timeout):
+        def _loaded():
+            if self.browser.elements(self.LOADING):
+                return False
+            elif self.table.is_displayed:
+                return True
+            return False
+
+        # Wait for "debounce" delay after search field input.
+        if self.SEARCH_DELAY:
+            time.sleep(self.SEARCH_DELAY)
+
+        wait_for(_loaded, delay=0.2, num_sec=timeout)
+
+    @contextmanager
+    def ensure_table_reloads(self, timeout=10):
+        yield
+        self._wait_for_table_load(timeout)
+
+
+class ListRemoveTab(SatSecondaryTab, SearchableViewMixin):
     """'List/Remove' tab, part of :class:`AddRemoveResourcesView`."""
 
     TAB_NAME = 'List/Remove'
-    searchbox = Search()
     remove_button = Text(
         './/div[@data-block="list-actions"]//button[contains(@ng-click, "remove")]'
     )
@@ -385,12 +492,12 @@ class ListRemoveTab(SatSecondaryTab):
 
     def search(self, value):
         """Search for specific associated resource and return the results"""
-        self.searchbox.search(value)
+        super().search(value)
         return self.table.read()
 
     def remove(self, value):
         """Remove specific associated resource"""
-        self.search(value)
+        super().search(value)
         next(self.table.rows())[0].widget.fill(True)
         self.remove_button.click()
 
@@ -406,9 +513,8 @@ class ListRemoveTab(SatSecondaryTab):
         return self.table.read()
 
 
-class AddTab(SatSecondaryTab):
+class AddTab(SatSecondaryTab, SearchableViewMixin):
     TAB_NAME = 'Add'
-    searchbox = Search()
     add_button = Text('.//div[@data-block="list-actions"]//button[contains(@ng-click, "add")]')
     table = SatTable(
         locator='.//table', column_widgets={0: Checkbox(locator=".//input[@type='checkbox']")}
@@ -416,12 +522,12 @@ class AddTab(SatSecondaryTab):
 
     def search(self, value):
         """Search for specific available resource and return the results"""
-        self.searchbox.search(value)
+        super().search(value)
         return self.table.read()
 
     def add(self, value):
         """Associate specific resource"""
-        self.search(value)
+        super().search(value)
         next(self.table.rows())[0].widget.fill(True)
         self.add_button.click()
 
@@ -476,8 +582,7 @@ class AddRemoveResourcesView(View):
         }
 
 
-class NewAddRemoveResourcesView(View):
-    searchbox = PF4Search()
+class NewAddRemoveResourcesView(View, SearchableViewMixin):
     status = PF5OUIASelect(component_id='select Status')
     remove_button = PF5OUIADropdown(component_id='repositoies-bulk-actions')
     add_button = Button(locator='.//button[@data-ouia-component-id="add-repositories"]')
@@ -500,8 +605,8 @@ class NewAddRemoveResourcesView(View):
 
     def search(self, value):
         """Search for specific available resource and return the results"""
-        self.searchbox.search(value)
-        return self.read()
+        super().search(value)
+        return self.table.read()
 
     def add(self, value):
         """Associate specific resource"""
@@ -527,12 +632,6 @@ class NewAddRemoveResourcesView(View):
 
     def read(self):
         """Read all table values from both resource tables"""
-        self.browser.wait_for_element(locator='//h4[text()="Loading"]', exception=False)
-        self.browser.wait_for_element(
-            self.table, exception=False, ensure_page_safe=True, timeout=10
-        )
-        self.browser.plugin.ensure_page_safe(timeout='60s')
-        self.table.wait_displayed()
         self.select_status('All')
         return self.table.read()
 
@@ -588,93 +687,6 @@ class TemplateEditor(View):
         super().fill(values)
 
 
-class SearchableViewMixin(WTMixin):
-    """Mixin which adds :class:`airgun.widgets.Search` widget and
-    :meth:`airgun.widgets.Search.search` to your view. It's useful for _most_ entities list views
-    where searchbox and results table are present.
-
-    Note that class which uses this mixin should have :attr: `table` attribute.
-    """
-
-    searchbox = Search()
-    welcome_message = Text("//div[@class='blank-slate-pf' or @id='welcome']")
-
-    def is_searchable(self):
-        """Verify that search procedure can be executed against specific page.
-        That means that we have search field present on the page and that page
-        is not a welcome one
-        """
-        if self.searchbox.search_field.is_displayed and (not self.welcome_message.is_displayed):
-            return True
-        return False
-
-    def search(self, query):
-        """Perform search using searchbox on the page and return table
-        contents.
-
-        :param str query: search query to type into search field. E.g. ``foo``
-            or ``name = "bar"``.
-        :return: list of dicts representing table rows
-        :rtype: list
-        """
-        if not hasattr(self.__class__, 'table'):
-            raise AttributeError(
-                f'Class {self.__class__.__name__} does not have attribute "table". '
-                'SearchableViewMixin only works with views, which have table for results. '
-                'Please define table or use custom search implementation instead'
-            )
-        if not self.is_searchable():
-            return None
-        self.searchbox.search(query)
-        if hasattr(self, 'title'):
-            self.title.click()
-        return self.table.read()
-
-
-class SearchableViewMixinPF4(SearchableViewMixin):
-    """Mixin which adds :class:`airgun.widgets.Search` widget and
-    :meth:`airgun.widgets.Search.search` to your view. It's useful for _most_ entities list views
-
-    where searchbox and results table are present.
-    Note that class which uses this mixin should have :attr: `table` attribute.
-    """
-
-    searchbox = PF4Search()
-    blank_page = Text("//div[contains(@class, 'pf-c-empty-state')]")
-
-    def is_searchable(self):
-        """Verify that search procedure can be executed against specific page
-        that is not blank
-        """
-        if self.searchbox.search_field.is_displayed and (not self.blank_page.is_displayed):
-            return True
-        return False
-
-    def search(self, query):
-        """Perform search using searchbox on the page and return table
-        contents.
-
-        :param str query: search query to type into search field. E.g. ``foo``
-            or ``name = "bar"``.
-        :return: list of dicts representing table rows
-        :rtype: list
-        """
-        if not hasattr(self.__class__, 'table'):
-            raise AttributeError(
-                f'Class {self.__class__.__name__} does not have attribute "table". '
-                'SearchableViewMixin only works with views, which have table for results. '
-                'Please define table or use custom search implementation instead'
-            )
-        if not self.is_searchable():
-            return None
-        self.searchbox.search(query)
-        self.browser.plugin.ensure_page_safe(timeout='60s')
-        if hasattr(self, 'title'):
-            self.title.click()
-        self.table.wait_displayed()
-        return self.table.read()
-
-
 class TaskDetailsView(BaseLoggedInView):
     """Common view for task details screen. Can be found for most of tasks for
     various entities like Products, Repositories, Errata etc.
@@ -722,7 +734,7 @@ class BookmarkCreateView(BaseLoggedInView):
 
     @property
     def is_displayed(self):
-        return self.browser.wait_for_element(self.title, exception=False) is not None
+        return self.title.is_displayed
 
 
 class TemplateInputItem(GenericRemovableWidgetItem):

--- a/airgun/views/computeprofile.py
+++ b/airgun/views/computeprofile.py
@@ -1,11 +1,11 @@
 from widgetastic.widget import Table, Text, TextInput
 from widgetastic_patternfly import BreadCrumb
 
-from airgun.views.common import BaseLoggedInView, SearchableViewMixinPF4
+from airgun.views.common import BaseLoggedInView, SearchableViewMixin
 from airgun.widgets import ActionsDropdown
 
 
-class ComputeProfilesView(BaseLoggedInView, SearchableViewMixinPF4):
+class ComputeProfilesView(BaseLoggedInView, SearchableViewMixin):
     title = Text('//*[(self::h1 or self::h5) and normalize-space(.)="Compute Profiles"]')
     new = Text('//a[normalize-space(.)="Create Compute Profile"]')
     table = Table(
@@ -18,7 +18,7 @@ class ComputeProfilesView(BaseLoggedInView, SearchableViewMixinPF4):
 
     @property
     def is_displayed(self):
-        return self.browser.wait_for_element(self.title, exception=False) is not None
+        return self.title.is_displayed
 
 
 class ComputeProfileCreateView(BaseLoggedInView):
@@ -28,9 +28,8 @@ class ComputeProfileCreateView(BaseLoggedInView):
 
     @property
     def is_displayed(self):
-        breadcrumb_loaded = self.browser.wait_for_element(self.breadcrumb, exception=False)
         return (
-            breadcrumb_loaded
+            self.breadcrumb.is_displayed
             and self.breadcrumb.locations[0] == 'Compute Profiles'
             and self.breadcrumb.read() == 'Create Compute Profile'
         )
@@ -47,9 +46,8 @@ class ComputeProfileDetailView(BaseLoggedInView):
 
     @property
     def is_displayed(self):
-        breadcrumb_loaded = self.browser.wait_for_element(self.breadcrumb, exception=False)
         return (
-            breadcrumb_loaded
+            self.breadcrumb.is_displayed
             and self.breadcrumb.locations[0] == 'Compute Profiles'
             and self.breadcrumb.read() != 'Create Compute Profile'
             and self.breadcrumb.read() != 'Edit Compute Profile'
@@ -59,9 +57,8 @@ class ComputeProfileDetailView(BaseLoggedInView):
 class ComputeProfileRenameView(ComputeProfileCreateView):
     @property
     def is_displayed(self):
-        breadcrumb_loaded = self.browser.wait_for_element(self.breadcrumb, exception=False)
         return (
-            breadcrumb_loaded
+            self.breadcrumb.is_displayed
             and self.breadcrumb.locations[0] == 'Compute profiles'
             and self.breadcrumb.read() == 'Edit Compute profile'
         )

--- a/airgun/views/computeresource.py
+++ b/airgun/views/computeresource.py
@@ -15,7 +15,6 @@ from airgun.views.common import (
     BaseLoggedInView,
     SatTab,
     SearchableViewMixin,
-    SearchableViewMixinPF4,
 )
 from airgun.views.host import HostCreateView
 from airgun.widgets import (
@@ -29,7 +28,7 @@ from airgun.widgets import (
 )
 
 
-class ComputeResourcesView(BaseLoggedInView, SearchableViewMixinPF4):
+class ComputeResourcesView(BaseLoggedInView, SearchableViewMixin):
     title = Text('//*[(self::h1 or self::h5) and normalize-space(.)="Compute Resources"]')
     new = Text('//a[normalize-space(.)="Create Compute Resource"]')
     table = SatTable(
@@ -43,7 +42,7 @@ class ComputeResourcesView(BaseLoggedInView, SearchableViewMixinPF4):
     @property
     def is_displayed(self):
         """Check if the right page is displayed"""
-        return self.browser.wait_for_element(self.title, exception=False) is not None
+        return self.title.is_displayed
 
 
 class ResourceProviderCreateView(BaseLoggedInView):
@@ -140,9 +139,8 @@ class ResourceProviderCreateView(BaseLoggedInView):
 
     @property
     def is_displayed(self):
-        breadcrumb_loaded = self.browser.wait_for_element(self.breadcrumb, exception=False)
         return (
-            breadcrumb_loaded
+            self.breadcrumb.is_displayed
             and self.breadcrumb.locations[0] == 'Compute Resources'
             and self.breadcrumb.read() == 'Create Compute Resource'
         )
@@ -151,9 +149,8 @@ class ResourceProviderCreateView(BaseLoggedInView):
 class ResourceProviderEditView(ResourceProviderCreateView):
     @property
     def is_displayed(self):
-        breadcrumb_loaded = self.browser.wait_for_element(self.breadcrumb, exception=False)
         return (
-            breadcrumb_loaded
+            self.breadcrumb.is_displayed
             and self.breadcrumb.locations[0] == 'Compute Resources'
             and self.breadcrumb.read().startswith('Edit ')
         )
@@ -166,9 +163,8 @@ class ResourceProviderDetailView(BaseLoggedInView):
 
     @property
     def is_displayed(self):
-        breadcrumb_loaded = self.browser.wait_for_element(self.breadcrumb, exception=False)
         return (
-            breadcrumb_loaded
+            self.breadcrumb.is_displayed
             and self.breadcrumb.locations[0] == 'Compute Resources'
             and self.breadcrumb.read() != 'Create Compute Resource'
         )
@@ -380,16 +376,11 @@ class ResourceProviderProfileView(BaseLoggedInView):
 
     @property
     def is_displayed(self):
-        breadcrumb_loaded = self.browser.wait_for_element(
-            self.breadcrumb, exception=False, ensure_page_safe=True, timeout=10
-        )
-        if not breadcrumb_loaded:
-            return False
-        breadcrumb_text = self.breadcrumb.read()
         return (
-            self.breadcrumb.locations[0] == 'Compute Resources'
+            self.breadcrumb.is_displayed
+            and self.breadcrumb.locations[0] == 'Compute Resources'
             and self.breadcrumb.locations[2] == 'Compute Profiles'
-            and (breadcrumb_text.startswith('Edit ') or breadcrumb_text.startswith('New '))
+            and self.breadcrumb.read().startswith(('Edit ', 'New '))
         )
 
 
@@ -398,9 +389,8 @@ class ResourceProviderVMImport(HostCreateView):
 
     @property
     def is_displayed(self):
-        breadcrumb_loaded = self.browser.wait_for_element(self.breadcrumb, exception=False)
         return (
-            breadcrumb_loaded
+            self.breadcrumb.is_displayed
             and self.breadcrumb.locations[0] == 'Compute Resources Vms'
             and self.breadcrumb.read().startswith('Import ')
         )
@@ -421,11 +411,8 @@ class ComputeResourceGenericImageCreateView(BaseLoggedInView):
 
     @property
     def is_displayed(self):
-        breadcrumb_loaded = self.browser.wait_for_element(
-            self.breadcrumb, exception=False, ensure_page_safe=True, timeout=10
-        )
         return (
-            breadcrumb_loaded
+            self.breadcrumb.is_displayed
             and self.breadcrumb.locations[0] == 'Compute Resources'
             and self.breadcrumb.locations[2] == 'Images'
             and self.breadcrumb.read() == 'Create image'
@@ -437,11 +424,8 @@ class ComputeResourceGenericImageEditViewMixin:
 
     @property
     def is_displayed(self):
-        breadcrumb_loaded = self.browser.wait_for_element(
-            self.breadcrumb, exception=False, ensure_page_safe=True, timeout=10
-        )
         return (
-            breadcrumb_loaded
+            self.breadcrumb.is_displayed
             and self.breadcrumb.locations[0] == 'Compute Resources'
             and self.breadcrumb.locations[2] == 'Images'
             and self.breadcrumb.read().startswith('Edit ')

--- a/airgun/views/config_report.py
+++ b/airgun/views/config_report.py
@@ -17,7 +17,7 @@ class ConfigReportsView(BaseLoggedInView, SearchableViewMixin):
 
     @property
     def is_displayed(self):
-        return self.browser.wait_for_element(self.title, exception=False) is not None
+        return self.title.is_displayed
 
 
 class ConfigReportDetailsView(BaseLoggedInView):
@@ -25,7 +25,7 @@ class ConfigReportDetailsView(BaseLoggedInView):
 
     @property
     def is_displayed(self):
-        breadcrumb_loaded = self.browser.wait_for_element(self.breadcrumb, exception=False)
+        breadcrumb_loaded = self.breadcrumb.is_displayed
         return breadcrumb_loaded and self.breadcrumb.locations[0] == 'Config Reports'
 
     delete = Button('Delete')

--- a/airgun/views/configgroup.py
+++ b/airgun/views/configgroup.py
@@ -18,7 +18,7 @@ class ConfigGroupsView(BaseLoggedInView, SearchableViewMixin):
 
     @property
     def is_displayed(self):
-        return self.browser.wait_for_element(self.title, exception=False) is not None
+        return self.title.is_displayed
 
 
 class ConfigGroupCreateView(BaseLoggedInView):
@@ -29,9 +29,8 @@ class ConfigGroupCreateView(BaseLoggedInView):
 
     @property
     def is_displayed(self):
-        breadcrumb_loaded = self.browser.wait_for_element(self.breadcrumb, exception=False)
         return (
-            breadcrumb_loaded
+            self.breadcrumb.is_displayed
             and self.breadcrumb.locations[0] == 'Config Groups'
             and self.breadcrumb.locations[1] == 'Create Config Group'
         )
@@ -40,9 +39,8 @@ class ConfigGroupCreateView(BaseLoggedInView):
 class ConfigGroupEditView(ConfigGroupCreateView):
     @property
     def is_displayed(self):
-        breadcrumb_loaded = self.browser.wait_for_element(self.breadcrumb, exception=False)
         return (
-            breadcrumb_loaded
+            self.breadcrumb.is_displayed
             and self.breadcrumb.locations[0] == 'Config Groups'
             and self.breadcrumb.read().startswith('Edit ')
         )

--- a/airgun/views/containerimages.py
+++ b/airgun/views/containerimages.py
@@ -8,7 +8,7 @@ from widgetastic_patternfly5.ouia import (
 )
 
 from airgun.views.all_hosts import MenuToggleDropdownInTable
-from airgun.views.common import BaseLoggedInView, PF4Search
+from airgun.views.common import BaseLoggedInView, SearchableViewMixin
 from airgun.widgets import CompoundExpandableTable  # Import the new widget
 
 
@@ -26,9 +26,8 @@ class SyncedContainerPullablePath(View):
     )
 
 
-class ContainerImagesView(BaseLoggedInView):
+class ContainerImagesView(BaseLoggedInView, SearchableViewMixin):
     title = PF5OUIATitle('container-images-title')
-    searchbox = PF4Search()
 
     # Passing in the nested table as content_view, refer to ExpandableTable docs for info
     table = CompoundExpandableTable(

--- a/airgun/views/containerimagetag.py
+++ b/airgun/views/containerimagetag.py
@@ -17,7 +17,7 @@ class ContainerImageTagsView(BaseLoggedInView, SearchableViewMixin):
 
     @property
     def is_displayed(self):
-        return self.browser.wait_for_element(self.title, exception=False) is not None
+        return self.title.is_displayed
 
 
 class ContainerImageTagDetailsView(TaskDetailsView):
@@ -26,9 +26,8 @@ class ContainerImageTagDetailsView(TaskDetailsView):
 
     @property
     def is_displayed(self):
-        breadcrumb_loaded = self.browser.wait_for_element(self.breadcrumb, exception=False)
         return (
-            breadcrumb_loaded
+            self.breadcrumb.is_displayed
             and self.breadcrumb.locations[0] == 'Container Image Tags'
             and len(self.breadcrumb.locations) >= self.BREADCRUMB_LENGTH
         )

--- a/airgun/views/contentcredential.py
+++ b/airgun/views/contentcredential.py
@@ -12,7 +12,7 @@ class ContentCredentialsTableView(BaseLoggedInView, SearchableViewMixin):
 
     @property
     def is_displayed(self):
-        return self.browser.wait_for_element(self.title, exception=False) is not None
+        return self.title.is_displayed
 
 
 class ContentCredentialCreateView(BaseLoggedInView):
@@ -25,9 +25,8 @@ class ContentCredentialCreateView(BaseLoggedInView):
 
     @property
     def is_displayed(self):
-        breadcrumb_loaded = self.browser.wait_for_element(self.breadcrumb, exception=False)
         return (
-            breadcrumb_loaded
+            self.breadcrumb.is_displayed
             and self.breadcrumb.locations[0] == 'Content Credential'
             and self.breadcrumb.read() == 'New Content Credential'
         )
@@ -40,9 +39,8 @@ class ContentCredentialEditView(BaseLoggedInView):
 
     @property
     def is_displayed(self):
-        breadcrumb_loaded = self.browser.wait_for_element(self.breadcrumb, exception=False)
         return (
-            breadcrumb_loaded
+            self.breadcrumb.is_displayed
             and self.breadcrumb.locations[0] == 'Content Credential'
             and self.breadcrumb.read() != 'New Content Credential'
         )

--- a/airgun/views/contentview.py
+++ b/airgun/views/contentview.py
@@ -18,7 +18,6 @@ from airgun.widgets import (
     PublishPromoteProgressBar,
     ReadOnlyEntry,
     SatSelect,
-    Search,
 )
 
 
@@ -29,7 +28,7 @@ class ContentViewTableView(BaseLoggedInView, SearchableViewMixin):
 
     @property
     def is_displayed(self):
-        return self.browser.wait_for_element(self.title, exception=False) is not None
+        return self.title.is_displayed
 
 
 class ContentViewCreateView(BaseLoggedInView):
@@ -44,9 +43,8 @@ class ContentViewCreateView(BaseLoggedInView):
 
     @property
     def is_displayed(self):
-        breadcrumb_loaded = self.browser.wait_for_element(self.breadcrumb, exception=False)
         return (
-            breadcrumb_loaded
+            self.breadcrumb.is_displayed
             and self.breadcrumb.locations[0] == 'Content Views'
             and self.breadcrumb.read() == 'New Content View'
         )
@@ -61,9 +59,8 @@ class ContentViewCopyView(BaseLoggedInView):
 
     @property
     def is_displayed(self):
-        breadcrumb_loaded = self.browser.wait_for_element(self.breadcrumb, exception=False)
         return (
-            breadcrumb_loaded
+            self.breadcrumb.is_displayed
             and self.breadcrumb.locations[0] == 'Content Views'
             and len(self.breadcrumb.locations) == self.BREADCRUMB_LENGTH
             and self.breadcrumb.read() == 'Copy'
@@ -84,9 +81,8 @@ class ContentViewRemoveView(BaseLoggedInView):
 
     @property
     def is_displayed(self):
-        breadcrumb_loaded = self.browser.wait_for_element(self.breadcrumb, exception=False)
         return (
-            breadcrumb_loaded
+            self.breadcrumb.is_displayed
             and self.breadcrumb.locations[0] == 'Content Views'
             and len(self.breadcrumb.locations) == self.BREADCRUMB_LENGTH
             and self.breadcrumb.read() == 'Deletion'
@@ -103,9 +99,8 @@ class ContentViewEditView(BaseLoggedInView):
 
     @property
     def is_displayed(self):
-        breadcrumb_loaded = self.browser.wait_for_element(self.breadcrumb, exception=False)
         return (
-            breadcrumb_loaded
+            self.breadcrumb.is_displayed
             and len(self.breadcrumb.locations) <= self.BREADCRUMB_LENGTH
             and self.breadcrumb.locations[0] == 'Content Views'
             and self.breadcrumb.read() != 'New Content View'
@@ -120,8 +115,8 @@ class ContentViewEditView(BaseLoggedInView):
         solve_dependencies = EditableEntryCheckbox(name='Solve Dependencies')
 
     @View.nested
-    class versions(SatTab):
-        searchbox = Search()
+    class versions(SatTab, SearchableViewMixin):
+        # searchbox = Search()
         table = Table(
             locator='//table',
             column_widgets={
@@ -131,20 +126,20 @@ class ContentViewEditView(BaseLoggedInView):
             },
         )
 
-        def search(self, version_name):
-            """Searches for content view version.
+        # def search(self, version_name):
+        #     """Searches for content view version.
 
-            Searchbox can't search by version name, only by id, that's why in
-            case version name was passed, it's transformed into recognizable
-            value before filling, for example::
+        #     Searchbox can't search by version name, only by id, that's why in
+        #     case version name was passed, it's transformed into recognizable
+        #     value before filling, for example::
 
-                'Version 1.0' -> 'version = 1'
-            """
-            search_phrase = version_name
-            if version_name.startswith('V') and '.' in version_name:
-                search_phrase = f'version = {version_name.split()[1].split(".")[0]}'
-            self.searchbox.search(search_phrase)
-            return self.table.read()
+        #         'Version 1.0' -> 'version = 1'
+        #     """
+        #     search_phrase = version_name
+        #     if version_name.startswith('V') and '.' in version_name:
+        #         search_phrase = f'version = {version_name.split()[1].split(".")[0]}'
+        #     self.searchbox.search(search_phrase)
+        #     return self.table.read()
 
     @View.nested
     class content_views(SatTab):
@@ -199,31 +194,29 @@ class ContentViewVersionPublishView(BaseLoggedInView):
 
     @property
     def is_displayed(self):
-        breadcrumb_loaded = self.browser.wait_for_element(self.breadcrumb, exception=False)
         return (
-            breadcrumb_loaded
+            self.breadcrumb.is_displayed
             and self.breadcrumb.locations[0] == 'Content Views'
             and self.breadcrumb.read() == 'Publish'
         )
 
 
-class EntitySearchView(SatSecondaryTab):
+class EntitySearchView(SatSecondaryTab, SearchableViewMixin):
     repo_filter = SatSelect(".//select[@ng-model='repository']")
-    searchbox = Search()
     table = Table('.//table')
 
-    def search(self, query, repo=None):
-        """Apply available filters before proceeding with searching.
+    # def search(self, query, repo=None):
+    #     """Apply available filters before proceeding with searching.
 
-        :param str query: search query to type into search field.
-        :param str optional repo: filter by repository name
-        :return: list of dicts representing table rows
-        :rtype: list
-        """
-        if repo:
-            self.repo_filter.fill(repo)
-        self.searchbox.search(query)
-        return self.table.read()
+    #     :param str query: search query to type into search field.
+    #     :param str optional repo: filter by repository name
+    #     :return: list of dicts representing table rows
+    #     :rtype: list
+    #     """
+    #     if repo:
+    #         self.repo_filter.fill(repo)
+    #     self.searchbox.search(query)
+    #     return self.table.read()
 
 
 class ContentViewVersionDetailsView(BaseLoggedInView):
@@ -232,9 +225,8 @@ class ContentViewVersionDetailsView(BaseLoggedInView):
 
     @property
     def is_displayed(self):
-        breadcrumb_loaded = self.browser.wait_for_element(self.breadcrumb, exception=False)
         return (
-            breadcrumb_loaded
+            self.breadcrumb.is_displayed
             and len(self.breadcrumb.locations) > self.BREADCRUMB_LENGTH
             and self.breadcrumb.locations[0] == 'Content Views'
             and self.breadcrumb.locations[2] == 'Versions'
@@ -278,9 +270,8 @@ class ContentViewVersionPromoteView(BaseLoggedInView):
 
     @property
     def is_displayed(self):
-        breadcrumb_loaded = self.browser.wait_for_element(self.breadcrumb, exception=False)
         return (
-            breadcrumb_loaded
+            self.breadcrumb.is_displayed
             and self.breadcrumb.locations[0] == 'Content Views'
             and self.breadcrumb.read() == 'Promotion'
         )
@@ -301,9 +292,8 @@ class ContentViewVersionRemoveView(BaseLoggedInView):
 
     @property
     def is_displayed(self):
-        breadcrumb_loaded = self.browser.wait_for_element(self.breadcrumb, exception=False)
         return (
-            breadcrumb_loaded
+            self.breadcrumb.is_displayed
             and self.breadcrumb.locations[0] == 'Content Views'
             and len(self.breadcrumb.locations) == self.BREADCRUMB_LENGTH
             and self.breadcrumb.read() == 'Deletion'
@@ -321,9 +311,8 @@ class ContentViewVersionRemoveConfirmationView(BaseLoggedInView):
 
     @property
     def is_displayed(self):
-        breadcrumb_loaded = self.browser.wait_for_element(self.breadcrumb, exception=False)
         return (
-            breadcrumb_loaded
+            self.breadcrumb.is_displayed
             and self.breadcrumb.locations[0] == 'Content Views'
             and len(self.breadcrumb.locations) == self.BREADCRUMB_LENGTH
             and self.breadcrumb.read() == 'Deletion'

--- a/airgun/views/contentview_new.py
+++ b/airgun/views/contentview_new.py
@@ -19,7 +19,7 @@ from airgun.views.common import (
     BaseLoggedInView,
     NewAddRemoveResourcesView,
     PF5LCECheckSelectorGroup,
-    SearchableViewMixinPF4,
+    SearchableViewMixin,
     TableRowKebabMenu,
 )
 from airgun.widgets import (
@@ -69,10 +69,9 @@ class AddContentViewModal(BaseLoggedInView):
         return self.title.is_displayed
 
 
-class ContentViewTableView(BaseLoggedInView, SearchableViewMixinPF4):
+class ContentViewTableView(BaseLoggedInView, SearchableViewMixin):
     title = PF5Text(component_id='cvPageHeaderText')
     create_content_view = PF5Button(component_id='create-content-view')
-    search = PF4Search()
     table = ExpandableTable(
         component_id='content-views-table',
         column_widgets={
@@ -130,7 +129,7 @@ class ContentViewEditView(BaseLoggedInView):
 
     @property
     def is_displayed(self):
-        breadcrumb_loaded = self.browser.wait_for_element(self.breadcrumb, exception=False)
+        breadcrumb_loaded = self.breadcrumb.is_displayed
         return breadcrumb_loaded and self.breadcrumb.locations[0] == 'Content views'
 
     @View.nested
@@ -145,11 +144,10 @@ class ContentViewEditView(BaseLoggedInView):
         import_only = Switch(name='import_only_switch')
 
     @View.nested
-    class versions(Tab):
+    class versions(Tab, SearchableViewMixin):
         TAB_LOCATOR = ParametrizedLocator(
             '//a[contains(@href, "#/versions") and @data-ouia-component-id="routed-tabs-tab-versions"]'
         )
-        searchbox = PF4Search()
         table = PatternflyTable(
             component_id='content-view-versions-table',
             column_widgets={
@@ -174,7 +172,7 @@ class ContentViewEditView(BaseLoggedInView):
             search_phrase = version_name
             if version_name.startswith('V') and '.' in version_name:
                 search_phrase = f'version = {version_name.split()[1].split(".")[0]}'
-            self.searchbox.search(search_phrase)
+            super().search(search_phrase)
             return self.table.read()
 
     @View.nested
@@ -189,10 +187,9 @@ class ContentViewEditView(BaseLoggedInView):
         resources = View.nested(NewAddRemoveResourcesView)
 
     @View.nested
-    class filters(Tab):
+    class filters(Tab, SearchableViewMixin):
         TAB_LOCATOR = ParametrizedLocator('//a[contains(@href, "#/filters")]')
         new_filter = PF5Button(component_id='create-filter-button')
-        searchbox = PF4Search()
         table = PatternflyTable(
             component_id='content-view-filters-table',
             column_widgets={
@@ -208,7 +205,7 @@ class ContentViewEditView(BaseLoggedInView):
 
         def search(self, name):
             """Searches for specific filter'"""
-            self.searchbox.search(name)
+            super().search(name)
             return self.table.read()
 
 
@@ -282,11 +279,10 @@ class ContentViewVersionDetailsView(BaseLoggedInView):
     progressbar = PF5ProgressBar()
 
     @View.nested
-    class repositories(Tab):
+    class repositories(Tab, SearchableViewMixin):
         TAB_LOCATOR = ParametrizedLocator(
             './/button[@data-ouia-component-id="cv-version-details-tabs-tab-repositories"]'
         )
-        searchbox = PF4Search()
         table = PatternflyTable(
             component_id='content-view-version-details-repositories-table',
             column_widgets={
@@ -299,11 +295,10 @@ class ContentViewVersionDetailsView(BaseLoggedInView):
         )
 
     @View.nested
-    class rpmPackages(Tab):
+    class rpmPackages(Tab, SearchableViewMixin):
         TAB_LOCATOR = ParametrizedLocator(
             './/button[@data-ouia-component-id="cv-version-details-tabs-tab-rpmPackages"]'
         )
-        searchbox = PF4Search()
         table = PatternflyTable(
             component_id='content-view-version-details-rpm-packages-table',
             column_widgets={
@@ -315,11 +310,10 @@ class ContentViewVersionDetailsView(BaseLoggedInView):
         )
 
     @View.nested
-    class rpmPackageGroups(Tab):
+    class rpmPackageGroups(Tab, SearchableViewMixin):
         TAB_LOCATOR = ParametrizedLocator(
             './/button[@data-ouia-component-id="cv-version-details-tabs-tab-rpmPackageGroups"]'
         )
-        searchbox = PF4Search()
         table = PatternflyTable(
             component_id='content-view-version-details-rpm-package-groups-table',
             column_widgets={
@@ -333,7 +327,6 @@ class ContentViewVersionDetailsView(BaseLoggedInView):
         TAB_LOCATOR = ParametrizedLocator(
             './/button[@data-ouia-component-id="cv-version-details-tabs-tab-errata"]'
         )
-        searchbox = PF4Search()
         table = PatternflyTable(
             component_id='content-view-version-details-errata-table',
             column_widgets={
@@ -348,8 +341,8 @@ class ContentViewVersionDetailsView(BaseLoggedInView):
 
     @property
     def is_displayed(self):
-        breadcrumb_loaded = self.browser.wait_for_element(self.breadcrumb, exception=False)
-        title_loaded = self.browser.wait_for_element(self.version, exception=False)
+        breadcrumb_loaded = self.breadcrumb.is_displayed
+        title_loaded = self.version.is_displayed
         return (
             breadcrumb_loaded
             and title_loaded

--- a/airgun/views/contentviewfilter.py
+++ b/airgun/views/contentviewfilter.py
@@ -138,9 +138,8 @@ class ContentViewFiltersView(BaseLoggedInView, SearchableViewMixin):
 
     @property
     def is_displayed(self):
-        breadcrumb_loaded = self.browser.wait_for_element(self.breadcrumb, exception=False)
         return (
-            breadcrumb_loaded
+            self.breadcrumb.is_displayed
             and self.breadcrumb.locations[0] == 'Content Views'
             and self.breadcrumb.read() == 'Yum Filters'
         )
@@ -159,9 +158,8 @@ class CreateYumFilterView(BaseLoggedInView):
 
     @property
     def is_displayed(self):
-        breadcrumb_loaded = self.browser.wait_for_element(self.breadcrumb, exception=False)
         return (
-            breadcrumb_loaded
+            self.breadcrumb.is_displayed
             and self.breadcrumb.locations[0] == 'Content Views'
             and self.breadcrumb.read() == 'Create Yum Filter'
         )
@@ -175,9 +173,8 @@ class EditYumFilterView(BaseLoggedInView):
 
     @property
     def is_displayed(self):
-        breadcrumb_loaded = self.browser.wait_for_element(self.breadcrumb, exception=False)
         return (
-            breadcrumb_loaded
+            self.breadcrumb.is_displayed
             and len(self.breadcrumb.locations) > self.BREADCRUMB_LENGTH
             and self.breadcrumb.locations[2] == 'Yum Filters'
             and self.breadcrumb.read() != 'Create Yum Filter'
@@ -316,10 +313,10 @@ class EditYumFilterView(BaseLoggedInView):
         pass
 
     @View.nested
-    class affected_repositories(AffectedRepositoriesTab):
+    class affected_repositories(AffectedRepositoriesTab, SearchableViewMixin):
         filter_toggle = RadioGroup(".//div[@class='col-sm-8']")
         product_filter = Select(locator=".//select[@ng-model='product']")
-        searchbox = TextInput(locator=".//input[@ng-model='repositorySearch']")
+        # searchbox = TextInput(locator=".//input[@ng-model='repositorySearch']")
         update_repositories = Button('Update Repositories')
         select_all = Checkbox(locator=".//table//th[@class='row-select']/input")
         table = SatTable(

--- a/airgun/views/dashboard.py
+++ b/airgun/views/dashboard.py
@@ -1,6 +1,6 @@
 from widgetastic.widget import Table, Text, View, Widget
 
-from airgun.views.common import BaseLoggedInView, SatTable, SearchableViewMixinPF4
+from airgun.views.common import BaseLoggedInView, SatTable, SearchableViewMixin
 from airgun.widgets import ActionsDropdown, PieChart
 
 
@@ -71,14 +71,14 @@ class AutoRefresh(Widget):
             self.browser.element(self.AUTO_REFRESH).click()
 
 
-class DashboardView(BaseLoggedInView, SearchableViewMixinPF4):
+class DashboardView(BaseLoggedInView, SearchableViewMixin):
     title = Text("//h1[normalize-space(.)='Overview']")
     manage = ActionsDropdown("//div[@class='btn-group']")
     refresh = AutoRefresh()
 
     @property
     def is_displayed(self):
-        return self.browser.wait_for_element(self.title, exception=False) is not None
+        return self.title.is_displayed
 
     def search(self, query):
         """Return whole dashboard view as a result of a search

--- a/airgun/views/discoveredhosts.py
+++ b/airgun/views/discoveredhosts.py
@@ -45,7 +45,7 @@ class DiscoveredHostsView(BaseLoggedInView, SearchableViewMixin):
 
     @property
     def is_displayed(self):
-        return self.browser.wait_for_element(self.title, exception=False) is not None
+        return self.title.is_displayed
 
     def is_searchable(self):
         """Verify that search procedure can be executed against discovered
@@ -121,9 +121,8 @@ class DiscoveredHostDetailsView(BaseLoggedInView):
 
     @property
     def is_displayed(self):
-        breadcrumb_loaded = self.browser.wait_for_element(self.breadcrumb, exception=False)
         return (
-            breadcrumb_loaded
+            self.breadcrumb.is_displayed
             and self.breadcrumb.locations[0] == 'Discovered hosts'
             and self.breadcrumb.locations[1].startswith('Discovered host:')
         )
@@ -138,7 +137,7 @@ class DiscoveredHostsActionDialog(BaseLoggedInView):
 
     @property
     def is_displayed(self):
-        return self.browser.wait_for_element(self.title, exception=False) is not None
+        return self.title.is_displayed
 
 
 class DiscoveredHostsAutoProvisionDialog(DiscoveredHostsActionDialog):
@@ -226,9 +225,8 @@ class DiscoveredHostEditProvisioningView(HostCreateView):
 
     @property
     def is_displayed(self):
-        breadcrumb_loaded = self.browser.wait_for_element(self.breadcrumb, exception=False)
         return (
-            breadcrumb_loaded
+            self.breadcrumb.is_displayed
             and self.breadcrumb.locations[0] == 'Discovered hosts'
             and self.breadcrumb.locations[1].startswith('Provision')
         )

--- a/airgun/views/discoveryrule.py
+++ b/airgun/views/discoveryrule.py
@@ -2,7 +2,7 @@ from widgetastic.widget import Checkbox, Table, Text, TextInput, View
 from widgetastic_patternfly import BreadCrumb
 from widgetastic_patternfly5 import Button as PF5Button
 
-from airgun.views.common import BaseLoggedInView, SatTab, SearchableViewMixinPF4
+from airgun.views.common import BaseLoggedInView, SatTab, SearchableViewMixin
 from airgun.widgets import (
     ActionsDropdown,
     AutoCompleteTextInput,
@@ -11,7 +11,7 @@ from airgun.widgets import (
 )
 
 
-class DiscoveryRulesView(BaseLoggedInView, SearchableViewMixinPF4):
+class DiscoveryRulesView(BaseLoggedInView, SearchableViewMixin):
     title = Text("//h1[normalize-space(.)='Discovery Rules']")
     page_info = Text("//foreman-react-component[contains(@name, 'DiscoveryRules')]/div/div")
     new = Text("//a[contains(@href, '/discovery_rules/new')]")
@@ -26,7 +26,7 @@ class DiscoveryRulesView(BaseLoggedInView, SearchableViewMixinPF4):
 
     @property
     def is_displayed(self):
-        return self.browser.wait_for_element(self.title, exception=False) is not None
+        return self.title.is_displayed
 
 
 class DiscoveryRuleCreateView(BaseLoggedInView):
@@ -36,9 +36,8 @@ class DiscoveryRuleCreateView(BaseLoggedInView):
 
     @property
     def is_displayed(self):
-        breadcrumb_loaded = self.browser.wait_for_element(self.breadcrumb, exception=False)
         return (
-            breadcrumb_loaded
+            self.breadcrumb.is_displayed
             and self.breadcrumb.locations[0] == 'Discovery rules'
             and self.breadcrumb.read() == 'New Discovery Rule'
         )
@@ -65,9 +64,8 @@ class DiscoveryRuleCreateView(BaseLoggedInView):
 class DiscoveryRuleEditView(DiscoveryRuleCreateView):
     @property
     def is_displayed(self):
-        breadcrumb_loaded = self.browser.wait_for_element(self.breadcrumb, exception=False)
         return (
-            breadcrumb_loaded
+            self.breadcrumb.is_displayed
             and self.breadcrumb.locations[0] == 'Discovery rules'
             and self.breadcrumb.read().startswith('Edit ')
         )

--- a/airgun/views/domain.py
+++ b/airgun/views/domain.py
@@ -1,11 +1,11 @@
 from widgetastic.widget import Table, Text, TextInput, View
 from widgetastic_patternfly import BreadCrumb
 
-from airgun.views.common import BaseLoggedInView, SatTab, SearchableViewMixinPF4
+from airgun.views.common import BaseLoggedInView, SatTab, SearchableViewMixin
 from airgun.widgets import CustomParameter, FilteredDropdown, MultiSelect
 
 
-class DomainListView(BaseLoggedInView, SearchableViewMixinPF4):
+class DomainListView(BaseLoggedInView, SearchableViewMixin):
     """List of all domains."""
 
     title = Text('//*[(self::h1 or self::h5) and normalize-space(.)="Domains"]')
@@ -21,7 +21,7 @@ class DomainListView(BaseLoggedInView, SearchableViewMixinPF4):
 
     @property
     def is_displayed(self):
-        return self.browser.wait_for_element(self.title, exception=False) is not None
+        return self.title.is_displayed
 
 
 class DomainCreateView(BaseLoggedInView):
@@ -49,9 +49,8 @@ class DomainCreateView(BaseLoggedInView):
 
     @property
     def is_displayed(self):
-        breadcrumb_loaded = self.browser.wait_for_element(self.breadcrumb, exception=False)
         return (
-            breadcrumb_loaded
+            self.breadcrumb.is_displayed
             and self.breadcrumb.locations[0] == 'Domains'
             and self.breadcrumb.read() == 'Create Domain'
         )
@@ -60,9 +59,8 @@ class DomainCreateView(BaseLoggedInView):
 class DomainEditView(DomainCreateView):
     @property
     def is_displayed(self):
-        breadcrumb_loaded = self.browser.wait_for_element(self.breadcrumb, exception=False)
         return (
-            breadcrumb_loaded
+            self.breadcrumb.is_displayed
             and self.breadcrumb.locations[0] == 'Domains'
             and self.breadcrumb.read().startswith('Edit ')
         )

--- a/airgun/views/dynflowconsole.py
+++ b/airgun/views/dynflowconsole.py
@@ -12,4 +12,4 @@ class DynflowConsoleView(BaseLoggedInView):
 
     @property
     def is_displayed(self):
-        return self.browser.wait_for_element(self.title, exception=False) is not None
+        return self.title.is_displayed

--- a/airgun/views/fact.py
+++ b/airgun/views/fact.py
@@ -1,10 +1,10 @@
 from widgetastic.widget import Table, Text
 from widgetastic_patternfly import BreadCrumb
 
-from airgun.views.common import BaseLoggedInView, SearchableViewMixinPF4
+from airgun.views.common import BaseLoggedInView, SearchableViewMixin
 
 
-class HostFactView(BaseLoggedInView, SearchableViewMixinPF4):
+class HostFactView(BaseLoggedInView, SearchableViewMixin):
     breadcrumb = BreadCrumb()
 
     table = Table(
@@ -19,5 +19,5 @@ class HostFactView(BaseLoggedInView, SearchableViewMixinPF4):
 
     @property
     def is_displayed(self):
-        breadcrumb_loaded = self.browser.wait_for_element(self.breadcrumb, exception=False)
+        breadcrumb_loaded = self.breadcrumb.is_displayed
         return breadcrumb_loaded and self.breadcrumb.read().startswith('Facts Values')

--- a/airgun/views/file.py
+++ b/airgun/views/file.py
@@ -24,7 +24,7 @@ class FilesView(BaseLoggedInView):
 
     @property
     def is_displayed(self):
-        return self.browser.wait_for_element(self.title, exception=False) is not None
+        return self.title.is_displayed
 
 
 class FileDetailsView(BaseLoggedInView):
@@ -32,7 +32,7 @@ class FileDetailsView(BaseLoggedInView):
 
     @property
     def is_displayed(self):
-        breadcrumb_loaded = self.browser.wait_for_element(self.breadcrumb, exception=False)
+        breadcrumb_loaded = self.breadcrumb.is_displayed
 
         return breadcrumb_loaded and self.breadcrumb.locations[0] == 'Files'
 

--- a/airgun/views/filter.py
+++ b/airgun/views/filter.py
@@ -6,18 +6,16 @@ from widgetastic.widget import (
 from widgetastic_patternfly import BreadCrumb
 from widgetastic_patternfly4 import Pagination as PF4Pagination
 
-from airgun.views.common import BaseLoggedInView
+from airgun.views.common import BaseLoggedInView, SearchableViewMixin
 from airgun.widgets import (
     ActionsDropdown,
     PF4FilteredDropdown,
     PF4MultiSelect,
-    Search,
 )
 
 
-class FiltersView(BaseLoggedInView):
+class FiltersView(BaseLoggedInView, SearchableViewMixin):
     breadcrumb = BreadCrumb()
-    searchbox = Search()
     new = Text("//a[contains(@href, '/filters/new')]")
     table = Table(
         './/table',
@@ -29,19 +27,20 @@ class FiltersView(BaseLoggedInView):
 
     @property
     def is_displayed(self):
-        breadcrumb_loaded = self.browser.wait_for_element(self.breadcrumb, exception=False)
         return (
-            breadcrumb_loaded
+            self.breadcrumb.is_displayed
             and self.breadcrumb.locations[0] == 'Roles'
             and self.breadcrumb.read().endswith(' filters')
         )
 
     def search(self, query):
         value = self.searchbox.read()
+
         role_id = [int(s) for s in value.split() if s.isdigit()]
         if len(role_id) > 0:
             query = f'role_id = {role_id[0]} and resource = "{query}"'
-        self.searchbox.search(query)
+
+        super().search(query)
         return self.table.read()
 
 
@@ -56,9 +55,8 @@ class FilterDetailsView(BaseLoggedInView):
 
     @property
     def is_displayed(self):
-        breadcrumb_loaded = self.browser.wait_for_element(self.breadcrumb, exception=False)
         return (
-            breadcrumb_loaded
+            self.breadcrumb.is_displayed
             and self.breadcrumb.locations[0] == 'Roles'
             and self.breadcrumb.read().startswith('Edit filter for ')
         )
@@ -67,9 +65,8 @@ class FilterDetailsView(BaseLoggedInView):
 class FilterCreateView(FilterDetailsView):
     @property
     def is_displayed(self):
-        breadcrumb_loaded = self.browser.wait_for_element(self.breadcrumb, exception=False)
         return (
-            breadcrumb_loaded
+            self.breadcrumb.is_displayed
             and self.breadcrumb.locations[0] == 'Roles'
             and self.breadcrumb.read() == 'Create Filter'
         )

--- a/airgun/views/flatpak.py
+++ b/airgun/views/flatpak.py
@@ -14,11 +14,11 @@ from widgetastic_patternfly5.ouia import (
     Title as PF5OUIATitle,
 )
 
-from airgun.views.common import BaseLoggedInView, SearchableViewMixinPF4
+from airgun.views.common import BaseLoggedInView, SearchableViewMixin
 from airgun.widgets import PF4Search, SearchInput
 
 
-class FlatpakRemotesView(BaseLoggedInView, SearchableViewMixinPF4):
+class FlatpakRemotesView(BaseLoggedInView, SearchableViewMixin):
     """View for the Flatpak Remotes page"""
 
     title = Text("//h1[normalize-space(.)='Flatpak Remotes']")
@@ -40,10 +40,10 @@ class FlatpakRemotesView(BaseLoggedInView, SearchableViewMixinPF4):
 
     @property
     def is_displayed(self):
-        return self.browser.wait_for_element(self.create_new_btn, exception=False) is not None
+        return self.create_new_btn.is_displayed
 
 
-class FlatpakRemoteDetailsView(BaseLoggedInView, SearchableViewMixinPF4):
+class FlatpakRemoteDetailsView(BaseLoggedInView, SearchableViewMixin):
     """View for the Flatpak Remote details page"""
 
     title = PF5OUIATitle('flatpak-remote-title')
@@ -70,7 +70,7 @@ class FlatpakRemoteDetailsView(BaseLoggedInView, SearchableViewMixinPF4):
 
     @property
     def is_displayed(self):
-        return self.browser.wait_for_element(self.title, exception=False) is not None
+        return self.title.is_displayed
 
 
 class CreateFlatpakRemoteModal(PF5Modal):
@@ -93,7 +93,7 @@ class CreateFlatpakRemoteModal(PF5Modal):
 
     @property
     def is_displayed(self):
-        return self.browser.wait_for_element(self.title, exception=False) is not None
+        return self.title.is_displayed
 
 
 class EditFlatpakRemoteModal(PF5Modal):
@@ -113,10 +113,10 @@ class EditFlatpakRemoteModal(PF5Modal):
 
     @property
     def is_displayed(self):
-        return self.browser.wait_for_element(self.title, exception=False) is not None
+        return self.title.is_displayed
 
 
-class MirrorFlatpakRemoteModal(PF5Modal, SearchableViewMixinPF4):
+class MirrorFlatpakRemoteModal(PF5Modal, SearchableViewMixin):
     """View for the Mirror Flatpak Remote modal"""
 
     ROOT = './/div[@data-ouia-component-id="mirror-repo-modal"]'
@@ -135,7 +135,7 @@ class MirrorFlatpakRemoteModal(PF5Modal, SearchableViewMixinPF4):
 
     @property
     def is_displayed(self):
-        return self.browser.wait_for_element(self.title, exception=False) is not None
+        return self.title.is_displayed
 
     def dependency_repo_names(self):
         """Return a list of dependency repository names from the alert."""
@@ -170,4 +170,4 @@ class FlatpakRemoteDeleteModal(PF5Modal):
 
     @property
     def is_displayed(self):
-        return self.browser.wait_for_element(self.title, exception=False) is not None
+        return self.title.is_displayed

--- a/airgun/views/global_parameter.py
+++ b/airgun/views/global_parameter.py
@@ -1,11 +1,11 @@
 from widgetastic.widget import Text
 
-from airgun.views.common import BaseLoggedInView, SearchableViewMixinPF4
+from airgun.views.common import BaseLoggedInView, SearchableViewMixin
 
 
-class GlobalParameterView(BaseLoggedInView, SearchableViewMixinPF4):
+class GlobalParameterView(BaseLoggedInView, SearchableViewMixin):
     title = Text("//h1[normalize-space(.)='Global Parameters']")
 
     @property
     def is_displayed(self):
-        return self.browser.wait_for_element(self.title, exception=False) is not None
+        return self.title.is_displayed

--- a/airgun/views/hardware_model.py
+++ b/airgun/views/hardware_model.py
@@ -2,7 +2,7 @@ from widgetastic.widget import Text, TextInput
 from widgetastic_patternfly import BreadCrumb
 from widgetastic_patternfly5.ouia import PatternflyTable as PF5OUIATable
 
-from airgun.views.common import BaseLoggedInView, SearchableViewMixinPF4
+from airgun.views.common import BaseLoggedInView, SearchableViewMixin
 from airgun.views.host_new import MenuToggleButtonMenu
 from airgun.widgets import Pf5ConfirmationDialog
 
@@ -12,7 +12,7 @@ class DeleteHardwareModelDialog(Pf5ConfirmationDialog):
     cancel_dialog = Text(".//button[normalize-space(.)='Cancel']")
 
 
-class HardwareModelsView(BaseLoggedInView, SearchableViewMixinPF4):
+class HardwareModelsView(BaseLoggedInView, SearchableViewMixin):
     delete_dialog = DeleteHardwareModelDialog()
     title = Text("//h1[normalize-space(.)='Hardware models']")
     new = Text("//a[contains(@href, '/models/new')]")
@@ -26,7 +26,7 @@ class HardwareModelsView(BaseLoggedInView, SearchableViewMixinPF4):
 
     @property
     def is_displayed(self):
-        return self.browser.wait_for_element(self.title, exception=False) is not None
+        return self.title.is_displayed
 
 
 class HardwareModelCreateView(BaseLoggedInView):
@@ -39,9 +39,8 @@ class HardwareModelCreateView(BaseLoggedInView):
 
     @property
     def is_displayed(self):
-        breadcrumb_loaded = self.browser.wait_for_element(self.breadcrumb, exception=False)
         return (
-            breadcrumb_loaded
+            self.breadcrumb.is_displayed
             and self.breadcrumb.locations[0] == 'Hardware Models'
             and self.breadcrumb.read() == 'Create Model'
         )
@@ -50,9 +49,8 @@ class HardwareModelCreateView(BaseLoggedInView):
 class HardwareModelEditView(HardwareModelCreateView):
     @property
     def is_displayed(self):
-        breadcrumb_loaded = self.browser.wait_for_element(self.breadcrumb, exception=False)
         return (
-            breadcrumb_loaded
+            self.breadcrumb.is_displayed
             and self.breadcrumb.locations[0] == 'Hardware Models'
             and self.breadcrumb.read().startswith('Edit ')
         )

--- a/airgun/views/host.py
+++ b/airgun/views/host.py
@@ -1,5 +1,4 @@
 import re
-import time
 
 from wait_for import wait_for
 from widgetastic.utils import ParametrizedLocator
@@ -30,7 +29,7 @@ from widgetastic_patternfly5.ouia import (
     TextInput as PF5OUIATextInput,
 )
 
-from airgun.views.common import BaseLoggedInView, SatTab, SearchableViewMixinPF4
+from airgun.views.common import BaseLoggedInView, SatTab, SearchableViewMixin
 from airgun.views.host_new import MenuToggleButtonMenu
 from airgun.views.job_invocation import JobInvocationCreateView, JobInvocationStatusView
 from airgun.views.task import TaskDetailsView
@@ -218,10 +217,10 @@ class HostStatusesView(BaseLoggedInView):
 
     @property
     def is_displayed(self):
-        return self.browser.wait_for_element(self.title, exception=False) is not None
+        return self.title.is_displayed
 
 
-class HostsView(BaseLoggedInView, SearchableViewMixinPF4):
+class HostsView(BaseLoggedInView, SearchableViewMixin):
     title = Text("//h1[normalize-space(.)='Hosts']")
     manage_columns = PF5Button('manage-columns-button')
     searchbar_dropdown = PF5OUIADropdown('selection-checkbox')
@@ -248,7 +247,7 @@ class HostsView(BaseLoggedInView, SearchableViewMixinPF4):
 
     @property
     def is_displayed(self):
-        return self.browser.wait_for_element(self.title, exception=False) is not None
+        return self.title.is_displayed and self.table.is_displayed
 
     @property
     def displayed_table_header_names(self) -> list:
@@ -268,9 +267,8 @@ class HostCreateView(BaseLoggedInView):
 
     @property
     def is_displayed(self):
-        breadcrumb_loaded = self.browser.wait_for_element(self.breadcrumb, exception=False)
         return (
-            breadcrumb_loaded
+            self.breadcrumb.is_displayed
             and self.breadcrumb.locations[0] == 'All Hosts'
             and self.breadcrumb.read() == 'Create Host'
         )
@@ -580,7 +578,7 @@ class HostRegisterView(BaseLoggedInView):
 
     @property
     def is_displayed(self):
-        return self.browser.wait_for_element(self.title, exception=False)
+        return self.title.is_displayed
 
     def before_fill(self, values):
         """Fill some of the parameters in the widgets with values.
@@ -602,7 +600,6 @@ class HostRegisterView(BaseLoggedInView):
                     logger=self.logger,
                 )
                 self.general.__getattribute__(field).fill(field_value)
-                time.sleep(1)
 
 
 class RepositoryListView(View):
@@ -687,9 +684,8 @@ class HostDetailsView(BaseLoggedInView):
 
     @property
     def is_displayed(self):
-        breadcrumb_loaded = self.browser.wait_for_element(self.breadcrumb, exception=False)
         return (
-            breadcrumb_loaded
+            self.breadcrumb.is_displayed
             and self.breadcrumb.locations[0] == 'All Hosts'
             and self.breadcrumb.read() != 'Create Host'
         )
@@ -729,9 +725,8 @@ class HostEditView(HostCreateView):
 
     @property
     def is_displayed(self):
-        breadcrumb_loaded = self.browser.wait_for_element(self.breadcrumb, exception=False)
         return (
-            breadcrumb_loaded
+            self.breadcrumb.is_displayed
             and self.breadcrumb.locations[0] == 'All Hosts'
             and self.breadcrumb.read().startswith('Edit ')
         )
@@ -747,7 +742,7 @@ class HostsActionCommonDialog(BaseLoggedInView):
 
     @property
     def is_displayed(self):
-        return self.browser.wait_for_element(self.title, exception=False) is not None
+        return self.title.is_displayed
 
 
 class HostsChangeGroup(HostsActionCommonDialog):

--- a/airgun/views/hostcollection.py
+++ b/airgun/views/hostcollection.py
@@ -29,7 +29,7 @@ class HostCollectionsView(BaseLoggedInView, SearchableViewMixin):
 
     @property
     def is_displayed(self):
-        return self.browser.wait_for_element(self.title, exception=False) is not None
+        return self.title.is_displayed
 
 
 class HostCollectionCreateView(BaseLoggedInView):
@@ -42,9 +42,8 @@ class HostCollectionCreateView(BaseLoggedInView):
 
     @property
     def is_displayed(self):
-        breadcrumb_loaded = self.browser.wait_for_element(self.breadcrumb, exception=False)
         return (
-            breadcrumb_loaded
+            self.breadcrumb.is_displayed
             and self.breadcrumb.locations[0] == 'Host Collections'
             and self.breadcrumb.read() == 'New Host Collection'
         )
@@ -57,9 +56,8 @@ class HostCollectionEditView(BaseLoggedInView):
 
     @property
     def is_displayed(self):
-        breadcrumb_loaded = self.browser.wait_for_element(self.breadcrumb, exception=False)
         return (
-            breadcrumb_loaded
+            self.breadcrumb.is_displayed
             and self.breadcrumb.locations[0] == 'Host Collections'
             and self.breadcrumb.read() != 'New Host Collection'
         )
@@ -170,7 +168,7 @@ class HostCollectionManagePackagesView(BaseLoggedInView):
     @property
     def is_displayed(self):
         """The view is displayed when it's title exists"""
-        return self.browser.wait_for_element(self.title, exception=False) is not None
+        return self.title.is_displayed
 
     @View.nested
     class dialog(ConfirmationDialog):
@@ -217,7 +215,7 @@ class HostCollectionInstallErrataView(BaseLoggedInView, SearchableViewMixin):
     @property
     def is_displayed(self):
         """The view is displayed when it's title exists"""
-        return self.browser.wait_for_element(self.title, exception=False) is not None
+        return self.title.is_displayed
 
 
 class HostCollectionManageModuleStreamsView(BaseLoggedInView, SearchableViewMixin):
@@ -233,7 +231,7 @@ class HostCollectionManageModuleStreamsView(BaseLoggedInView, SearchableViewMixi
     @property
     def is_displayed(self):
         """The view is displayed when it's title exists"""
-        return self.browser.wait_for_element(self.title, exception=False) is not None
+        return self.title.is_displayed
 
 
 class HostCollectionChangeAssignedContentView(BaseLoggedInView):
@@ -254,7 +252,7 @@ class HostCollectionChangeAssignedContentView(BaseLoggedInView):
     @property
     def is_displayed(self):
         """The view is displayed when it's title exists"""
-        return self.browser.wait_for_element(self.title, exception=False) is not None
+        return self.title.is_displayed
 
 
 class HostCollectionActionTaskDetailsView(TaskDetailsView):
@@ -264,15 +262,14 @@ class HostCollectionActionTaskDetailsView(TaskDetailsView):
     @property
     def is_displayed(self):
         """The view is displayed when it's title exists"""
-        return self.browser.wait_for_element(self.title, exception=False) is not None
+        return self.title.is_displayed
 
 
 class HostCollectionActionRemoteExecutionJobCreate(JobInvocationCreateView):
     @property
     def is_displayed(self):
-        breadcrumb_loaded = self.browser.wait_for_element(self.breadcrumb, exception=False)
         return (
-            breadcrumb_loaded
+            self.breadcrumb.is_displayed
             and self.breadcrumb.locations[0] == 'Remote Executions'
             and self.breadcrumb.read() == 'Job invocation'
         )

--- a/airgun/views/hostgroup.py
+++ b/airgun/views/hostgroup.py
@@ -7,7 +7,7 @@ from widgetastic_patternfly5 import (
 )
 from widgetastic_patternfly5.ouia import Select as PF5OUIASelect
 
-from airgun.views.common import BaseLoggedInView, SatTab, SearchableViewMixinPF4
+from airgun.views.common import BaseLoggedInView, SatTab, SearchableViewMixin
 from airgun.widgets import (
     ActionsDropdown,
     ConfigGroupMultiSelect,
@@ -31,7 +31,7 @@ class ActivationKeyDropDown(ActionsDropdown):
         ]
 
 
-class HostGroupsView(BaseLoggedInView, SearchableViewMixinPF4):
+class HostGroupsView(BaseLoggedInView, SearchableViewMixin):
     title = Text(
         "//h1[contains(., 'Host Group Configuration') or normalize-space(.)='Host Groups']"
     )
@@ -47,9 +47,10 @@ class HostGroupsView(BaseLoggedInView, SearchableViewMixinPF4):
 
     @property
     def is_displayed(self):
-        page_loaded = self.browser.wait_for_element(
-            self.title, exception=False
-        ) or self.browser.wait_for_element(self.new_on_blank_page, exception=False)
+        page_loaded = (
+            self.browser.wait_for_element(self.title, exception=False)
+            or self.new_on_blank_page.is_displayed
+        )
         return page_loaded and self.browser.url.endswith('hostgroups')
 
 
@@ -59,9 +60,8 @@ class HostGroupCreateView(BaseLoggedInView):
 
     @property
     def is_displayed(self):
-        breadcrumb_loaded = self.browser.wait_for_element(self.breadcrumb, exception=False)
         return (
-            breadcrumb_loaded
+            self.breadcrumb.is_displayed
             and self.breadcrumb.locations[0] == 'Host Groups'
             and self.breadcrumb.read() == 'Create Host Group'
         )
@@ -148,9 +148,8 @@ class HostGroupEditView(HostGroupCreateView):
 
     @property
     def is_displayed(self):
-        breadcrumb_loaded = self.browser.wait_for_element(self.breadcrumb, exception=False)
         return (
-            breadcrumb_loaded
+            self.breadcrumb.is_displayed
             and self.breadcrumb.locations[0] == 'Host Groups'
             and self.breadcrumb.read().startswith('Edit ')
         )

--- a/airgun/views/http_proxy.py
+++ b/airgun/views/http_proxy.py
@@ -19,7 +19,7 @@ class HTTPProxyView(BaseLoggedInView, SearchableViewMixin):
 
     @property
     def is_displayed(self):
-        return self.browser.wait_for_element(self.title, exception=False) is not None
+        return self.title.is_displayed
 
 
 class HTTPProxyCreateView(BaseLoggedInView):
@@ -30,9 +30,8 @@ class HTTPProxyCreateView(BaseLoggedInView):
 
     @property
     def is_displayed(self):
-        breadcrumb_loaded = self.browser.wait_for_element(self.breadcrumb, exception=False)
         return (
-            breadcrumb_loaded
+            self.breadcrumb.is_displayed
             and self.breadcrumb.locations[0] == 'HTTP proxies'
             and self.breadcrumb.read() == 'New HTTP proxy'
         )
@@ -61,9 +60,8 @@ class HTTPProxyCreateView(BaseLoggedInView):
 class HTTPProxyEditView(HTTPProxyCreateView):
     @property
     def is_displayed(self):
-        breadcrumb_loaded = self.browser.wait_for_element(self.breadcrumb, exception=False)
         return (
-            breadcrumb_loaded
+            self.breadcrumb.is_displayed
             and self.breadcrumb.locations[0] == 'Http proxies'
             and self.breadcrumb.read().startswith('Edit ')
         )

--- a/airgun/views/job_invocation.py
+++ b/airgun/views/job_invocation.py
@@ -36,8 +36,6 @@ class HostsExpandableTable(PF5OUIAExpandableTable):
         execution does not time out in case the hosts table is empty.
         Then `super().read()` should return empty list.
         """
-        wait_for(func=lambda: self.is_displayed, timeout=15, delay=1)
-        self.browser.plugin.ensure_page_safe(timeout='15s')
         script = f"""
         rows = document.getElementsByTagName('{self.ROW_TAG}');
         last_row = rows[rows.length-1];
@@ -60,11 +58,15 @@ class HostsExpandableTable(PF5OUIAExpandableTable):
 class JobInvocationsView(BaseLoggedInView, SearchableViewMixin):
     title = Text("//h1[contains(., 'Job') and contains(., 'nvocations')]")
     new = Text("//a[contains(@href, '/job_invocations/new')]")
+
+    # searchbox = SearchInput(
+    #     locator='.//div[@class="foreman-search-bar"]//input[@aria-label="Search input"]'
+    # )
     table = SatTable('.//table', column_widgets={'Description': Text('./a')})
 
     @property
     def is_displayed(self):
-        return self.browser.wait_for_element(self.title, exception=False) is not None
+        return self.title.is_displayed and self.table.is_displayed
 
 
 class JobInvocationCreateView(BaseLoggedInView):
@@ -174,9 +176,8 @@ class JobInvocationCreateView(BaseLoggedInView):
 
     @property
     def is_displayed(self):
-        breadcrumb_loaded = self.browser.wait_for_element(self.breadcrumb, exception=False)
         return (
-            breadcrumb_loaded
+            self.breadcrumb.is_displayed
             and self.breadcrumb.locations[0] == 'Jobs'
             and self.breadcrumb.read() == 'Job invocation'
         )

--- a/airgun/views/job_template.py
+++ b/airgun/views/job_template.py
@@ -4,7 +4,7 @@ from widgetastic_patternfly import BreadCrumb
 from airgun.views.common import (
     BaseLoggedInView,
     SatTab,
-    SearchableViewMixinPF4,
+    SearchableViewMixin,
     TemplateEditor,
     TemplateInputItem,
 )
@@ -17,7 +17,7 @@ from airgun.widgets import (
 )
 
 
-class JobTemplatesView(BaseLoggedInView, SearchableViewMixinPF4):
+class JobTemplatesView(BaseLoggedInView, SearchableViewMixin):
     title = Text("//h1[contains(., 'Job Templates')]")
     import_template = Text("//a[normalize-space(.)='Import']")
     new = Text("//a[contains(@href, '/job_templates/new')]")
@@ -31,7 +31,7 @@ class JobTemplatesView(BaseLoggedInView, SearchableViewMixinPF4):
 
     @property
     def is_displayed(self):
-        return self.browser.wait_for_element(self.title, exception=False) is not None
+        return self.title.is_displayed
 
 
 class JobTemplateForeignInputSetItem(GenericRemovableWidgetItem):
@@ -50,9 +50,8 @@ class JobTemplateCreateView(BaseLoggedInView):
 
     @property
     def is_displayed(self):
-        breadcrumb_loaded = self.browser.wait_for_element(self.breadcrumb, exception=False)
         return (
-            breadcrumb_loaded
+            self.breadcrumb.is_displayed
             and self.breadcrumb.locations[0] == 'Job Templates'
             and self.breadcrumb.read() == 'New Job Template'
         )
@@ -105,9 +104,8 @@ class JobTemplateCreateView(BaseLoggedInView):
 class JobTemplateEditView(JobTemplateCreateView):
     @property
     def is_displayed(self):
-        breadcrumb_loaded = self.browser.wait_for_element(self.breadcrumb, exception=False)
         return (
-            breadcrumb_loaded
+            self.breadcrumb.is_displayed
             and self.breadcrumb.locations[0] == 'Job Templates'
             and self.breadcrumb.read().startswith('Edit ')
         )

--- a/airgun/views/ldapauthentication.py
+++ b/airgun/views/ldapauthentication.py
@@ -29,7 +29,7 @@ class LDAPAuthenticationsView(BaseLoggedInView):
 
     @property
     def is_displayed(self):
-        return self.browser.wait_for_element(self.title, exception=False) is not None
+        return self.title.is_displayed
 
 
 class LDAPAuthenticationCreateView(BaseLoggedInView):
@@ -38,9 +38,8 @@ class LDAPAuthenticationCreateView(BaseLoggedInView):
 
     @property
     def is_displayed(self):
-        breadcrumb_loaded = self.browser.wait_for_element(self.breadcrumb, exception=False)
         return (
-            breadcrumb_loaded
+            self.breadcrumb.is_displayed
             and self.breadcrumb.locations[0] == 'Auth source ldaps'
             and self.breadcrumb.read() == 'Create LDAP Auth Source'
         )
@@ -89,9 +88,8 @@ class LDAPAuthenticationCreateView(BaseLoggedInView):
 class LDAPAuthenticationEditView(LDAPAuthenticationCreateView):
     @property
     def is_displayed(self):
-        breadcrumb_loaded = self.browser.wait_for_element(self.breadcrumb, exception=False)
         return (
-            breadcrumb_loaded
+            self.breadcrumb.is_displayed
             and self.breadcrumb.locations[0] == 'Auth source ldaps'
             and self.breadcrumb.read().startswith('Edit LDAP-')
         )

--- a/airgun/views/lifecycleenvironment.py
+++ b/airgun/views/lifecycleenvironment.py
@@ -14,7 +14,6 @@ from airgun.widgets import (
     EditableEntryCheckbox,
     ReadOnlyEntry,
     SatSelect,
-    Search,
 )
 
 
@@ -39,7 +38,7 @@ class LCEView(BaseLoggedInView, ParametrizedView):
 
     @property
     def is_displayed(self):
-        return self.browser.wait_for_element(self.title, exception=False) is not None
+        return self.title.is_displayed
 
     @View.nested
     class lce(ParametrizedView):
@@ -93,9 +92,8 @@ class LCECreateView(BaseLoggedInView):
 
     @property
     def is_displayed(self):
-        breadcrumb_loaded = self.browser.wait_for_element(self.breadcrumb, exception=False)
         return (
-            breadcrumb_loaded
+            self.breadcrumb.is_displayed
             and self.breadcrumb.locations[0] == 'Environments List'
             and self.breadcrumb.read() == 'New Environment'
         )
@@ -107,9 +105,8 @@ class LCEEditView(BaseLoggedInView):
 
     @property
     def is_displayed(self):
-        breadcrumb_loaded = self.browser.wait_for_element(self.breadcrumb, exception=False)
         return (
-            breadcrumb_loaded
+            self.breadcrumb.is_displayed
             and self.breadcrumb.locations[0] == 'Environments'
             and self.breadcrumb.read() != 'New Environment'
         )
@@ -128,10 +125,9 @@ class LCEEditView(BaseLoggedInView):
         resources = Table(locator='.//table')
 
     @View.nested
-    class packages(SatTab):
+    class packages(SatTab, SearchableViewMixin):
         cv_filter = SatSelect(".//select[@ng-model='contentView']")
         repo_filter = SatSelect(".//select[@ng-model='repository']")
-        searchbox = Search()
         table = Table(locator='.//table')
 
         def search(self, query, cv=None, repo=None):
@@ -147,16 +143,15 @@ class LCEEditView(BaseLoggedInView):
                 self.cv_filter.fill(cv)
             if repo:
                 self.repo_filter.fill(repo)
-            self.searchbox.search(query)
+            super().search(query)
             return self.table.read()
 
     @View.nested
-    class module_streams(SatTab):
+    class module_streams(SatTab, SearchableViewMixin):
         TAB_NAME = 'Module Streams'
 
         cv_filter = SatSelect(".//select[@ng-model='contentView']")
         repo_filter = SatSelect(".//select[@ng-model='repository']")
-        searchbox = Search()
         table = Table('.//table')
 
         def search(self, query, cv=None, repo=None):
@@ -172,5 +167,5 @@ class LCEEditView(BaseLoggedInView):
                 self.cv_filter.fill(cv)
             if repo:
                 self.repo_filter.fill(repo)
-            self.searchbox.search(query)
+            super().search(query)
             return self.table.read()

--- a/airgun/views/location.py
+++ b/airgun/views/location.py
@@ -2,7 +2,7 @@ from widgetastic.widget import Checkbox, Table, Text, TextInput, View
 from widgetastic_patternfly import BreadCrumb
 from widgetastic_patternfly4 import Pagination as PF4Pagination
 
-from airgun.views.common import BaseLoggedInView, SatVerticalTab, SearchableViewMixinPF4
+from airgun.views.common import BaseLoggedInView, SatVerticalTab, SearchableViewMixin
 from airgun.widgets import (
     ActionsDropdown,
     CustomParameter,
@@ -11,7 +11,7 @@ from airgun.widgets import (
 )
 
 
-class LocationsView(BaseLoggedInView, SearchableViewMixinPF4):
+class LocationsView(BaseLoggedInView, SearchableViewMixin):
     title = Text("//h1[normalize-space(.)='Locations']")
     new = Text("//a[contains(@href, '/locations/new')]")
     table = Table(
@@ -25,7 +25,7 @@ class LocationsView(BaseLoggedInView, SearchableViewMixinPF4):
 
     @property
     def is_displayed(self):
-        return self.browser.wait_for_element(self.title, exception=False) is not None
+        return self.title.is_displayed
 
 
 class LocationCreateView(BaseLoggedInView):
@@ -37,9 +37,8 @@ class LocationCreateView(BaseLoggedInView):
 
     @property
     def is_displayed(self):
-        breadcrumb_loaded = self.browser.wait_for_element(self.breadcrumb, exception=False)
         return (
-            breadcrumb_loaded
+            self.breadcrumb.is_displayed
             and self.breadcrumb.locations[0] == 'Locations'
             and self.breadcrumb.read() == 'New Location'
         )
@@ -52,9 +51,8 @@ class LocationsEditView(BaseLoggedInView):
 
     @property
     def is_displayed(self):
-        breadcrumb_loaded = self.browser.wait_for_element(self.breadcrumb, exception=False)
         return (
-            breadcrumb_loaded
+            self.breadcrumb.is_displayed
             and self.breadcrumb.locations[0] == 'Locations'
             and self.breadcrumb.read().startswith('Edit ')
         )

--- a/airgun/views/login.py
+++ b/airgun/views/login.py
@@ -10,4 +10,4 @@ class LoginView(View, ClickableMixin):
 
     @property
     def is_displayed(self):
-        return self.browser.wait_for_element(self.username, exception=False) is not None
+        return self.username.is_displayed

--- a/airgun/views/media.py
+++ b/airgun/views/media.py
@@ -1,11 +1,11 @@
 from widgetastic.widget import Table, Text, TextInput, View
 from widgetastic_patternfly import BreadCrumb
 
-from airgun.views.common import BaseLoggedInView, SatTab, SearchableViewMixinPF4
+from airgun.views.common import BaseLoggedInView, SatTab, SearchableViewMixin
 from airgun.widgets import FilteredDropdown, MultiSelect
 
 
-class MediumView(BaseLoggedInView, SearchableViewMixinPF4):
+class MediumView(BaseLoggedInView, SearchableViewMixin):
     title = Text("//h1[normalize-space(.)='Installation Media']")
     new = Text("//a[contains(@href, '/media/new')]")
     table = Table(
@@ -18,7 +18,7 @@ class MediumView(BaseLoggedInView, SearchableViewMixinPF4):
 
     @property
     def is_displayed(self):
-        return self.browser.wait_for_element(self.title, exception=False) is not None
+        return self.title.is_displayed
 
 
 class MediaCreateView(BaseLoggedInView):
@@ -27,9 +27,8 @@ class MediaCreateView(BaseLoggedInView):
 
     @property
     def is_displayed(self):
-        breadcrumb_loaded = self.browser.wait_for_element(self.breadcrumb, exception=False)
         return (
-            breadcrumb_loaded
+            self.breadcrumb.is_displayed
             and self.breadcrumb.locations[0] == 'Installation Media'
             and self.breadcrumb.read() == 'Create Medium'
         )
@@ -52,9 +51,8 @@ class MediaCreateView(BaseLoggedInView):
 class MediaEditView(MediaCreateView):
     @property
     def is_displayed(self):
-        breadcrumb_loaded = self.browser.wait_for_element(self.breadcrumb, exception=False)
         return (
-            breadcrumb_loaded
+            self.breadcrumb.is_displayed
             and self.breadcrumb.locations[0] == 'Installation Media'
             and self.breadcrumb.read().startswith('Edit ')
         )

--- a/airgun/views/modulestream.py
+++ b/airgun/views/modulestream.py
@@ -5,12 +5,12 @@ from airgun.views.common import (
     BaseLoggedInView,
     SatTab,
     SatTable,
-    SearchableViewMixinPF4,
+    SearchableViewMixin,
 )
 from airgun.widgets import SatTableWithUnevenStructure
 
 
-class ModuleStreamView(BaseLoggedInView, SearchableViewMixinPF4):
+class ModuleStreamView(BaseLoggedInView, SearchableViewMixin):
     """Main Module_Streams view"""
 
     title = Text('//h1[contains(., "Module Streams")]')
@@ -19,7 +19,7 @@ class ModuleStreamView(BaseLoggedInView, SearchableViewMixinPF4):
     @property
     def is_displayed(self):
         """The view is displayed when it's title exists"""
-        return self.browser.wait_for_element(self.title, exception=False) is not None
+        return self.title.is_displayed
 
 
 class ModuleStreamsDetailsView(BaseLoggedInView):
@@ -31,7 +31,7 @@ class ModuleStreamsDetailsView(BaseLoggedInView):
     @property
     def is_displayed(self):
         """Assume the view is displayed when its breadcrumb is visible"""
-        breadcrumb_loaded = self.browser.wait_for_element(self.breadcrumb, exception=False)
+        breadcrumb_loaded = self.breadcrumb.is_displayed
         return breadcrumb_loaded and self.breadcrumb.locations[0] == 'Module Streams'
 
     @View.nested

--- a/airgun/views/organization.py
+++ b/airgun/views/organization.py
@@ -1,7 +1,7 @@
 from widgetastic.widget import Checkbox, Table, Text, TextInput, View
 from widgetastic_patternfly import BreadCrumb
 
-from airgun.views.common import BaseLoggedInView, SatVerticalTab, SearchableViewMixinPF4
+from airgun.views.common import BaseLoggedInView, SatVerticalTab, SearchableViewMixin
 from airgun.widgets import (
     ActionsDropdown,
     CustomParameter,
@@ -10,7 +10,7 @@ from airgun.widgets import (
 )
 
 
-class OrganizationsView(BaseLoggedInView, SearchableViewMixinPF4):
+class OrganizationsView(BaseLoggedInView, SearchableViewMixin):
     title = Text("//h1[normalize-space(.)='Organizations']")
     new = Text("//a[contains(@href, '/organizations/new')]")
     table = Table(
@@ -23,7 +23,7 @@ class OrganizationsView(BaseLoggedInView, SearchableViewMixinPF4):
 
     @property
     def is_displayed(self):
-        return self.browser.wait_for_element(self.title, exception=False) is not None
+        return self.title.is_displayed
 
 
 class OrganizationCreateView(BaseLoggedInView):
@@ -35,9 +35,8 @@ class OrganizationCreateView(BaseLoggedInView):
 
     @property
     def is_displayed(self):
-        breadcrumb_loaded = self.browser.wait_for_element(self.breadcrumb, exception=False)
         return (
-            breadcrumb_loaded
+            self.breadcrumb.is_displayed
             and self.breadcrumb.locations[0] == 'Organizations'
             and self.breadcrumb.read() == 'New Organization'
         )
@@ -51,9 +50,8 @@ class OrganizationCreateSelectHostsView(BaseLoggedInView):
 
     @property
     def is_displayed(self):
-        breadcrumb_loaded = self.browser.wait_for_element(self.breadcrumb, exception=False)
         return (
-            breadcrumb_loaded
+            self.breadcrumb.is_displayed
             and self.breadcrumb.locations[0] == 'Organizations'
             and self.breadcrumb.read() == 'Assign Hosts to'
         )
@@ -66,9 +64,8 @@ class OrganizationEditView(BaseLoggedInView):
 
     @property
     def is_displayed(self):
-        breadcrumb_loaded = self.browser.wait_for_element(self.breadcrumb, exception=False)
         return (
-            breadcrumb_loaded
+            self.breadcrumb.is_displayed
             and self.breadcrumb.locations[0] == 'Organizations'
             and self.breadcrumb.read().startswith('Edit ')
         )

--- a/airgun/views/os.py
+++ b/airgun/views/os.py
@@ -1,7 +1,7 @@
 from widgetastic.widget import Table, Text, TextInput, View
 from widgetastic_patternfly import BreadCrumb
 
-from airgun.views.common import BaseLoggedInView, SatTab, SearchableViewMixinPF4
+from airgun.views.common import BaseLoggedInView, SatTab, SearchableViewMixin
 from airgun.widgets import (
     ActionsDropdown,
     CustomParameter,
@@ -66,7 +66,7 @@ class TemplatesList(View):
             result[title].fill(select_value)
 
 
-class OperatingSystemsView(BaseLoggedInView, SearchableViewMixinPF4):
+class OperatingSystemsView(BaseLoggedInView, SearchableViewMixin):
     title = Text("//h1[normalize-space(.)='Operating Systems']")
     new = Text("//a[contains(@href, '/operatingsystems/new')]")
     table = Table(
@@ -79,7 +79,7 @@ class OperatingSystemsView(BaseLoggedInView, SearchableViewMixinPF4):
 
     @property
     def is_displayed(self):
-        return self.browser.wait_for_element(self.title, exception=False) is not None
+        return self.title.is_displayed
 
 
 class OperatingSystemEditView(BaseLoggedInView):
@@ -88,9 +88,8 @@ class OperatingSystemEditView(BaseLoggedInView):
 
     @property
     def is_displayed(self):
-        breadcrumb_loaded = self.browser.wait_for_element(self.breadcrumb, exception=False)
         return (
-            breadcrumb_loaded
+            self.breadcrumb.is_displayed
             and self.breadcrumb.locations[0] == 'Operating Systems'
             and self.breadcrumb.read().startswith('Edit ')
         )
@@ -129,9 +128,8 @@ class OperatingSystemEditView(BaseLoggedInView):
 class OperatingSystemCreateView(OperatingSystemEditView):
     @property
     def is_displayed(self):
-        breadcrumb_loaded = self.browser.wait_for_element(self.breadcrumb, exception=False)
         return (
-            breadcrumb_loaded
+            self.breadcrumb.is_displayed
             and self.breadcrumb.locations[0] == 'Operating Systems'
             and self.breadcrumb.read() == 'Create Operating System'
         )

--- a/airgun/views/oscapcontent.py
+++ b/airgun/views/oscapcontent.py
@@ -1,11 +1,11 @@
 from widgetastic.widget import FileInput, Text, TextInput, View
 from widgetastic_patternfly import BreadCrumb
 
-from airgun.views.common import BaseLoggedInView, SatTab, SearchableViewMixinPF4
+from airgun.views.common import BaseLoggedInView, SatTab, SearchableViewMixin
 from airgun.widgets import ActionsDropdown, MultiSelect, SatTable
 
 
-class SCAPContentsView(BaseLoggedInView, SearchableViewMixinPF4):
+class SCAPContentsView(BaseLoggedInView, SearchableViewMixin):
     title = Text("//h1[normalize-space(.)='SCAP Contents']")
     new = Text("//a[contains(@href, 'scap_contents/new')]")
     table = SatTable(
@@ -18,7 +18,7 @@ class SCAPContentsView(BaseLoggedInView, SearchableViewMixinPF4):
 
     @property
     def is_displayed(self):
-        return self.browser.wait_for_element(self.title, exception=False) is not None
+        return self.title.is_displayed
 
 
 class SCAPContentCreateView(BaseLoggedInView):
@@ -42,7 +42,7 @@ class SCAPContentCreateView(BaseLoggedInView):
 
     @property
     def is_displayed(self):
-        return self.browser.wait_for_element(self.create_form, exception=False) is not None
+        return self.create_form.is_displayed
 
 
 class SCAPContentEditView(SCAPContentCreateView):
@@ -58,5 +58,5 @@ class SCAPContentEditView(SCAPContentCreateView):
 
     @property
     def is_displayed(self):
-        breadcrumb_loaded = self.browser.wait_for_element(self.breadcrumb, exception=False)
+        breadcrumb_loaded = self.breadcrumb.is_displayed
         return breadcrumb_loaded and self.breadcrumb.locations[0] == 'Scap Contents'

--- a/airgun/views/oscappolicy.py
+++ b/airgun/views/oscappolicy.py
@@ -25,7 +25,7 @@ class SCAPPoliciesView(BaseLoggedInView, SearchableViewMixin):
 
     @property
     def is_displayed(self):
-        return self.browser.wait_for_element(self.title, exception=False) is not None
+        return self.title.is_displayed
 
 
 class ScapPolicyRadioGroup(RadioGroup):
@@ -67,9 +67,8 @@ class SCAPPolicyCreateView(BaseLoggedInView):
 
     @property
     def is_displayed(self):
-        breadcrumb_loaded = self.browser.wait_for_element(self.breadcrumb, exception=False)
         return (
-            breadcrumb_loaded
+            self.breadcrumb.is_displayed
             and self.breadcrumb.locations[0] == 'Policies'
             and self.breadcrumb.read() == 'New Compliance Policy'
         )
@@ -156,9 +155,8 @@ class SCAPPolicyEditView(BaseLoggedInView):
 
     @property
     def is_displayed(self):
-        breadcrumb_loaded = self.browser.wait_for_element(self.breadcrumb, exception=False)
         return (
-            breadcrumb_loaded
+            self.breadcrumb.is_displayed
             and self.breadcrumb.locations[0] == 'Policies'
             and self.breadcrumb.read() != 'New Compliance Policy'
         )
@@ -217,7 +215,7 @@ class SCAPPolicyDetailsView(BaseLoggedInView):
 
     @property
     def is_displayed(self):
-        return self.browser.wait_for_element(self.title, exception=False) is not None
+        return self.title.is_displayed
 
     @View.nested
     class HostsBreakdownStatus(View):

--- a/airgun/views/oscapreport.py
+++ b/airgun/views/oscapreport.py
@@ -27,7 +27,7 @@ class SCAPReportView(BaseLoggedInView, SearchableViewMixin):
 
     @property
     def is_displayed(self):
-        return self.browser.wait_for_element(self.title, exception=False) is not None
+        return self.title.is_displayed
 
 
 class SCAPReportDetailsView(BaseLoggedInView):
@@ -45,9 +45,7 @@ class SCAPReportDetailsView(BaseLoggedInView):
 
     @property
     def is_displayed(self):
-        return (
-            self.browser.wait_for_element(self.show_log_messages_label, exception=False) is not None
-        )
+        return self.show_log_messages_label.is_displayed
 
 
 class RemediateModal(View):

--- a/airgun/views/oscaptailoringfile.py
+++ b/airgun/views/oscaptailoringfile.py
@@ -18,7 +18,7 @@ class SCAPTailoringFilesView(BaseLoggedInView, SearchableViewMixin):
 
     @property
     def is_displayed(self):
-        return self.browser.wait_for_element(self.title, exception=False) is not None
+        return self.title.is_displayed
 
 
 class SCAPTailoringFileCreateView(BaseLoggedInView):
@@ -28,9 +28,8 @@ class SCAPTailoringFileCreateView(BaseLoggedInView):
 
     @property
     def is_displayed(self):
-        breadcrumb_loaded = self.browser.wait_for_element(self.breadcrumb, exception=False)
         return (
-            breadcrumb_loaded
+            self.breadcrumb.is_displayed
             and self.breadcrumb.locations[0] == 'Tailoring files'
             and self.breadcrumb.read() == 'Upload new Tailoring File'
         )
@@ -62,9 +61,8 @@ class SCAPTailoringFileEditView(SCAPTailoringFileCreateView):
 
     @property
     def is_displayed(self):
-        breadcrumb_loaded = self.browser.wait_for_element(self.breadcrumb, exception=False)
         return (
-            breadcrumb_loaded
+            self.breadcrumb.is_displayed
             and self.breadcrumb.locations[0] == 'Tailoring files'
             and self.breadcrumb.read() != 'Upload new Tailoring File'
         )

--- a/airgun/views/package.py
+++ b/airgun/views/package.py
@@ -46,7 +46,7 @@ class PackagesView(BaseLoggedInView):
     @property
     def is_displayed(self):
         """The view is displayed when it's title exists"""
-        return self.browser.wait_for_element(self.title, exception=False) is not None
+        return self.title.is_displayed
 
 
 class PackageDetailsView(BaseLoggedInView):
@@ -55,7 +55,7 @@ class PackageDetailsView(BaseLoggedInView):
 
     @property
     def is_displayed(self):
-        breadcrumb_loaded = self.browser.wait_for_element(self.breadcrumb, exception=False)
+        breadcrumb_loaded = self.breadcrumb.is_displayed
 
         return breadcrumb_loaded and self.breadcrumb.locations[0] == 'Packages'
 

--- a/airgun/views/partitiontable.py
+++ b/airgun/views/partitiontable.py
@@ -11,7 +11,7 @@ from widgetastic_patternfly import BreadCrumb, Button
 from airgun.views.common import (
     BaseLoggedInView,
     SatTab,
-    SearchableViewMixinPF4,
+    SearchableViewMixin,
     TemplateEditor,
     TemplateInputItem,
 )
@@ -23,7 +23,7 @@ from airgun.widgets import (
 )
 
 
-class PartitionTablesView(BaseLoggedInView, SearchableViewMixinPF4):
+class PartitionTablesView(BaseLoggedInView, SearchableViewMixin):
     title = Text("//h1[text()='Partition Tables']")
     new = Button('Create Partition Table')
     table = Table(
@@ -36,7 +36,7 @@ class PartitionTablesView(BaseLoggedInView, SearchableViewMixinPF4):
 
     @property
     def is_displayed(self):
-        return self.browser.wait_for_element(self.title, exception=False) is not None
+        return self.title.is_displayed
 
 
 class PartitionTableEditView(BaseLoggedInView):
@@ -77,9 +77,8 @@ class PartitionTableEditView(BaseLoggedInView):
 
     @property
     def is_displayed(self):
-        breadcrumb_loaded = self.browser.wait_for_element(self.breadcrumb, exception=False)
         return (
-            breadcrumb_loaded
+            self.breadcrumb.is_displayed
             and self.breadcrumb.locations[0] == 'Partition Tables'
             and self.breadcrumb.read().startswith('Edit ')
         )
@@ -88,9 +87,8 @@ class PartitionTableEditView(BaseLoggedInView):
 class PartitionTableCreateView(PartitionTableEditView):
     @property
     def is_displayed(self):
-        breadcrumb_loaded = self.browser.wait_for_element(self.breadcrumb, exception=False)
         return (
-            breadcrumb_loaded
+            self.breadcrumb.is_displayed
             and self.breadcrumb.locations[0] == 'Partition Tables'
             and self.breadcrumb.read() == 'Create Partition Table'
         )

--- a/airgun/views/product.py
+++ b/airgun/views/product.py
@@ -25,16 +25,14 @@ from airgun.widgets import (
     ReadOnlyEntry,
     SatSelect,
     SatTable,
-    Search,
 )
 
 
-class CreateDiscoveredReposView(View):
+class CreateDiscoveredReposView(View, SearchableViewMixin):
     """View which represent Discovered Repository section in Repository
     Discovery procedure.
     """
 
-    searchbox = Search()
     table = SatTable(
         locator='.//table',
         column_widgets={0: Checkbox(locator=".//input[@ng-change='itemSelected(urlRow)']")},
@@ -72,7 +70,7 @@ class ProductsTableView(BaseLoggedInView, SearchableViewMixin):
 
     @property
     def is_displayed(self):
-        return self.browser.wait_for_element(self.title, exception=False) is not None
+        return self.title.is_displayed
 
 
 class ProductCreateView(BaseLoggedInView):
@@ -90,9 +88,8 @@ class ProductCreateView(BaseLoggedInView):
 
     @property
     def is_displayed(self):
-        breadcrumb_loaded = self.browser.wait_for_element(self.breadcrumb, exception=False)
         return (
-            breadcrumb_loaded
+            self.breadcrumb.is_displayed
             and self.breadcrumb.locations[0] == 'Products'
             and self.breadcrumb.read() == 'New Product'
         )
@@ -106,9 +103,8 @@ class ProductEditView(BaseLoggedInView):
 
     @property
     def is_displayed(self):
-        breadcrumb_loaded = self.browser.wait_for_element(self.breadcrumb, exception=False)
         return (
-            breadcrumb_loaded
+            self.breadcrumb.is_displayed
             and self.breadcrumb.locations[0] == 'Products'
             and self.breadcrumb.read() not in ('New Product', 'Discover Repositories')
             and len(self.breadcrumb.locations) <= self.BREADCRUMB_LENGTH
@@ -150,9 +146,8 @@ class ProductRepoDiscoveryView(BaseLoggedInView, SearchableViewMixin):
 
     @property
     def is_displayed(self):
-        breadcrumb_loaded = self.browser.wait_for_element(self.breadcrumb, exception=False)
         return (
-            breadcrumb_loaded
+            self.breadcrumb.is_displayed
             and self.breadcrumb.locations[0] == 'Products'
             and self.breadcrumb.read() == 'Discover Repositories'
         )
@@ -227,9 +222,8 @@ class ProductTaskDetailsView(TaskDetailsView):
 
     @property
     def is_displayed(self):
-        breadcrumb_loaded = self.browser.wait_for_element(self.breadcrumb, exception=False)
         return (
-            breadcrumb_loaded
+            self.breadcrumb.is_displayed
             and self.breadcrumb.locations[0] == 'Products'
             and self.breadcrumb.locations[2] == 'Tasks'
             and len(self.breadcrumb.locations) > self.BREADCRUMB_LENGTH
@@ -242,7 +236,7 @@ class ProductSyncPlanView(SyncPlanCreateView):
 
     @property
     def is_displayed(self):
-        return self.browser.wait_for_element(self.title, exception=False) is not None
+        return self.title.is_displayed
 
 
 class ProductManageHttpProxy(BaseLoggedInView):
@@ -259,7 +253,7 @@ class ProductManageHttpProxy(BaseLoggedInView):
 
     @property
     def is_displayed(self):
-        return self.browser.wait_for_element(self.title, exception=False) is not None
+        return self.title.is_displayed
 
 
 class ProductAdvancedSync(BaseLoggedInView):
@@ -273,7 +267,7 @@ class ProductAdvancedSync(BaseLoggedInView):
 
     @property
     def is_displayed(self):
-        return self.browser.wait_for_element(self.title, exception=False) is not None
+        return self.title.is_displayed
 
 
 class ProductVerifyContentChecksum(BaseLoggedInView):
@@ -283,4 +277,4 @@ class ProductVerifyContentChecksum(BaseLoggedInView):
 
     @property
     def is_displayed(self):
-        return self.browser.wait_for_element(self.task_alert, exception=False) is not None
+        return self.task_alert.is_displayed

--- a/airgun/views/provisioning_template.py
+++ b/airgun/views/provisioning_template.py
@@ -4,7 +4,7 @@ from widgetastic_patternfly import BreadCrumb, Button
 from airgun.views.common import (
     BaseLoggedInView,
     SatTab,
-    SearchableViewMixinPF4,
+    SearchableViewMixin,
     TemplateEditor,
     TemplateInputItem,
 )
@@ -24,7 +24,7 @@ class TemplateHostEnvironmentAssociation(GenericRemovableWidgetItem):
     host_group = Select(locator=".//select[contains(@name, '[hostgroup_id]')]")
 
 
-class ProvisioningTemplatesView(BaseLoggedInView, SearchableViewMixinPF4):
+class ProvisioningTemplatesView(BaseLoggedInView, SearchableViewMixin):
     title = Text("//h1[normalize-space(.)='Provisioning Templates']")
     new = Button('Create Template')
     build_pxe_default = Button('Build PXE Default')
@@ -39,7 +39,7 @@ class ProvisioningTemplatesView(BaseLoggedInView, SearchableViewMixinPF4):
 
     @property
     def is_displayed(self):
-        return self.browser.wait_for_element(self.title, exception=False) is not None
+        return self.title.is_displayed
 
 
 class ProvisioningTemplateDetailsView(BaseLoggedInView):
@@ -48,9 +48,8 @@ class ProvisioningTemplateDetailsView(BaseLoggedInView):
 
     @property
     def is_displayed(self):
-        breadcrumb_loaded = self.browser.wait_for_element(self.breadcrumb, exception=False)
         return (
-            breadcrumb_loaded
+            self.breadcrumb.is_displayed
             and self.breadcrumb.locations[0] == 'Provisioning Templates'
             and self.breadcrumb.read().startswith('Edit ')
         )
@@ -96,9 +95,8 @@ class ProvisioningTemplateDetailsView(BaseLoggedInView):
 class ProvisioningTemplateCreateView(ProvisioningTemplateDetailsView):
     @property
     def is_displayed(self):
-        breadcrumb_loaded = self.browser.wait_for_element(self.breadcrumb, exception=False)
         return (
-            breadcrumb_loaded
+            self.breadcrumb.is_displayed
             and self.breadcrumb.locations[0] == 'Provisioning Templates'
             and self.breadcrumb.read() == 'Create Template'
         )

--- a/airgun/views/puppet_class.py
+++ b/airgun/views/puppet_class.py
@@ -19,7 +19,7 @@ class PuppetClassesView(BaseLoggedInView, SearchableViewMixin):
 
     @property
     def is_displayed(self):
-        return self.browser.wait_for_element(self.title, exception=False) is not None
+        return self.title.is_displayed
 
 
 class PuppetClassDetailsView(BaseLoggedInView):
@@ -28,9 +28,8 @@ class PuppetClassDetailsView(BaseLoggedInView):
 
     @property
     def is_displayed(self):
-        breadcrumb_loaded = self.browser.wait_for_element(self.breadcrumb, exception=False)
         return (
-            breadcrumb_loaded
+            self.breadcrumb.is_displayed
             and self.breadcrumb.locations[0] == 'Puppetclasses'
             and self.breadcrumb.read().startswith('Edit Puppet Class ')
         )

--- a/airgun/views/puppet_environment.py
+++ b/airgun/views/puppet_environment.py
@@ -31,7 +31,7 @@ class PuppetEnvironmentTableView(BaseLoggedInView, SearchableViewMixin):
 
     @property
     def is_displayed(self):
-        return self.browser.wait_for_element(self.title, exception=False) is not None
+        return self.title.is_displayed
 
 
 class PuppetEnvironmentImportView(BaseLoggedInView, SearchableViewMixin):
@@ -55,9 +55,8 @@ class PuppetEnvironmentImportView(BaseLoggedInView, SearchableViewMixin):
 
     @property
     def is_displayed(self):
-        breadcrumb_loaded = self.browser.wait_for_element(self.breadcrumb, exception=False)
         return (
-            breadcrumb_loaded
+            self.breadcrumb.is_displayed
             and self.breadcrumb.locations[0] == 'Environments'
             and self.breadcrumb.read() == 'Changed Environments'
         )
@@ -74,9 +73,8 @@ class PuppetEnvironmentCreateView(BaseLoggedInView):
 
     @property
     def is_displayed(self):
-        breadcrumb_loaded = self.browser.wait_for_element(self.breadcrumb, exception=False)
         return (
-            breadcrumb_loaded
+            self.breadcrumb.is_displayed
             and self.breadcrumb.locations[0] == 'Environments'
             and self.breadcrumb.read() == 'Create Environment'
         )

--- a/airgun/views/redhat_repository.py
+++ b/airgun/views/redhat_repository.py
@@ -261,4 +261,4 @@ class RedHatRepositoriesView(BaseLoggedInView):
 
     @property
     def is_displayed(self):
-        return self.browser.wait_for_element(self.title, exception=False) is not None
+        return self.title.is_displayed

--- a/airgun/views/report_template.py
+++ b/airgun/views/report_template.py
@@ -4,7 +4,7 @@ from widgetastic_patternfly import BreadCrumb, Button
 from airgun.views.common import (
     BaseLoggedInView,
     SatTab,
-    SearchableViewMixinPF4,
+    SearchableViewMixin,
     TemplateEditor,
     TemplateInputItem,
 )
@@ -17,7 +17,7 @@ from airgun.widgets import (
 )
 
 
-class ReportTemplatesView(BaseLoggedInView, SearchableViewMixinPF4):
+class ReportTemplatesView(BaseLoggedInView, SearchableViewMixin):
     title = Text("//h1[normalize-space(.)='Report Templates']")
     new = Button('Create Template')
     table = Table(
@@ -31,7 +31,7 @@ class ReportTemplatesView(BaseLoggedInView, SearchableViewMixinPF4):
 
     @property
     def is_displayed(self):
-        return self.browser.wait_for_element(self.title, exception=False) is not None
+        return self.title.is_displayed
 
 
 class ReportTemplateDetailsView(BaseLoggedInView):
@@ -40,9 +40,8 @@ class ReportTemplateDetailsView(BaseLoggedInView):
 
     @property
     def is_displayed(self):
-        breadcrumb_loaded = self.browser.wait_for_element(self.breadcrumb, exception=False)
         return (
-            breadcrumb_loaded
+            self.breadcrumb.is_displayed
             and self.breadcrumb.locations[0] == 'Report Templates'
             and self.breadcrumb.read().startswith('Edit ')
         )
@@ -76,9 +75,8 @@ class ReportTemplateDetailsView(BaseLoggedInView):
 class ReportTemplateCreateView(ReportTemplateDetailsView):
     @property
     def is_displayed(self):
-        breadcrumb_loaded = self.browser.wait_for_element(self.breadcrumb, exception=False)
         return (
-            breadcrumb_loaded
+            self.breadcrumb.is_displayed
             and self.breadcrumb.locations[0] == 'Report Templates'
             and self.breadcrumb.read() == 'Create Template'
         )
@@ -102,9 +100,8 @@ class ReportTemplateGenerateView(BaseLoggedInView):
 
     @property
     def is_displayed(self):
-        breadcrumb_loaded = self.browser.wait_for_element(self.breadcrumb, exception=False)
         return (
-            breadcrumb_loaded
+            self.breadcrumb.is_displayed
             and self.breadcrumb.locations[0] == 'Report Templates'
             and self.breadcrumb.read() == 'Generate a Report'
         )
@@ -116,9 +113,8 @@ class ReportTemplateGeneratedView(BaseLoggedInView):
 
     @property
     def is_displayed(self):
-        breadcrumb_loaded = self.browser.wait_for_element(self.breadcrumb, exception=False)
         return (
-            breadcrumb_loaded
+            self.breadcrumb.is_displayed
             and self.breadcrumb.locations[0] == 'Report Templates'
             and self.breadcrumb.read() == 'Download generated report'
         )

--- a/airgun/views/repository.py
+++ b/airgun/views/repository.py
@@ -41,9 +41,8 @@ class RepositoriesView(BaseLoggedInView, SearchableViewMixin):
 
     @property
     def is_displayed(self):
-        breadcrumb_loaded = self.browser.wait_for_element(self.breadcrumb, exception=False)
         return (
-            breadcrumb_loaded
+            self.breadcrumb.is_displayed
             and self.breadcrumb.locations[0] == 'Products'
             and self.breadcrumb.read() == 'Repositories'
         )
@@ -188,9 +187,8 @@ class RepositoryCreateView(BaseLoggedInView):
 
     @property
     def is_displayed(self):
-        breadcrumb_loaded = self.browser.wait_for_element(self.breadcrumb, exception=False)
         return (
-            breadcrumb_loaded
+            self.breadcrumb.is_displayed
             and self.breadcrumb.locations[0] == 'Products'
             and self.breadcrumb.locations[2] == 'Repositories'
             and self.breadcrumb.read() == 'New Repository'
@@ -305,9 +303,8 @@ class RepositoryEditView(BaseLoggedInView):
 
     @property
     def is_displayed(self):
-        breadcrumb_loaded = self.browser.wait_for_element(self.breadcrumb, exception=False)
         return (
-            breadcrumb_loaded
+            self.breadcrumb.is_displayed
             and self.breadcrumb.locations[0] == 'Products'
             # repositories do not have tabs, so if we are deep inside some
             # specific repository (e.g. in repository packages) - there's no
@@ -334,9 +331,8 @@ class RepositoryPackagesView(BaseLoggedInView, SearchableViewMixin):
 
     @property
     def is_displayed(self):
-        breadcrumb_loaded = self.browser.wait_for_element(self.breadcrumb, exception=False)
         return (
-            breadcrumb_loaded
+            self.breadcrumb.is_displayed
             and self.breadcrumb.locations[0] == 'Products'
             and self.breadcrumb.locations[2] == 'Repositories'
             and self.breadcrumb.read() == 'Packages'

--- a/airgun/views/rhai.py
+++ b/airgun/views/rhai.py
@@ -21,10 +21,7 @@ class InsightsOrganizationErrorView(BaseLoggedInView):
 
     @property
     def is_displayed(self):
-        return (
-            self.browser.wait_for_element(self.title, exception=False) is not None
-            and self.browser.wait_for_element(self.message, exception=False) is not None
-        )
+        return self.title.is_displayed and self.message.is_displayed
 
     def read(self, widget_names=None):
         return f'{self.title.read()}: {self.message.read()}'

--- a/airgun/views/rhsso_login.py
+++ b/airgun/views/rhsso_login.py
@@ -9,7 +9,7 @@ class RhssoLoginView(View, ClickableMixin):
 
     @property
     def is_displayed(self):
-        return self.browser.wait_for_element(self.username, exception=False) is not None
+        return self.username.is_displayed
 
 
 class RhssoExternalLogoutView(View, ClickableMixin):
@@ -18,7 +18,7 @@ class RhssoExternalLogoutView(View, ClickableMixin):
 
     @property
     def is_displayed(self):
-        return self.browser.wait_for_element(self.login_again, exception=False) is not None
+        return self.login_again.is_displayed
 
 
 class RhssoTwoFactorSuccessView(View, ClickableMixin):
@@ -26,7 +26,7 @@ class RhssoTwoFactorSuccessView(View, ClickableMixin):
 
     @property
     def is_displayed(self):
-        return self.browser.wait_for_element(self.code, exception=False) is not None
+        return self.code.is_displayed
 
 
 class RhssoTotpView(View, ClickableMixin):
@@ -35,4 +35,4 @@ class RhssoTotpView(View, ClickableMixin):
 
     @property
     def is_displayed(self):
-        return self.browser.wait_for_element(self.totp, exception=False) is not None
+        return self.totp.is_displayed

--- a/airgun/views/role.py
+++ b/airgun/views/role.py
@@ -1,11 +1,11 @@
 from widgetastic.widget import Text, TextInput
 from widgetastic_patternfly import BreadCrumb
 
-from airgun.views.common import BaseLoggedInView, SearchableViewMixinPF4
+from airgun.views.common import BaseLoggedInView, SearchableViewMixin
 from airgun.widgets import ActionsDropdown, MultiSelect, SatTable
 
 
-class RolesView(BaseLoggedInView, SearchableViewMixinPF4):
+class RolesView(BaseLoggedInView, SearchableViewMixin):
     title = Text("//h1[normalize-space(.)='Roles']")
     new = Text("//a[contains(@href, '/roles/new')]")
     table = SatTable(
@@ -18,7 +18,7 @@ class RolesView(BaseLoggedInView, SearchableViewMixinPF4):
 
     @property
     def is_displayed(self):
-        return self.browser.wait_for_element(self.title, exception=False) is not None
+        return self.title.is_displayed
 
 
 class RoleEditView(BaseLoggedInView):
@@ -31,9 +31,8 @@ class RoleEditView(BaseLoggedInView):
 
     @property
     def is_displayed(self):
-        breadcrumb_loaded = self.browser.wait_for_element(self.breadcrumb, exception=False)
         return (
-            breadcrumb_loaded
+            self.breadcrumb.is_displayed
             and self.breadcrumb.locations[0] == 'Roles'
             and self.breadcrumb.read().startswith('Edit ')
         )
@@ -42,9 +41,8 @@ class RoleEditView(BaseLoggedInView):
 class RoleCreateView(RoleEditView):
     @property
     def is_displayed(self):
-        breadcrumb_loaded = self.browser.wait_for_element(self.breadcrumb, exception=False)
         return (
-            breadcrumb_loaded
+            self.breadcrumb.is_displayed
             and self.breadcrumb.locations[0] == 'Roles'
             and self.breadcrumb.read() == 'Create Role'
         )

--- a/airgun/views/settings.py
+++ b/airgun/views/settings.py
@@ -19,7 +19,7 @@ class SettingsView(BaseLoggedInView, SearchableViewMixin):
 
     @property
     def is_displayed(self):
-        return self.browser.wait_for_element(self.title, exception=False) is not None
+        return self.title.is_displayed
 
     def wait_for_update(self):
         """Wait for value to update"""

--- a/airgun/views/smart_class_parameter.py
+++ b/airgun/views/smart_class_parameter.py
@@ -113,7 +113,7 @@ class SmartClassParametersView(BaseLoggedInView, SearchableViewMixin):
 
     @property
     def is_displayed(self):
-        return self.browser.wait_for_element(self.title, exception=False) is not None
+        return self.title.is_displayed
 
 
 class SmartClassParameterEditView(BaseLoggedInView):
@@ -124,9 +124,8 @@ class SmartClassParameterEditView(BaseLoggedInView):
 
     @property
     def is_displayed(self):
-        breadcrumb_loaded = self.browser.wait_for_element(self.breadcrumb, exception=False)
         return (
-            breadcrumb_loaded
+            self.breadcrumb.is_displayed
             and self.breadcrumb.locations[0] == 'Smart Class Parameters'
             and len(self.breadcrumb.locations) == self.BREADCRUMB_LENGTH
         )

--- a/airgun/views/subnet.py
+++ b/airgun/views/subnet.py
@@ -1,7 +1,7 @@
 from widgetastic.widget import Table, Text, TextInput, View
 from widgetastic_patternfly import BreadCrumb
 
-from airgun.views.common import BaseLoggedInView, SatTab, SearchableViewMixinPF4
+from airgun.views.common import BaseLoggedInView, SatTab, SearchableViewMixin
 from airgun.widgets import (
     CustomParameter,
     FilteredDropdown,
@@ -10,7 +10,7 @@ from airgun.widgets import (
 )
 
 
-class SubnetsView(BaseLoggedInView, SearchableViewMixinPF4):
+class SubnetsView(BaseLoggedInView, SearchableViewMixin):
     title = Text('//*[(self::h1 or self::h5) and normalize-space(.)="Subnets"]')
     new = Text('//a[normalize-space(.)="Create Subnet"]')
     table = Table(
@@ -24,7 +24,7 @@ class SubnetsView(BaseLoggedInView, SearchableViewMixinPF4):
 
     @property
     def is_displayed(self):
-        return self.browser.wait_for_element(self.title, exception=False) is not None
+        return self.title.is_displayed
 
 
 class SubnetCreateView(BaseLoggedInView):
@@ -33,9 +33,8 @@ class SubnetCreateView(BaseLoggedInView):
 
     @property
     def is_displayed(self):
-        breadcrumb_loaded = self.browser.wait_for_element(self.breadcrumb, exception=False)
         return (
-            breadcrumb_loaded
+            self.breadcrumb.is_displayed
             and self.breadcrumb.locations[0] == 'Subnets'
             and self.breadcrumb.read() == 'Create Subnet'
         )
@@ -88,9 +87,8 @@ class SubnetCreateView(BaseLoggedInView):
 class SubnetEditView(SubnetCreateView):
     @property
     def is_displayed(self):
-        breadcrumb_loaded = self.browser.wait_for_element(self.breadcrumb, exception=False)
         return (
-            breadcrumb_loaded
+            self.breadcrumb.is_displayed
             and self.breadcrumb.locations[0] == 'Subnets'
             and self.breadcrumb.read().startswith('Edit ')
         )

--- a/airgun/views/subscription.py
+++ b/airgun/views/subscription.py
@@ -10,12 +10,7 @@ from widgetastic.widget import (
 from widgetastic_patternfly import BreadCrumb, Button
 
 from airgun.exceptions import ReadOnlyWidgetError
-from airgun.views.common import (
-    BaseLoggedInView,
-    PF5ModalViewMixin,
-    SatTab,
-    SearchableViewMixinPF4,
-)
+from airgun.views.common import BaseLoggedInView, PF5ModalViewMixin, SatTab, SearchableViewMixin
 from airgun.widgets import (
     ConfirmationDialog,
     ItemsListReadOnly,
@@ -122,7 +117,7 @@ class SubscriptionColumnsFilter(GenericLocatorWidget):
         self.close()
 
 
-class SubscriptionListView(BaseLoggedInView, SearchableViewMixinPF4):
+class SubscriptionListView(BaseLoggedInView, SearchableViewMixin):
     """List of all subscriptions."""
 
     table = SatSubscriptionsViewTable(

--- a/airgun/views/sync_status.py
+++ b/airgun/views/sync_status.py
@@ -272,4 +272,4 @@ class SyncStatusView(BaseLoggedInView):
 
     @property
     def is_displayed(self):
-        return self.browser.wait_for_element(self.title, exception=False) is not None
+        return self.title.is_displayed

--- a/airgun/views/sync_templates.py
+++ b/airgun/views/sync_templates.py
@@ -23,11 +23,7 @@ class SyncTemplatesView(BaseLoggedInView):
 
     @property
     def is_displayed(self):
-        breadcrumb_loaded = self.browser.wait_for_element(self.breadcrumb, exception=False)
-        return (
-            breadcrumb_loaded
-            and self.browser.wait_for_element(self.title, exception=False) is not None
-        )
+        return self.breadcrumb.is_displayed and self.title.is_displayed
 
     def before_fill(self, values):
         """Wait for Sync Type Radio Button to be displayed"""
@@ -72,7 +68,7 @@ class TemplatesReportView(BaseLoggedInView):
     def is_displayed(self):
         return all(
             [
-                self.browser.wait_for_element(self.title, exception=False),
+                self.title.is_displayed,
                 self.browser.elements(self.REPORTS),
             ]
         )

--- a/airgun/views/syncplan.py
+++ b/airgun/views/syncplan.py
@@ -26,7 +26,7 @@ class SyncPlansView(BaseLoggedInView, SearchableViewMixin):
 
     @property
     def is_displayed(self):
-        return self.browser.wait_for_element(self.title, exception=False) is not None
+        return self.title.is_displayed
 
 
 class SyncPlanCreateView(BaseLoggedInView):
@@ -40,9 +40,8 @@ class SyncPlanCreateView(BaseLoggedInView):
 
     @property
     def is_displayed(self):
-        breadcrumb_loaded = self.browser.wait_for_element(self.breadcrumb, exception=False)
         return (
-            breadcrumb_loaded
+            self.breadcrumb.is_displayed
             and self.breadcrumb.locations[0] == 'Sync Plans'
             and self.breadcrumb.read() == 'New Sync Plan'
         )
@@ -55,9 +54,8 @@ class SyncPlanEditView(BaseLoggedInView):
 
     @property
     def is_displayed(self):
-        breadcrumb_loaded = self.browser.wait_for_element(self.breadcrumb, exception=False)
         return (
-            breadcrumb_loaded
+            self.breadcrumb.is_displayed
             and self.breadcrumb.locations[0] == 'Sync Plans'
             and self.breadcrumb.read() != 'New Sync Plan'
         )

--- a/airgun/views/task.py
+++ b/airgun/views/task.py
@@ -3,7 +3,7 @@ from widgetastic.widget import Table, Text, View
 from widgetastic_patternfly import BreadCrumb, Button
 from widgetastic_patternfly5 import Pagination as PF5Pagination
 
-from airgun.views.common import BaseLoggedInView, SatTab, SearchableViewMixinPF4
+from airgun.views.common import BaseLoggedInView, SatTab, SearchableViewMixin
 from airgun.widgets import (
     ActionsDropdown,
     PieChart,
@@ -24,7 +24,7 @@ class TaskReadOnlyEntryError(ReadOnlyEntry):
     BASE_LOCATOR = "//span[contains(., '{}')]//parent::div/following-sibling::pre"
 
 
-class TasksView(BaseLoggedInView, SearchableViewMixinPF4):
+class TasksView(BaseLoggedInView, SearchableViewMixin):
     title = Text("//h1[normalize-space(.)='Tasks']")
     focus = ActionsDropdown("//div[./button[@id='tasks-dashboard-time-period-dropdown']]")
     table = SatTable(
@@ -38,7 +38,7 @@ class TasksView(BaseLoggedInView, SearchableViewMixinPF4):
 
     @property
     def is_displayed(self):
-        return self.browser.wait_for_element(self.title, exception=False) is not None
+        return self.title.is_displayed
 
     @View.nested
     class RunningChart(View):
@@ -76,9 +76,8 @@ class TaskDetailsView(BaseLoggedInView):
 
     @property
     def is_displayed(self):
-        breadcrumb_loaded = self.browser.wait_for_element(self.breadcrumb, exception=False)
         return (
-            breadcrumb_loaded
+            self.breadcrumb.is_displayed
             and self.breadcrumb.locations[0] == 'Tasks'
             and len(self.breadcrumb.locations) == self.BREADCRUMB_LENGTH
         )

--- a/airgun/views/upgrade.py
+++ b/airgun/views/upgrade.py
@@ -9,4 +9,4 @@ class UpgradeView(BaseLoggedInView):
 
     @property
     def is_displayed(self):
-        return self.browser.wait_for_element(self.title, exception=False) is not None
+        return self.title.is_displayed

--- a/airgun/views/user.py
+++ b/airgun/views/user.py
@@ -1,16 +1,17 @@
 from widgetastic.widget import Checkbox, Table, Text, TextInput, View
 from widgetastic_patternfly import BreadCrumb
 
-from airgun.views.common import BaseLoggedInView, SatTab, SearchableViewMixinPF4
+from airgun.views.common import BaseLoggedInView, SatTab, SearchableViewMixin
 from airgun.widgets import FilteredDropdown, MultiSelect
 
 
-class UsersView(BaseLoggedInView, SearchableViewMixinPF4):
+class UsersView(BaseLoggedInView, SearchableViewMixin):
     title = Text("//h1[normalize-space(.)='Users']")
     new = Text("//a[contains(@href, '/users/new')]")
     dropdown = Text("//a[@href='#' and contains(@class, 'dropdown-toggle')]")
     invalidate_jwt = Text('.//a[@data-method="patch"]')
     impersonate_user = Text('.//a[@data-method="post"]')
+    # searchbox = SearchInput(locator='//div[@id="content"]//input[@aria-label="Search input"]')
     table = Table(
         './/table',
         column_widgets={
@@ -22,7 +23,7 @@ class UsersView(BaseLoggedInView, SearchableViewMixinPF4):
 
     @property
     def is_displayed(self):
-        return self.browser.wait_for_element(self.title, exception=False) is not None
+        return self.title.is_displayed
 
 
 class UserDetailsView(BaseLoggedInView):
@@ -31,9 +32,8 @@ class UserDetailsView(BaseLoggedInView):
 
     @property
     def is_displayed(self):
-        breadcrumb_loaded = self.browser.wait_for_element(self.breadcrumb, exception=False)
         return (
-            breadcrumb_loaded
+            self.breadcrumb.is_displayed
             and self.breadcrumb.locations[0] == 'Users'
             and self.breadcrumb.read().startswith('Edit ')
         )
@@ -68,9 +68,8 @@ class UserDetailsView(BaseLoggedInView):
 class UserCreateView(UserDetailsView):
     @property
     def is_displayed(self):
-        breadcrumb_loaded = self.browser.wait_for_element(self.breadcrumb, exception=False)
         return (
-            breadcrumb_loaded
+            self.breadcrumb.is_displayed
             and self.breadcrumb.locations[0] == 'Users'
             and self.breadcrumb.read() == 'Create User'
         )

--- a/airgun/views/usergroup.py
+++ b/airgun/views/usergroup.py
@@ -2,11 +2,11 @@ from widgetastic.widget import Checkbox, Table, Text, TextInput, View
 from widgetastic_patternfly import BreadCrumb
 from widgetastic_patternfly5 import Button
 
-from airgun.views.common import BaseLoggedInView, SatTab, SearchableViewMixinPF4
+from airgun.views.common import BaseLoggedInView, SatTab, SearchableViewMixin
 from airgun.widgets import FilteredDropdown, MultiSelect
 
 
-class UserGroupsView(BaseLoggedInView, SearchableViewMixinPF4):
+class UserGroupsView(BaseLoggedInView, SearchableViewMixin):
     title = Text("//h1[normalize-space(.)='User Groups']")
     new_on_blank_page = Button('Create User group')
     new = Text("//a[contains(@href, '/usergroups/new')]")
@@ -20,7 +20,7 @@ class UserGroupsView(BaseLoggedInView, SearchableViewMixinPF4):
 
     @property
     def is_displayed(self):
-        return self.browser.wait_for_element(self.title, exception=False) is not None
+        return self.title.is_displayed
 
 
 class UserGroupDetailsView(BaseLoggedInView):
@@ -29,9 +29,8 @@ class UserGroupDetailsView(BaseLoggedInView):
 
     @property
     def is_displayed(self):
-        breadcrumb_loaded = self.browser.wait_for_element(self.breadcrumb, exception=False)
         return (
-            breadcrumb_loaded
+            self.breadcrumb.is_displayed
             and self.breadcrumb.locations[0] == 'User Groups'
             and self.breadcrumb.read().startswith('Edit ')
         )
@@ -78,9 +77,8 @@ class UserGroupDetailsView(BaseLoggedInView):
 class UserGroupCreateView(UserGroupDetailsView):
     @property
     def is_displayed(self):
-        breadcrumb_loaded = self.browser.wait_for_element(self.breadcrumb, exception=False)
         return (
-            breadcrumb_loaded
+            self.breadcrumb.is_displayed
             and self.breadcrumb.locations[0] == 'User Groups'
             and self.breadcrumb.read() == 'Create User group'
         )

--- a/airgun/views/virtwho_configure.py
+++ b/airgun/views/virtwho_configure.py
@@ -143,7 +143,7 @@ class VirtwhoConfiguresView(BaseLoggedInView, SearchableViewMixin):
 
     @property
     def is_displayed(self):
-        return self.browser.wait_for_element(self.title, exception=False) is not None
+        return self.title.is_displayed
 
 
 class VirtwhoConfigureCreateView(BaseLoggedInView):
@@ -207,9 +207,8 @@ class VirtwhoConfigureCreateView(BaseLoggedInView):
 
     @property
     def is_displayed(self):
-        breadcrumb_loaded = self.browser.wait_for_element(self.breadcrumb, exception=False)
         return (
-            breadcrumb_loaded
+            self.breadcrumb.is_displayed
             and self.breadcrumb.locations[0] == 'Satellite Virt Who Configure Configs'
             and self.breadcrumb.read() == 'New Virt-who Config'
         )
@@ -218,9 +217,8 @@ class VirtwhoConfigureCreateView(BaseLoggedInView):
 class VirtwhoConfigureEditView(VirtwhoConfigureCreateView):
     @property
     def is_displayed(self):
-        breadcrumb_loaded = self.browser.wait_for_element(self.breadcrumb, exception=False)
         return (
-            breadcrumb_loaded
+            self.breadcrumb.is_displayed
             and self.breadcrumb.locations[0] == 'Virt-who Configurations'
             and self.breadcrumb.read().startswith('Edit ')
         )
@@ -233,9 +231,8 @@ class VirtwhoConfigureDetailsView(BaseLoggedInView):
 
     @property
     def is_displayed(self):
-        breadcrumb_loaded = self.browser.wait_for_element(self.breadcrumb, exception=False)
         return (
-            breadcrumb_loaded
+            self.breadcrumb.is_displayed
             and self.breadcrumb.locations[0] == 'Virt-who Configurations'
             and self.breadcrumb.read() != 'Create Config'
         )

--- a/airgun/views/webhook.py
+++ b/airgun/views/webhook.py
@@ -3,11 +3,11 @@ from widgetastic.widget import Checkbox, Text, TextInput, View
 from widgetastic_patternfly import Button
 from widgetastic_patternfly5 import Button as PF5Button, Tab
 
-from airgun.views.common import BaseLoggedInView, SearchableViewMixinPF4
+from airgun.views.common import BaseLoggedInView, SearchableViewMixin
 from airgun.widgets import AutoCompleteTextInput, SatTable
 
 
-class WebhooksView(BaseLoggedInView, SearchableViewMixinPF4):
+class WebhooksView(BaseLoggedInView, SearchableViewMixin):
     title = Text("//h1[normalize-space(.)='Webhooks']")
     new = PF5Button('Create new')
     table = SatTable(
@@ -20,7 +20,7 @@ class WebhooksView(BaseLoggedInView, SearchableViewMixinPF4):
 
     @property
     def is_displayed(self):
-        return self.browser.wait_for_element(self.title, exception=False) is not None
+        return self.title.is_displayed
 
 
 class WebhookCreateView(BaseLoggedInView):

--- a/airgun/widgets.py
+++ b/airgun/widgets.py
@@ -818,9 +818,16 @@ class Search(Widget):
     """Searchbar for table filtering"""
 
     ROOT = (
-        './/div[contains(@class, "toolbar-pf-filter") or contains(@class, "title_filter")'
+        '( '
+        './/div[contains(@class, "foreman-search-bar")] | '
+        './/div[@data-ouia-component-id="table-toolbar"] | '
+        './/div[contains(@class, "toolbar-pf")] | '
+        './/div[@id="ins-primary-data-toolbar"] | '
+        './/div[contains(@class, "toolbar-pf-filter") or contains(@class, "title_filter") '
         'or contains(@class, "dataTables_filter") or @id="search-bar"]'
+        ' )'
     )
+
     search_field = TextInput(
         locator=(
             ".//input[@id='search' or contains(@placeholder, 'Filter') or "


### PR DESCRIPTION
Refactoring of Airgun navigation and wait patterns to improve reliability and reduce code duplication.

SAT-41489

# Navigation retry logic fixes

  **Before**: Navigation retry handled via decorator on individual entity methods
  
```
  @retry_navigation
  def get_details(self, entity_name):
      view = self.navigate_to(self, 'Details', entity_name=entity_name)
      view.wait_displayed()
      self.browser.plugin.ensure_page_safe()
      return view.read()
```

  **After**: Update the `go` method in `airgun.navigation.NavigateStep` to verify that the target destination is displayed before returning. This is the same approach used by IQE tests, and ensures that the target view is displayed. Any `wait_displayed` and `ensure_page_safe` calls are redundant after `self.navigate_to()` returns to the caller.

```
  def get_details(self, entity_name):
      view = self.navigate_to(self, 'Details', entity_name=entity_name)
      return view.read()
```
Benefits:
  - Automatic retry on TimedOutError or NoSuchElementException (up to 3 attempts)
  - Built-in post-navigation validation via `wait_for` on the navigation step's `am_i_here` method (which calls the view's `is_displayed` method)
  - Configurable retry count and validation timeout
  - Eliminates need for manual `wait_displayed` and `ensure_page_safe` calls

# Removed Redundant Wait Patterns

  Removed across all entity methods:
  - `view.wait_displayed()`
  - `self.browser.plugin.ensure_page_safe()`
  - `time.sleep()`
  - browser refresh on navigation failures - retries now handled by navmazing

# Implemented `SearchableViewMixin` for IoP tables:

  - Configurable delay (`SEARCH_DELAY`) field added. This is the number of seconds to wait, after filling the search input field, before the UI starts the search and refreshes the table. Default: 1 second.
 