### PR TITLE
[6.18.z] Fix ansible roles/variables pagination selector (#2328)

### DIFF
--- a/airgun/entities/ansible_role.py
+++ b/airgun/entities/ansible_role.py
@@ -39,7 +39,7 @@ class AnsibleRolesEntity(BaseEntity):
         # present on the page
         # Applying wait_displayed for the page to get rendered
         view.wait_displayed()
-        return int(view.total_imported_roles.read())
+        return view.pagination.total_items
 
     def import_all_roles(self):
         """Import all available roles and return the number of roles

--- a/airgun/views/ansible_role.py
+++ b/airgun/views/ansible_role.py
@@ -8,7 +8,7 @@ from widgetastic_patternfly5 import (
 )
 
 from airgun.views.common import BaseLoggedInView, SearchableViewMixin
-from airgun.widgets import ActionsDropdown
+from airgun.widgets import ActionsDropdown, Pf5ConfirmationDialog
 
 
 class AnsibleRolesView(BaseLoggedInView, SearchableViewMixin):
@@ -19,7 +19,6 @@ class AnsibleRolesView(BaseLoggedInView, SearchableViewMixin):
     title = Text("//h1[contains(normalize-space(.),'Ansible Roles')]")
     import_button = Text("//a[contains(@href, '/ansible_roles/import')]")
     submit = PF5button('Submit')
-    total_imported_roles = Text("//span[@class='pf-c-options-menu__toggle-text']//b[2]")
     table = Table(
         './/table',
         column_widgets={
@@ -27,6 +26,7 @@ class AnsibleRolesView(BaseLoggedInView, SearchableViewMixin):
         },
     )
     pagination = PF5Pagination()
+    dialog = Pf5ConfirmationDialog()
 
     @property
     def is_displayed(self):

--- a/airgun/views/ansible_variable.py
+++ b/airgun/views/ansible_variable.py
@@ -15,7 +15,7 @@ class AnsibleVariablesView(BaseLoggedInView, SearchableViewMixinPF4):
 
     title = Text("//h1[contains(normalize-space(.),'Ansible Variables')]")
     new_variable = Text("//a[contains(@href, '/ansible/ansible_variables/new')]")
-    total_variables = Text("//span[@class='pf-c-options-menu__toggle-text']//b[2]")
+    total_variables = Text("//span[@class='pf-v5-c-menu-toggle__text']//b[2]")
     table = SatTable(
         './/table',
         column_widgets={


### PR DESCRIPTION
Should fix test_positive_import_all_roles, test_positive_import_all_roles and test_positive_hostgroup_ansible_roles_tab_pagination in tests/foreman/destructive/test_ansible.py

manual cherrypick of https://github.com/SatelliteQE/airgun/pull/2328