### PR TITLE
flatpak remote repository dependancy warning while publishing cv

### DIFF
--- a/airgun/entities/contentview_new.py
+++ b/airgun/entities/contentview_new.py
@@ -66,6 +66,22 @@ class NewContentViewEntity(BaseEntity):
         view.wait_displayed()
         return view.versions.table.read()
 
+    def read_flatpak_dependencies_alert(self, entity_name, values=None):
+        """Read Flatpak dependencies alert text from publish review step."""
+        view = self.navigate_to(self, 'Publish', entity_name=entity_name)
+        self.browser.plugin.ensure_page_safe(timeout='5s')
+        view.wait_displayed()
+        if values:
+            view.fill(values)
+        view.next_button.click()
+        self.browser.plugin.ensure_page_safe(timeout='5s')
+        try:
+            alert_text = view.flatpak_dependencies_alert.title
+        except NoSuchElementException:
+            alert_text = None
+        view.cancel_button.click()
+        return alert_text
+
     def check_publish_banner(self, cv_name):
         """Check if the needs_publish banner is displayed on the content view index page"""
         view = self.navigate_to(self, 'All')

--- a/airgun/views/contentview_new.py
+++ b/airgun/views/contentview_new.py
@@ -2,7 +2,7 @@ from wait_for import wait_for
 from widgetastic.utils import ParametrizedLocator
 from widgetastic.widget import Checkbox, ParametrizedView, Text, TextInput, View
 from widgetastic_patternfly import BreadCrumb, Tab
-from widgetastic_patternfly5 import Button, Modal, Radio as PF5Radio
+from widgetastic_patternfly5 import Alert as PF5Alert, Button, Modal, Radio as PF5Radio
 from widgetastic_patternfly5.ouia import (
     Button as PF5Button,
     Dropdown as PF5Dropdown,
@@ -217,6 +217,9 @@ class ContentViewVersionPublishView(BaseLoggedInView):
     ROOT = './/div[@id="content-view-publish-wizard"]'
     title = Text(".//h2[contains(., 'Publish') and @id='pf-wizard-title-0']")
     publish_alert = Text(".//h4[contains(., 'No available repository or filter updates')]")
+    flatpak_dependencies_alert = PF5Alert(
+        locator='.//div[@data-ouia-component-id="flatpak-dependencies-alert"]'
+    )
     # publishing screen
     description = TextInput(id='description')
     promote = Switch('promote-switch')


### PR DESCRIPTION
<img width="2290" height="1078" alt="Screenshot From 2026-01-22 17-32-47" src="https://github.com/user-attachments/assets/61079c0b-6165-4b96-a498-f0851ac924c5" />

[SAT-28473](https://issues.redhat.com/browse/SAT-28473)
Robottelo PR- https://github.com/SatelliteQE/robottelo/pull/20677
Add support for entities and view for the contentview_new page, check dependency alert/warning for flatpak repositories throughout WebUI while CV publish.
Warning message- `Make sure the runtimes required by the Flatpak apps in this content view are available to the host(s).`