### PR TITLE
flatpack remote mirror repos depedancy modal

### DIFF
--- a/airgun/views/flatpak.py
+++ b/airgun/views/flatpak.py
@@ -1,4 +1,5 @@
 from widgetastic.widget import Text
+from widgetastic.xpath import quote
 from widgetastic_patternfly5 import (
     Alert as PF5Alert,
     Button as PF5Button,
@@ -121,12 +122,35 @@ class MirrorFlatpakRemoteModal(PF5Modal, SearchableViewMixinPF4):
         locator='.//input[contains(@class, "pf-v5-c-text-input-group__text-input")]'
     )
 
+    dependency_alert = PF5Alert(locator='.//div[@data-ouia-component-id="dependency-alert"]')
+    dependency_info = PF5OUIAText('dependency-info-text')
+
     mirror_btn = PF5Button('Mirror')
     cancel_btn = PF5Button('Cancel')
 
     @property
     def is_displayed(self):
         return self.browser.wait_for_element(self.title, exception=False) is not None
+
+    def dependency_repo_names(self):
+        """Return a list of dependency repository names from the alert."""
+        if not self.dependency_alert.is_displayed:
+            return []
+        repo_nodes = self.browser.elements(
+            './/div[@data-ouia-component-id="dependency-alert"]//label//strong'
+        )
+        return [self.browser.text(node) for node in repo_nodes]
+
+    def select_dependency(self, repo_name):
+        """Select a dependency checkbox by repository name."""
+        label = self.browser.element(
+            './/div[@data-ouia-component-id="dependency-alert"]//label['
+            f'.//strong[normalize-space(.)={quote(repo_name)}]'
+            ']'
+        )
+        checkbox_id = label.get_attribute('for')
+        checkbox = self.browser.element(f'.//input[@id={quote(checkbox_id)}]')
+        checkbox.click()
 
 
 class FlatpakRemoteDeleteModal(PF5Modal):


### PR DESCRIPTION
<img width="2565" height="864" alt="flatpak_remote_dependancy_warning" src="https://github.com/user-attachments/assets/f6861992-b336-4005-b1c7-9c7a13c156d2" />

Robottelo test case: https://github.com/SatelliteQE/robottelo/pull/20669 for [SAT-28473](https://issues.redhat.com/browse/SAT-28473)
## Solution
- **airgun/views/flatpak.py**: Added support in the Mirror modal to detect the dependency alert, read its info text, list dependency repo names, and select dependency checkboxes by repo name.
- **airgun/entities/flatpak.py**: Added helpers to open the Mirror modal, read dependency alert details, and submit the modal while selecting dependency repos. This enables the test to validate dependency detection and mirror dependencies via UI.