### PR TITLE
template editor: update navigation bar locator

### DIFF
--- a/airgun/views/common.py
+++ b/airgun/views/common.py
@@ -575,7 +575,7 @@ class TemplateEditor(View):
     """
 
     ROOT = ".//div[@id='editor-container']"
-    rendering_options = ItemsList(".//div[contains(@class,'navbar-editor')]/ul")
+    rendering_options = ItemsList(".//div[contains(@class,'navbar-editor')]/ul")  # For PRT only
     import_template = Button(id='import-btn')
     fullscreen = Text(locator=".//button[@id='fullscreen-btn']")
     fullscreen_close = Text(

--- a/airgun/views/common.py
+++ b/airgun/views/common.py
@@ -575,7 +575,7 @@ class TemplateEditor(View):
     """
 
     ROOT = ".//div[@id='editor-container']"
-    rendering_options = ItemsList(".//div[contains(@class,'navbar-editor')]/ul")  # For PRT only
+    rendering_options = ItemsList(".//div[@data-ouia-component-id='editor-navbar-tabs']/ul")
     import_template = Button(id='import-btn')
     fullscreen = Text(locator=".//button[@id='fullscreen-btn']")
     fullscreen_close = Text(


### PR DESCRIPTION
Locator for the template nagigation bar (Editor/Changes/Preview) has slightly changed.

This verifies PR ~https://github.com/theforeman/foreman/pull/10728~
~UPDATE: https://github.com/theforeman/foreman/pull/10728 has been deprecated and replaced by https://github.com/theforeman/foreman/pull/11091~
UPDATE2: this automation fix is actually needed for https://github.com/theforeman/foreman/pull/11099