### PR TITLE
Cherry pick disable_vulnerability_analysis entity to 6.19.z

### DIFF
--- a/airgun/entities/all_hosts.py
+++ b/airgun/entities/all_hosts.py
@@ -151,6 +151,25 @@ class AllHostsEntity(BaseEntity):
         view.fill(values)
         view.submit()
 
+    def disable_vulnerability_analysis(self, host_name):
+        """Disable vulnerability analysis for a host via kebab menu
+
+        Args:
+            host_name: Name of the host to disable vulnerability analysis for
+        """
+        view = self.all_hosts_navigate_and_select_hosts_helper(host_names=host_name)
+        # Get the first row after search/filter
+        row = view.table[0]
+        # Access via the row's browser element directly
+        row_element = row.__locator__()
+        kebab_button = view.browser.element(
+            './/td[contains(@class, "pf-v5-c-table__action")]//button', parent=row_element
+        )
+        kebab_button.click()
+        # Now find and click the menu item
+        view.browser.click('.//button[contains(., "Disable vulnerability analysis")]')
+        self.browser.plugin.ensure_page_safe(timeout='10s')
+
     def get_displayed_table_headers(self):
         """
         Return displayed columns in the hosts table.


### PR DESCRIPTION
https://github.com/SatelliteQE/airgun/pull/2272 was not cherry picked into the 6.19.z branch after it was merged. However, `tests/foreman/ui/test_rhcloud_insights_vulnerability.py::test_positive_disable_vulnerability_analysis_for_host` is present on the 6.19.z branch of Robottelo and is currently failing due to its inability to access the entity added by https://github.com/SatelliteQE/airgun/pull/2272. 

This PR cherry picks https://github.com/SatelliteQE/airgun/pull/2272 into 6.19.z in order to resolve this test failure.