### PR TITLE
[6.17.z] fix: switch prt_labels workflow to use GITHUB_TOKEN

### DIFF
--- a/.github/workflows/prt_labels.yml
+++ b/.github/workflows/prt_labels.yml
@@ -27,7 +27,7 @@ jobs:
           if: always() && ${{steps.prt.outputs.result}} == 'not_found'
           uses: actions/github-script@v8
           with:
-            github-token: ${{ secrets.CHERRYPICK_PAT }}
+            github-token: ${{ secrets.GITHUB_TOKEN }}
             script: |
               const prNumber = '${{ github.event.number }}';
               const issue = await github.rest.issues.get({


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/airgun/pull/2346

The `prt_labels` workflow was failing because `CHERRYPICK_PAT` (an org-level secret) was not accessible to the workflow, causing `actions/github-script@v8` to error with `Input required and not supplied: github-token`.

## Change

- **`.github/workflows/prt_labels.yml`**: Replace `secrets.CHERRYPICK_PAT` with `secrets.GITHUB_TOKEN`, which is always injected by the Actions runner and has sufficient permissions to remove labels on PRs within the same repo.

```yaml
# before
github-token: ${{ secrets.CHERRYPICK_PAT }}

# after
github-token: ${{ secrets.GITHUB_TOKEN }}
```

<!-- START COPILOT ORIGINAL PROMPT -->



<details>

<summary>Original prompt</summary>

> 
> ----
> 
> *This section details on the original issue you should resolve*
> 
> <issue_title>Fix failing PRT labels action</issue_title>
> <issue_description>The job is currently failing because it can't see the organization-level CHERRYPICK_PAT for some reason. It may be worth trying to fix this by switching to the default github token.
> 
> 
> ```
> Run actions/github-script@v8
>   with:
>     script: const prNumber = '2256';
>   const issue = await github.rest.issues.get({
>     owner: context.repo.owner,
>     repo: context.repo.repo,
>     issue_number: prNumber,
>   });
>   const labelsToRemove = ['PRT-Failed', 'PRT-Passed'];
>   const labelsToRemoveFiltered = labelsToRemove.filter(label => issue.data.labels.some(({ name }) => name === label));
>   if (labelsToRemoveFiltered.length > 0) {
>     await Promise.all(labelsToRemoveFiltered.map(async label => {
>       await github.rest.issues.removeLabel({
>         issue_number: prNumber,
>         owner: context.repo.owner,
>         repo: context.repo.repo,
>         name: label
>       });
>     }));
>   }
>   
>     debug: false
>     user-agent: actions/github-script
>     result-encoding: json
>     retries: 0
>     retry-exempt-status-codes: 400,401,403,404,422
> Error: Input required and not supplied: github-token
>     at Object.getInput (/home/runner/work/_actions/actions/github-script/v8/dist/index.js:212:15)
>     at main (/home/runner/work/_actions/actions/github-script/v8/dist/index.js:36262:24)
>     at /home/runner/work/_actions/actions/github-script/v8/dist/index.js:36260:1
>     at /home/runner/work/_actions/actions/github-script/v8/dist/index.js:36317:3
>     at Object.<anonymous> (/home/runner/work/_actions/actions/github-script/v8/dist/index.js:36320:12)
>     at Module._compile (node:internal/modules/cjs/loader:1761:14)
>     at Object..js (node:internal/modules/cjs/loader:1893:10)
>     at Module.load (node:internal/modules/cjs/loader:1481:32)
>     at Module._load (node:internal/modules/cjs/loader:1300:12)
>     at TracingChannel.traceSync (node:diagnostics_channel:328:14)
> Error: Unhandled error: Error: Input required and not supplied: github-token
> ```</issue_description>
> 
> <agent_instructions>The job is currently defined at https://github.com/SatelliteQE/airgun/blob/master/.github/workflows/prt_labels.yml</agent_instructions>
> 
> ## Comments on the Issue (you are @copilot in this section)
> 
> <comments>
> </comments>
> 


</details>



<!-- START COPILOT CODING AGENT SUFFIX -->

- Fixes SatelliteQE/airgun#2345

<!-- START COPILOT CODING AGENT TIPS -->
---

📱 Kick off Copilot coding agent tasks wherever you are with [GitHub Mobile](https://gh.io/cca-mobile-docs), available on iOS and Android.