### PR TITLE
Add post-navigation am_i_here check

### DIFF
--- a/airgun/entities/cloud_insights.py
+++ b/airgun/entities/cloud_insights.py
@@ -3,8 +3,7 @@ import time
 from wait_for import wait_for
 
 from airgun.entities.base import BaseEntity
-from airgun.navigation import NavigateStep, navigator
-from airgun.utils import retry_navigation
+from airgun.navigation import NavigateStepWithWait as NavigateStep, navigator
 from airgun.views.cloud_insights import (
     CloudInsightsView,
     CloudTokenView,
@@ -236,7 +235,6 @@ class SaveCloudTokenView(NavigateStep):
 
     VIEW = CloudTokenView
 
-    @retry_navigation
     def step(self, *args, **kwargs):
         self.view.menu.select('Red Hat Lightspeed')
 
@@ -247,7 +245,6 @@ class ShowCloudInsightsView(NavigateStep):
 
     VIEW = CloudInsightsView
 
-    @retry_navigation
     def step(self, *args, **kwargs):
         self.view.menu.select('Red Hat Lightspeed', 'Recommendations')
 
@@ -258,6 +255,5 @@ class ShowRecommendationsView(NavigateStep):
 
     VIEW = RecommendationsTabView
 
-    @retry_navigation
     def step(self, *args, **kwargs):
         self.view.menu.select('Red Hat Lightspeed', 'Recommendations')

--- a/airgun/entities/cloud_inventory.py
+++ b/airgun/entities/cloud_inventory.py
@@ -1,8 +1,7 @@
 import time
 
 from airgun.entities.base import BaseEntity
-from airgun.navigation import NavigateStep, navigator
-from airgun.utils import retry_navigation
+from airgun.navigation import NavigateStepWithWait as NavigateStep, navigator
 from airgun.views.cloud_inventory import CloudInventoryListView
 
 
@@ -132,6 +131,5 @@ class ShowCloudInventoryListView(NavigateStep):
 
     VIEW = CloudInventoryListView
 
-    @retry_navigation
     def step(self, *args, **kwargs):
         self.view.menu.select('Red Hat Lightspeed', 'Inventory Upload')

--- a/airgun/entities/cloud_vulnerabilities.py
+++ b/airgun/entities/cloud_vulnerabilities.py
@@ -1,8 +1,7 @@
 from wait_for import wait_for
 
 from airgun.entities.base import BaseEntity
-from airgun.navigation import NavigateStep, navigator
-from airgun.utils import retry_navigation
+from airgun.navigation import NavigateStepWithWait as NavigateStep, navigator
 from airgun.views.cloud_vulnerabilities import (
     CloudVulnerabilityView,
     CVEDetailsView,
@@ -433,6 +432,5 @@ class ShowVulnerabilityListView(NavigateStep):
 
     VIEW = CloudVulnerabilityView
 
-    @retry_navigation
     def step(self, *args, **kwargs):
         self.view.menu.select('Red Hat Lightspeed', 'Vulnerability')

--- a/airgun/entities/host_new.py
+++ b/airgun/entities/host_new.py
@@ -960,17 +960,8 @@ class NewHostEntity(HostEntity):
         self.browser.plugin.ensure_page_safe()
         return view.reports.read()
 
-    def get_insights(self, entity_name):
-        view = self.navigate_to(self, 'NewDetails', entity_name=entity_name)
-        view.wait_displayed()
-        self.browser.plugin.ensure_page_safe()
-        wait_for(lambda: view.insights.recommendations_table.is_displayed, timeout=10)
-        return view.insights.read()
-
     def get_vulnerabilities(self, entity_name):
         view = self.navigate_to(self, 'NewDetails', entity_name=entity_name)
-        view.wait_displayed()
-        self.browser.plugin.ensure_page_safe()
         wait_for(lambda: view.vulnerabilities.vulnerabilities_table.is_displayed, timeout=30)
         vulnerabilities = getattr(view.vulnerabilities, 'vulnerabilities_table', None)
         if vulnerabilities is not None:
@@ -980,16 +971,13 @@ class NewHostEntity(HostEntity):
 
     def get_recommendations(self, entity_name):
         view = self.navigate_to(self, 'NewDetails', entity_name=entity_name)
-        view.wait_displayed()
-        self.browser.plugin.ensure_page_safe()
         wait_for(lambda: view.iop_recommendations.recommendations_table.is_displayed, timeout=30)
         return view.iop_recommendations.recommendations_table.read()
 
     def remediate_host_recommendation(self, entity_name, recommendation):
         """Function that can remediate an iop recommendation from the host page"""
         view = self.navigate_to(self, 'NewDetails', entity_name=entity_name)
-        view.wait_displayed()
-        self.browser.plugin.ensure_page_safe()
+
         wait_for(lambda: view.iop_recommendations.is_displayed, timeout=30)
         view.iop_recommendations.search_field.fill(recommendation)
         wait_for(lambda: view.iop_recommendations.recommendations_table.is_displayed, timeout=30)
@@ -998,14 +986,16 @@ class NewHostEntity(HostEntity):
             handle_exception=True,
             timeout=30,
         )
+
         row = view.iop_recommendations.recommendations_table.row(description=recommendation)
         row[1].widget.fill(True)
         view.iop_recommendations.remediate.wait_displayed()
         view.iop_recommendations.remediate.click()
-        self.browser.plugin.ensure_page_safe(timeout='30s')
+
         modal = RemediateSummary(self.browser)
         wait_for(lambda: modal.is_displayed, handle_exception=True, timeout=20)
         modal.remediate.click()
+
         view = JobInvocationStatusView(view.browser)
         view.wait_for_result()
         return view.read()
@@ -1013,16 +1003,16 @@ class NewHostEntity(HostEntity):
     def bulk_remediate_host_recommendation(self, entity_name):
         """Function that can bulk remediate an iop recommendation from the host page"""
         view = self.navigate_to(self, 'NewDetails', entity_name=entity_name)
-        view.wait_displayed()
-        self.browser.plugin.ensure_page_safe()
         wait_for(lambda: view.iop_recommendations.is_displayed, timeout=30)
         view.iop_recommendations.bulk_select.select_all()
+
         view.iop_recommendations.remediate.wait_displayed()
         view.iop_recommendations.remediate.click()
-        self.browser.plugin.ensure_page_safe(timeout='30s')
+
         modal = RemediateSummary(self.browser)
         wait_for(lambda: modal.is_displayed, handle_exception=True, timeout=20)
         modal.remediate.click()
+
         view = JobInvocationStatusView(view.browser)
         view.wait_for_result()
         return view.read()
@@ -1045,16 +1035,15 @@ class NewHostEntity(HostEntity):
 
         """
 
-        if ((recommendation_to_remediate is not None) and remediate_all) or (
-            (recommendation_to_remediate is None) and (remediate_all is False)
+        if (recommendation_to_remediate and remediate_all) or (
+            not recommendation_to_remediate and not remediate_all
         ):
             raise ValueError(
                 'Either recommendation_to_remediate or remediate_all must be provided!'
             )
 
         view = self.navigate_to(self, 'NewDetails', entity_name=entity_name)
-        view.wait_displayed()
-        self.browser.plugin.ensure_page_safe()
+
         if remediate_all:
             view.insights.select_all_one_page.click()
             view.insights.select_all_pages.click()
@@ -1071,8 +1060,6 @@ class NewHostEntity(HostEntity):
                     _rec = f'title = "{_rec}"'
                     view.insights.search_bar.fill(_rec, enter_timeout=3)
                     view.wait_displayed()
-                    self.browser.plugin.ensure_page_safe()
-                    time.sleep(3)
                     try:
                         # Click the checkbox of the first recommendation
                         view.insights.recommendations_table[0][0].widget.click()
@@ -1087,8 +1074,6 @@ class NewHostEntity(HostEntity):
                 recommendation_to_remediate = f'title = "{recommendation_to_remediate}"'
                 view.insights.search_bar.fill(recommendation_to_remediate, enter_timeout=3)
                 view.wait_displayed()
-                self.browser.plugin.ensure_page_safe()
-                time.sleep(3)
                 try:
                     # Click the checkbox of the first recommendation
                     view.insights.recommendations_table[0][0].widget.click()

--- a/airgun/navigation.py
+++ b/airgun/navigation.py
@@ -3,6 +3,10 @@
 from cached_property import cached_property
 import navmazing
 from selenium.common.exceptions import NoSuchElementException
+from wait_for import wait_for
+from widgetastic_patternfly4.navigation import NavSelectionNotFound
+
+NAV_EXCEPTIONS = NavSelectionNotFound
 
 
 class NavigateStep(navmazing.NavigateStep):
@@ -10,6 +14,10 @@ class NavigateStep(navmazing.NavigateStep):
     implementations of `navmazing.NavigateStep.am_i_here` and `navmazing.NavigateStep.go`
     and ability to work with views.
     """
+
+    DEFAULT_TRIES = 1
+    WAIT_TIMEOUT = 20
+    WAIT_FOR_AM_I_HERE = False
 
     VIEW = None
 
@@ -76,17 +84,76 @@ class NavigateStep(navmazing.NavigateStep):
         except (AttributeError, NoSuchElementException):
             return False
 
+    def pre_navigate(self, *args, **kwargs):
+        return
+
+    def post_navigate(self, *args, **kwargs):
+        return
+
     def go(self, _tries=0, *args, **kwargs):
-        """Wrapper around :meth:`navmazing.NavigateStep.go` which returns
-        instance of view after successful navigation flow.
+        """Override of :meth:`navmazing.NavigateStep.go`, which returns
+        instance of view after successful navigation.
 
         :return: view instance if class attribute ``VIEW`` is set or ``None``
             otherwise
         """
-        super().go(*args, _tries=_tries, **kwargs)
-        self.navigate_obj.browser.plugin.ensure_page_safe()
-        view = self.view if self.VIEW is not None else None
-        return view
+        # Legacy method, with no post-navigation check and weird recursive retry behavior
+        if not self.WAIT_FOR_AM_I_HERE:
+            super().go(*args, _tries=_tries, **kwargs)
+            self.navigate_obj.browser.plugin.ensure_page_safe()
+            view = self.view if self.VIEW is not None else None
+            return view
+
+        # New method, with post-navigation check and explicit retry loop
+        for _ in range(self.DEFAULT_TRIES):
+            self.pre_navigate(*args, **kwargs)
+
+            self.logger.info(
+                f'NAVIGATE: Checking if already at {self._name} for {type(self).__name__}.'
+            )
+            here = False
+            try:
+                here = self.am_i_here(*args, **kwargs)
+            except NAV_EXCEPTIONS as e:
+                self.logger.error(
+                    f'NAVIGATE: Exception while checking if already at {self._name}: {e}. Continuing with navigation.'
+                )
+            if here:
+                self.logger.info(f'NAVIGATE: Already at {self._name}.')
+            else:
+                # Perform the navigation steps and wait for the final destination to be ready
+                self.logger.info(f'NAVIGATE: Not at {self._name}. Heading to prerequisite.')
+                self.parent = self.prerequisite(*args, **kwargs)
+
+                self.logger.info(
+                    f'NAVIGATE: Prerequisite complete. Heading to destination {self._name}.'
+                )
+                self.step(*args, **kwargs)
+
+                here, _ = wait_for(
+                    self.am_i_here,
+                    func_args=args,
+                    func_kwargs=kwargs,
+                    timeout=self.WAIT_TIMEOUT,
+                    message=f'NAVIGATE: Waiting for am_i_here of {type(self).__name__}',
+                    handle_exception=True,
+                    silent_failure=True,
+                )
+                if not here:
+                    self.logger.error('NAVIGATE: Timed out waiting for am_i_here.')
+
+            # Return view if successful, otherwise go on to the next try
+            if here:
+                self.resetter(*args, **kwargs)
+                self.post_navigate(*args, **kwargs)
+                view = self.view if self.VIEW is not None else None
+                return view
+        # Ran out of tries: raise an exception.
+        raise navmazing.NavigationTriesExceeded(self._name)
+
+
+class NavigateStepWithWait(NavigateStep):
+    WAIT_FOR_AM_I_HERE = True
 
 
 class Navigate(navmazing.Navigate):
@@ -106,6 +173,13 @@ class Navigate(navmazing.Navigate):
         """
         super().__init__()
         self.browser = browser
+
+    def navigate(self, cls_or_obj, name, *args, **kwargs):
+        """Perform the navigation"""
+        __tracebackhide__ = True
+
+        nav = self.get_class(cls_or_obj, name)
+        return nav(cls_or_obj, self, self.logger).go(*args, **kwargs)
 
 
 # Navigator instance to be used in other modules. Please note that you should

--- a/airgun/views/cloud_insights.py
+++ b/airgun/views/cloud_insights.py
@@ -28,7 +28,7 @@ class CloudTokenView(BaseLoggedInView):
 
     @property
     def is_displayed(self):
-        return self.rhcloud_token.wait_displayed()
+        return self.rhcloud_token.is_displayed
 
 
 class RemediationView(PF5OUIAModal):
@@ -49,7 +49,7 @@ class RemediationView(PF5OUIAModal):
 
     @property
     def is_displayed(self):
-        return self.title.wait_displayed()
+        return self.title.is_displayed
 
 
 class CloudInsightsView(BaseLoggedInView, SearchableViewMixinPF4):
@@ -77,7 +77,7 @@ class CloudInsightsView(BaseLoggedInView, SearchableViewMixinPF4):
 
     @property
     def is_displayed(self):
-        return self.browser.wait_for_element(self.title, exception=False) is not None
+        return self.title.is_displayed
 
 
 class BulkSelectMenuToggle(PF5Menu):
@@ -177,7 +177,7 @@ class RecommendationsDetailsView(BaseLoggedInView):
 
     @property
     def is_displayed(self):
-        return self.browser.wait_for_element(self.table, exception=False) is not None
+        return self.table.is_displayed
 
 
 class RecommendationsTableExpandedRowView(RecommendationsDetailsView):
@@ -224,7 +224,4 @@ class RecommendationsTabView(BaseLoggedInView):
 
     @property
     def is_displayed(self):
-        return (
-            self.browser.wait_for_element(self.table, exception=False) is not None
-            and self.browser.wait_for_element(self.clear_button, exception=False) is not None
-        )
+        return self.table.is_displayed and self.clear_button.is_displayed

--- a/airgun/views/cloud_inventory.py
+++ b/airgun/views/cloud_inventory.py
@@ -119,7 +119,7 @@ class CloudInventoryListView(BaseLoggedInView):
 
     @property
     def is_displayed(self):
-        return self.browser.wait_for_element(self.title, exception=False) is not None
+        return self.title.is_displayed
 
     def read(self, widget_names=None):
         final_dict = {

--- a/airgun/views/cloud_vulnerabilities.py
+++ b/airgun/views/cloud_vulnerabilities.py
@@ -36,7 +36,7 @@ class EditBusinessRiskModal(PF5Modal):
 
     @property
     def is_displayed(self):
-        return self.browser.wait_for_element(self.title, exception=False) is not None
+        return self.title.is_displayed
 
 
 class EditStatusModal(PF5Modal):
@@ -58,7 +58,7 @@ class EditStatusModal(PF5Modal):
 
     @property
     def is_displayed(self):
-        return self.browser.wait_for_element(self.title, exception=False) is not None
+        return self.title.is_displayed
 
 
 class BulkActionsMenu(Widget):
@@ -171,7 +171,7 @@ class CloudVulnerabilityView(BaseLoggedInView):
 
     @property
     def is_displayed(self):
-        return self.browser.wait_for_element(self.title, exception=False) is not None
+        return self.title.is_displayed
 
 
 class ActionsDropdownMenu(Widget):
@@ -219,7 +219,7 @@ class CVEDetailsView(BaseLoggedInView):
 
     @property
     def is_displayed(self):
-        return self.browser.wait_for_element(self.title, exception=False) is not None
+        return self.title.is_displayed
 
 
 class EditVulnerabilitiesModal(PF5Modal):
@@ -231,3 +231,7 @@ class EditVulnerabilitiesModal(PF5Modal):
     status = PF5FormSelect(locator=".//select[contains(@aria-label, 'Select Input')]")
     save = PF5Button('Save')
     cancel = PF5Button('Cancel')
+
+    @property
+    def is_displayed(self):
+        return self.title.is_displayed

--- a/airgun/views/host_new.py
+++ b/airgun/views/host_new.py
@@ -919,10 +919,7 @@ class NewHostDetailsView(BaseLoggedInView):
 
         @property
         def is_displayed(self):
-            return (
-                self.browser.wait_for_element(self.recommendations_table, exception=False)
-                is not None
-            )
+            return self.recommendations_table.is_displayed
 
     @View.nested
     class vulnerabilities(PF5Tab):
@@ -947,12 +944,9 @@ class NewHostDetailsView(BaseLoggedInView):
 
         @property
         def is_displayed(self):
-            table_displayed = self.vulnerabilities_table.wait_displayed(exception=False)
-            no_cves_message_displayed = (
-                self.browser.wait_for_element(self.no_cves_found_message, exception=False)
-                is not None
+            return (
+                self.vulnerabilities_table.is_displayed or self.no_cves_found_message.is_displayed
             )
-            return table_displayed or no_cves_message_displayed
 
 
 class InstallPackagesView(View):


### PR DESCRIPTION
Add an opt-in post-navigation verification mechanism and updates the RHCloud and Insights entities to use it. This aligns the behavior in Satellite/airgun with that in Insights/Lightspeed/IQE.

1. Navigation with Post-Navigation Verification
- Added `WAIT_FOR_AM_I_HERE` field to `NavigateStep` (defaults to `False` for backward compatibility).
- Created new class `NavigateStepWithWait` that enables this post-navigation check. With `WAIT_FOR_AM_I_HERE=True`, `navigate_to()` will:
  - Wait for `am_i_here()` to return `True` (Default timeout: `20` seconds, configurable on a per-step level with `WAIT_TIMEOUT`).
  - Use an explicit retry loop with configurable per-step `DEFAULT_TRIES` (default: `1`), instead of using navmazing's weird recursive retry behavior.
  - Raise `NavigationTriesExceeded` if all retry attempts fail.

2. Enabling the new feature for RH Cloud and IoP entities 
- Migrated `cloud_insights`, `cloud_vulnerabilities`, and `cloud_inventory` entities to use `NavigateStepWithWait`
- Navigation now waits for successful page load and `step.am_i_here` / `view.is_displayed` before returning.

3. `View.is_displayed` improvements
- Changed from using `wait_displayed()` calls to `is_displayed` property checks within `view.is_displayed` methods. All waiting should now be handled by the new post-navigation check.

4. Removed post-navigation wait / sleep calls
- Removed other post-navigation calls to `view.wait_displayed()`, `self.browser.plugin.ensure_page_safe()`, `time.sleep()`, etc. that are no longer needed.

5. Removed `retry_navigation` decorator usage
- The decorator is no longer needed: the new navigation logic handles retries explicitly.


# Test results

#### tests/foreman/ui/test_rhcloud_inventory.py

robottelo-pr-testing job #14755

#### tests/foreman/ui/test_rhcloud_iop.py:

robottelo-pr-testing job #14753

#### tests/foreman/ui/test_rhcloud_insights_vulnerability.py

robottelo-pr-testing job #14754



There are two failed vulnerability tests, but they also fail against airgun `master`:

robottelo-pr-testing job #14767

- FAILED  tests/foreman/ui/test_rhcloud_insights_vulnerability.py::test_rhcloud_insights_vulnerabilities_e2e[rhel10-ipv4-local]
- FAILED  tests/foreman/ui/test_rhcloud_insights_vulnerability.py::test_edit_from_cve_details_page[rhel10-ipv4-local]

And I've re-run the two failed tests in tests/foreman/ui/test_rhcloud_iop.py successfully since job #14753.