### PR TITLE
Fix host delete race condition in UI

### DIFF
--- a/airgun/entities/host_new.py
+++ b/airgun/entities/host_new.py
@@ -71,6 +71,8 @@ class NewHostEntity(HostEntity):
     def delete(self, entity_name, cancel=False):
         """Delete host from the system"""
         view = self.navigate_to(self, 'NewUIAll')
+        view.wait_displayed()
+        self.browser.plugin.ensure_page_safe()
         view.search(entity_name)
         view.table.row(name=entity_name)[6].widget.item_select('Delete')
         self.browser.handle_alert()


### PR DESCRIPTION
Problem :
The issue is that when `delete()` navigates to the All Hosts page and tries to find the row in the table, the table isn't fully loaded yet, so the columns aren't  available. 

Solution:
Adding `wait_displayed()` and `ensure_page_safe()` before accessing the table should fix it.

