### PR TITLE
Fix TasksView table locator for PatternFly 5 migration

### DIFF
--- a/airgun/views/task.py
+++ b/airgun/views/task.py
@@ -28,7 +28,7 @@ class TasksView(BaseLoggedInView, SearchableViewMixinPF4):
     title = Text("//h1[normalize-space(.)='Tasks']")
     focus = ActionsDropdown("//div[./button[@id='tasks-dashboard-time-period-dropdown']]")
     table = SatTable(
-        ".//div[@class='tasks-table']//table",
+        ".//table[@data-ouia-component-id='table']",
         column_widgets={
             'Action': Text('./a'),
         },


### PR DESCRIPTION
Problem statement:
Test cases getting timeout as table element has been changed
`wait_for.TimedOutError: Could not do 'lambda defined as `lambda: session.task.search(f'Insights full sync and started_at >= "{timestamp}"'),`' at /opt/app-root/src/robottelo/tests/foreman/ui/test_rhcloud_insights.py:43 in time
`
Solution:
Update the table locator in TasksView from the legacy PF4 selector `.//div[@class='tasks-table']//table` to the PF5 OUIA-based selector `.//table[@data-ouia-component-id='table']`.

The Tasks page has been migrated to PatternFly 5, which uses different DOM structure and OUIA (Open UI Accessibility) attributes for component identification. The old locator was causing timeouts in `session.task.search()` and other table-dependent operations because the wrapper div with `class='tasks-table'` no longer exists in the PF5 implementation.

The new PF5 table structure uses:
- `class="pf-v5-c-table pf-m-grid-md pf-m-compact pf-m-striped"`
- `data-ouia-component-type="PF5/Table"`
- `data-ouia-component-id="table"`

This change fixes timeout issues in:
- TaskEntity.search() - used for finding tasks by query
- TaskEntity.read_all() - used for reading table data
- TaskEntity navigation flows that depend on table rendering
- All test cases using session.task.search() across the test suite

Affects test files:
- tests/foreman/ui/test_rhcloud_insights.py
- tests/foreman/ui/test_dashboard.py
- tests/foreman/ui/test_settings.py
- tests/foreman/ui/test_ldap_authentication.py
- tests/foreman/destructive/test_ldap_authentication.py