### PR TITLE
Draft initial multi-CV view and entity components

### DIFF
--- a/airgun/entities/host_new.py
+++ b/airgun/entities/host_new.py
@@ -1160,6 +1160,12 @@ class NewHostEntity(HostEntity):
         assignment_section.content_source_select.item_select(cv_name)
         view.save_btn.click()
 
+    def get_content_view_envs(self, entity_name):
+        view = self.navigate_to(self, 'NewDetails', entity_name=entity_name)
+        view.wait_displayed()
+        self.browser.plugin.ensure_page_safe()
+        return view.overview.content_view_details.read()
+
 
 @navigator.register(HostEntity, 'NewUIAll')
 class ShowAllHosts(NavigateStep):

--- a/airgun/views/host_new.py
+++ b/airgun/views/host_new.py
@@ -3,7 +3,6 @@ import time
 from selenium.webdriver.common.by import By
 from widgetastic.widget import (
     Checkbox,
-    ParametrizedLocator,
     ParametrizedView,
     Text,
     TextInput,
@@ -45,7 +44,6 @@ from widgetastic_patternfly5.ouia import (
     Text as PF5OUIAText,
 )
 
-# from airgun.views.all_hosts import ManageCVEModal as ManageCVEnvModal
 from airgun.views.cloud_insights import BulkSelectMenuToggle
 from airgun.views.common import BaseLoggedInView, PF5LCESelectorGroup, SearchableViewMixinPF4
 from airgun.widgets import (
@@ -242,12 +240,33 @@ class NewHostDetailsView(BaseLoggedInView):
         @View.nested
         class content_view_details(Card):
             ROOT = './/div[@data-ouia-component-id="content-view-details-card"]'
-            # dropdown = PF5Dropdown(locator='.//div[@data-ouia-component-id="change-content-view-environments-kebab"]/button')
+            ITEMS = './/div[@class="pf-v5-l-flex pf-m-row pf-m-row-on-sm pf-m-wrap"]'
+            LCE_NAME = './/span[@class="pf-v5-c-label__text"]'
+            CV_NAME = './/a[contains(@href, "content_views") and not(contains(@href, "versions"))]'
+            CV_VERSION = './/a[contains(@href, "versions")]//span'
+
             dropdown = PF5Dropdown(
                 locator='.//div[button[@aria-label="change_content_view_kebab"]]'
             )
 
             org_view = Text('.//a[contains(@href, "content_views")]')
+
+            def read(self):
+                """Return a list of dictionaries containing LCE name, CV name, and CV version"""
+                items = []
+                for item in self.browser.elements(self.ITEMS):
+                    lce_element = self.browser.element(self.LCE_NAME, parent=item)
+                    cv_element = self.browser.element(self.CV_NAME, parent=item)
+                    cv_version_element = self.browser.element(self.CV_VERSION, parent=item)
+
+                    items.append(
+                        {
+                            'lce': self.browser.text(lce_element),
+                            'content_view': self.browser.text(cv_element),
+                            'version': self.browser.text(cv_version_element),
+                        }
+                    )
+                return items
 
         @View.nested
         class installable_errata(Card):


### PR DESCRIPTION
This PR adds the necessary bits to support the ability to select multiple content view environments, which will be used in several places in the UI.

The view classes added here will likely need to end up in `airgun/views/common.py`, but I am keeping them in `host_new.py` for debugging purposes until I get them functioning properly. 