### PR TITLE
Remove the unnecessary line, disable password functionality does not exist.

### DIFF
--- a/airgun/entities/discoveredhosts.py
+++ b/airgun/entities/discoveredhosts.py
@@ -98,8 +98,6 @@ class DiscoveredHostsEntity(BaseEntity):
         else:
             view.customize_create.click()
             discovered_host_edit_view = DiscoveredHostEditProvisioningView(self.browser)
-            if 'operating_system.root_password' in host_values:
-                discovered_host_edit_view.operating_system.disable_passwd.click()
             discovered_host_edit_view.fill(host_values)
             self.browser.click(discovered_host_edit_view.submit, ignore_ajax=True)
             self.browser.plugin.ensure_page_safe(timeout='120s')


### PR DESCRIPTION
Removing the unnecessary line, as the disable password functionality does not exist. The function attempts to fetch it, which causes a failure due to its non-existence, so the line is being removed to avoid the failure.

Dependent PR: https://github.com/SatelliteQE/robottelo/pull/21791