### PR TITLE
[6.19.z] Entity was getting timeout as Recommendations tab takes time to load

### DIFF
--- a/airgun/entities/host_new.py
+++ b/airgun/entities/host_new.py
@@ -4,8 +4,7 @@ from navmazing import NavigateToSibling
 from wait_for import wait_for
 
 from airgun.entities.host import HostEntity
-from airgun.navigation import NavigateStep, navigator
-from airgun.utils import retry_navigation
+from airgun.navigation import NavigateStepWithWait as NavigateStep, navigator
 from airgun.views.cloud_insights import RemediateSummary
 from airgun.views.fact import HostFactView
 from airgun.views.host import HostsView as LegacyHostsView
@@ -977,7 +976,8 @@ class NewHostEntity(HostEntity):
 
     def get_recommendations(self, entity_name):
         view = self.navigate_to(self, 'NewDetails', entity_name=entity_name)
-        wait_for(lambda: view.iop_recommendations.recommendations_table.is_displayed, timeout=30)
+        view.iop_recommendations.select()
+        wait_for(lambda: view.iop_recommendations.recommendations_table.is_displayed, timeout=60)
         return view.iop_recommendations.recommendations_table.read()
 
     def remediate_host_recommendation(self, entity_name, recommendation):
@@ -1186,7 +1186,6 @@ class ShowAllHosts(NavigateStep):
 
     VIEW = HostsView
 
-    @retry_navigation
     def step(self, *args, **kwargs):
         self.view.menu.select('Hosts', 'All Hosts')
 

--- a/airgun/views/host_new.py
+++ b/airgun/views/host_new.py
@@ -95,7 +95,7 @@ class RemediationView(View):
 
     @property
     def is_displayed(self):
-        return self.title.wait_displayed()
+        return self.remediate.is_displayed
 
 
 class Card(View):
@@ -267,7 +267,7 @@ class HostsView(BaseLoggedInView, SearchableViewMixinPF4):
 
     @property
     def is_displayed(self):
-        return self.browser.wait_for_element(self.title, exception=False) is not None
+        return self.title.is_displayed
 
 
 class NewHostDetailsView(BaseLoggedInView):
@@ -275,8 +275,7 @@ class NewHostDetailsView(BaseLoggedInView):
 
     @property
     def is_displayed(self):
-        breadcrumb_loaded = self.browser.wait_for_element(self.breadcrumb, exception=False)
-        return breadcrumb_loaded and self.breadcrumb.locations[0] == 'Hosts'
+        return self.breadcrumb.is_displayed and self.breadcrumb.locations[0] == 'Hosts'
 
     edit = PF5OUIAButton('host-edit-button')
     dropdown = PF5Dropdown(locator='//button[@id="hostdetails-kebab"]/..')
@@ -1167,8 +1166,7 @@ class ManageColumnsView(BaseLoggedInView):
 
     @property
     def is_displayed(self):
-        title = self.browser.wait_for_element(self.title, exception=False)
-        return title is not None and title.is_displayed()
+        return self.title.is_displayed
 
     def expand_all(self):
         """Expand all tree sections that are collapsed"""
@@ -1244,4 +1242,4 @@ class ManageMultiCVEnvModal(PF5Modal):
 
     @property
     def is_displayed(self):
-        return self.browser.wait_for_element(self.title, exception=False) is not None
+        return self.title.is_displayed


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/airgun/pull/2385

Entity was getting timeout as Recommendations tab takes time to load
Added wait for view and increased timeout for recommendation table 

As per comment from @tpapaioa Implemented :
   Post-navigation verification mechanism as documented in AGENTS.md
   to improve navigation reliability and eliminate manual wait/retry logic.

   Changes:
   - Updated imports to use NavigateStepWithWait as NavigateStep
   - Removed @retry_navigation decorator from ShowAllHosts navigation step
   - Updated is_displayed methods in views to use property checks instead
     of browser.wait_for_element() calls for:
     * NewHostDetailsView - breadcrumb verification
     * HostsView - title verification
     * RemediationView - remediate button verification
     * ManageColumnsView - title verification
     * ManageMultiCVEnvModal - title verification
   - Simplified get_recommendations() method to rely on navigation framework
     while keeping explicit wait for table display

   Benefits:
   - Navigation framework now automatically verifies views are displayed
   - Eliminates race conditions from manual wait logic
   - More consistent navigation behavior across all host operations
   - Reduced code complexity in entity methods

   Verified with test cases:
   - test_iop_recommendations_host_details_e2e (RHEL10 variants)
   - test_positive_read_from_details_page
   - test_rhcloud_inventory_disabled_local_insights


