### PR TITLE
host: update tabs on `Recent jobs` card to PF5

### DIFF
--- a/airgun/views/host_new.py
+++ b/airgun/views/host_new.py
@@ -19,7 +19,6 @@ from widgetastic_patternfly4 import (
     DualListSelector,
     Pagination as PF4Pagination,
     Select,
-    Tab,
 )
 from widgetastic_patternfly4.ouia import (
     Button as OUIAButton,
@@ -363,13 +362,13 @@ class NewHostDetailsView(BaseLoggedInView):
             ROOT = './/div[@data-ouia-component-id="card-template-Recent jobs"]'
             actions = Dropdown(locator='.//div[contains(@class, "pf-v5-c-dropdown")]')
 
-            class finished(Tab):
+            class finished(PF5Tab):
                 table = SatTableWithoutHeaders(locator='.//table[@aria-label="recent-jobs-table"]')
 
-            class running(Tab):
+            class running(PF5Tab):
                 table = SatTableWithoutHeaders(locator='.//table[@aria-label="recent-jobs-table"]')
 
-            class scheduled(Tab):
+            class scheduled(PF5Tab):
                 table = SatTableWithoutHeaders(locator='.//table[@aria-label="recent-jobs-table"]')
 
         @View.nested


### PR DESCRIPTION
**host: update tabs on `Recent jobs` card to PF5**

Update tabs on host detail Overview/Recent jobs card from PF4 to PF5.

This fixes robottelo test `tests/foreman/ui/test_remoteexecution.py::test_rex_through_host_details`.

**PRT**
```
trigger: test-robottelo
pytest: tests/foreman/ui/test_remoteexecution.py -k test_rex_through_host_details
```
