### PR TITLE
[6.17.z] Update PR label removal workflow permissions and expression syntax

### DIFF
--- a/.github/workflows/prt_labels.yml
+++ b/.github/workflows/prt_labels.yml
@@ -1,11 +1,15 @@
 name: Remove the PRT label, for the new commit
 
 on:
-  pull_request:
+  pull_request_target:
     types: ["synchronize"]
 
 jobs:
     prt_labels_remover:
+      permissions:
+        checks: read
+        issues: write
+        statuses: read
       name: remove the PRT label when amendments or new commits added to PR
       runs-on: ubuntu-latest
       if: "(contains(github.event.pull_request.labels.*.name, 'PRT-Passed') || contains(github.event.pull_request.labels.*.name, 'PRT-Failed'))"
@@ -24,7 +28,7 @@ jobs:
             count: 5
 
         - name: remove the PRT Passed/Failed label, for new commit
-          if: always() && ${{steps.prt.outputs.result}} == 'not_found'
+          if: ${{ always() && steps.prt.outputs.result == 'not_found' }}
           uses: actions/github-script@v8
           with:
             github-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/airgun/pull/2351

Fixes:
- Corrected the YAML syntax for the conditional expression in the label removal step to ensure proper evaluation of the step output.

Configuration:
- Added explicit write permissions for issues to the workflow job to grant the GitHub script necessary authorization to modify pull request labels.