### PR TITLE
Fix some search bugs with CV UI

### DIFF
--- a/airgun/entities/contentview_new.py
+++ b/airgun/entities/contentview_new.py
@@ -125,7 +125,7 @@ class NewContentViewEntity(BaseEntity):
         )
         time.sleep(5)  # 'Loading' widget on page
         self.browser.plugin.ensure_page_safe(timeout='10s')
-        wait_for(lambda: view.table.is_displayed, timeout=20)
+        wait_for(lambda: view.repositories.table.is_displayed, timeout=20)
         result = view.version_dropdown.item_select('Delete')
         view.wait_displayed()
         # Remove from environment(s) wizard, if it appears
@@ -385,7 +385,7 @@ class EditContentView(NavigateStep):
 
     def step(self, *args, **kwargs):
         entity_name = kwargs.get('entity_name')
-        self.parent.search.search(entity_name)
+        self.parent.search(entity_name)
         self.parent.table.wait_displayed()
         self.parent.table.row(name=entity_name)['Name'].widget.click()
 
@@ -404,7 +404,6 @@ class ShowContentViewVersionDetails(NavigateStep):
         self.parent.versions.wait_displayed()
         self.parent.versions.search(version)
         self.parent.versions.table.wait_displayed()
-        self.parent.versions.search(version).click()
         self.parent.versions.table.row(version=version)['Version'].widget.click()
 
 

--- a/airgun/views/contentview_new.py
+++ b/airgun/views/contentview_new.py
@@ -72,7 +72,6 @@ class AddContentViewModal(BaseLoggedInView):
 class ContentViewTableView(BaseLoggedInView, SearchableViewMixinPF4):
     title = PF5Text(component_id='cvPageHeaderText')
     create_content_view = PF5Button(component_id='create-content-view')
-    search = PF4Search()
     table = ExpandableTable(
         component_id='content-views-table',
         column_widgets={


### PR DESCRIPTION
Just fixes some small problems that have crept into CV UI over the last year or so.

Removing the 
```search = PF4Search()``` 
is fine, since it uses SearchableViewMixin, like most other pages.