### PR TITLE
Fix Sat Subscription Table

### DIFF
--- a/airgun/views/subscription.py
+++ b/airgun/views/subscription.py
@@ -42,7 +42,7 @@ class SatSubscriptionsViewTable(SatTable):
     @property
     def is_displayed(self):
         """Check if the table element exists on the page."""
-        return self.browser.is_element_present(self.locator)
+        return self.browser.wait_for_element(self.locator, exception=False) is not None
 
     def wait_displayed(self, timeout=10):
         """Explicitly wait for the table to be displayed."""


### PR DESCRIPTION
`is_element_present` does not exist.
Tests were failing with `'AirgunBrowser' object has no attribute 'is_element_present'`
### PRT Example
```
trigger: test-robottelo
pytest: tests/foreman/ui/test_subscription.py
```
