### PR TITLE
Fix NavigateStep.go() using wrong browser attribute

### DIFF
--- a/airgun/navigation.py
+++ b/airgun/navigation.py
@@ -84,7 +84,7 @@ class NavigateStep(navmazing.NavigateStep):
             otherwise
         """
         super().go(*args, _tries=_tries, **kwargs)
-        self.browser.plugin.ensure_page_safe()
+        self.navigate_obj.browser.plugin.ensure_page_safe()
         view = self.view if self.VIEW is not None else None
         return view
 


### PR DESCRIPTION
The `go()` method was using `self.browser` which doesn't exist on NavigateStep. NavigateStep accesses the browser via `self.navigate_obj.browser`.

This bug was introduced in commit f8115b77 and breaks all UI navigation, causing errors like:
  'NavigateToLogin' object has no attribute 'browser'