### PR TITLE
[6.18.z] read values from Legacy UI page

### DIFF
--- a/airgun/entities/host_new.py
+++ b/airgun/entities/host_new.py
@@ -60,13 +60,19 @@ class NewHostEntity(HostEntity):
         host_view.flash.dismiss()
 
     def get_details(self, entity_name, widget_names=None):
-        """Read host values from Host Details page, optionally only the widgets in widget_names
-        will be read.
-        """
+        """Read host values from Host Details page, optionally only the widgets in widget_names will be read."""
         view = self.navigate_to(self, 'NewDetails', entity_name=entity_name)
         view.wait_displayed()
         self.browser.plugin.ensure_page_safe()
         return view.read(widget_names=widget_names)
+
+    def delete(self, entity_name, cancel=False):
+        """Delete host from the system"""
+        view = self.navigate_to(self, 'NewUIAll')
+        view.search(entity_name)
+        view.table.row(name=entity_name)[6].widget.item_select('Delete')
+        self.browser.handle_alert()
+        self.browser.refresh()
 
     def run_bootc_job(self, entity_name, job_name, job_options=None):
         """Navigate to the Host Details UI, and run a specified job from the link on the bootc card."""

--- a/airgun/views/host_new.py
+++ b/airgun/views/host_new.py
@@ -35,7 +35,7 @@ from widgetastic_patternfly5.ouia import (
 )
 
 from airgun.views.cloud_insights import BulkSelectMenuToggle
-from airgun.views.common import BaseLoggedInView
+from airgun.views.common import BaseLoggedInView, SearchableViewMixinPF4
 from airgun.widgets import (
     Accordion,
     ActionsDropdown,
@@ -135,7 +135,7 @@ class HostColectionsList(Widget):
         return [self.browser.text(item) for item in self.browser.elements(self.ITEMS)]
 
 
-class HostsView(BaseLoggedInView):
+class HostsView(BaseLoggedInView, SearchableViewMixinPF4):
     """New All Hosts view.
     Note: This is a minimal implementation of the new Hosts page, and currently it serves only to transition
     to the now-legacy UI page.
@@ -143,6 +143,17 @@ class HostsView(BaseLoggedInView):
 
     title = Text('//h1[normalize-space(.)="Hosts"]')
     actions = PF5OUIADropdown(component_id='legacy-ui-kebab')
+    table = PF5OUIATable(
+        component_id='hosts-index-table',
+        column_widgets={
+            0: Checkbox(locator='.//input[@type="checkbox"]'),
+            'Name': Text(
+                './/a[contains(@href, "/new/hosts/") and not(contains(@href, "Red Hat Lightspeed"))]'
+            ),
+            'Recommendations': Text('./a'),
+            6: MenuToggleButtonMenu(),
+        },
+    )
 
     @property
     def is_displayed(self):


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/airgun/pull/2231

Added a condition to read the value from the Legacy UI page.
In Robottelo, the code was updated from `host` to `new_host`, ensuring that the details are fetched correctly.

Dependent PR: https://github.com/SatelliteQE/robottelo/pull/20370