### PR TITLE
More stable get_register_command

### DIFF
--- a/airgun/entities/host.py
+++ b/airgun/entities/host.py
@@ -70,6 +70,7 @@ class HostEntity(BaseEntity):
             view = self.navigate_to(self, 'Register')
             self.browser.plugin.ensure_page_safe()
             view.wait_displayed()
+            wait_for(lambda: view.general.insecure.is_enabled, timeout=30, delay=1)
             view.fill(values)
         if view.general.activation_keys.read():
             self.browser.click(view.generate_command)


### PR DESCRIPTION
`get_register_command` is too fast in some cases, when the page form is still disabled.

Add a check that the form element is not disabled.

### PRT Example
<img width="342" height="133" alt="image" src="https://github.com/user-attachments/assets/f70562ae-9d90-4373-be2f-9d4bd4bd2847" />

```
trigger: test-robottelo
pytest: tests/foreman/ui/test_registration.py -k "test_positive_global_registration_end_to_end or test_global_registration_form_populate or test_global_registration_with_gpg_repo_and_default_package"
```
