### PR TITLE
Add method to switch initial associated content view

### DIFF
--- a/airgun/entities/host_new.py
+++ b/airgun/entities/host_new.py
@@ -1168,6 +1168,20 @@ class NewHostEntity(HostEntity):
             handle_exception=True,
         )
 
+    def switch_associated_cv(self, entity_name, cv_name):
+        view = self.navigate_to(self, 'NewDetails', entity_name=entity_name)
+        view.wait_displayed()
+        view.overview.content_view_details.dropdown.item_select('Assign content view environments')
+        modal = ManageMultiCVEnvModal(self.browser)
+        modal.associated_content_view.item_select(cv_name)
+        modal.save_btn.click()
+        wait_for(
+            lambda: not modal.is_displayed,
+            timeout=10,
+            delay=1,
+            handle_exception=True,
+        )
+
     def get_content_view_envs(self, entity_name):
         view = self.navigate_to(self, 'NewDetails', entity_name=entity_name)
         view.wait_displayed()

--- a/airgun/views/host_new.py
+++ b/airgun/views/host_new.py
@@ -47,7 +47,6 @@ from widgetastic_patternfly5.ouia import (
     Text as PF5OUIAText,
 )
 
-# from airgun.views.all_hosts import ManageCVEModal as ManageCVEnvModal
 from airgun.views.cloud_insights import BulkSelectMenuToggle
 from airgun.views.common import BaseLoggedInView, PF5LCESelectorGroup, SearchableViewMixinPF4
 from airgun.widgets import (
@@ -1248,6 +1247,7 @@ class ManageMultiCVEnvModal(PF5Modal):
         locator='.//button[@data-ouia-component-id="assign-cv-modal-cancel-button" or @data-ouia-component-id="bulk-assign-cves-modal-cancel-button"]'
     )
     new_assignment_section = ParametrizedView.nested(NewCVEnvAssignmentSection)
+    associated_content_view = CVESelect()
 
     @property
     def is_displayed(self):


### PR DESCRIPTION
This PR adds a method to the host entity that changes the initial content view associated with the host's initial content view environment. It also adds one line to the host view to support this change.

This change enables test coverage for https://github.com/Katello/katello/pull/11637, which fixed a bug found in the initial multicv host implementation in which changing the content view in a host's content view environment to a different content view in the same lifecycle environment did not function properly.