### PR TITLE
Add breadcrumb switcher support for host details page (SAT-38703)

### DIFF
--- a/airgun/entities/host_new.py
+++ b/airgun/entities/host_new.py
@@ -974,6 +974,50 @@ class NewHostEntity(HostEntity):
         wait_for(lambda: view.insights.recommendations_table.is_displayed, timeout=10)
         return view.insights.read()
 
+    def select_host_from_breadcrumb(self, hostname):
+        """Select a different host using the breadcrumb switcher.
+
+        This method uses the breadcrumb switcher to change hosts without full page navigation.
+        Useful for testing that tabs update correctly when switching hosts via breadcrumb.
+
+        Args:
+            hostname: Name of the host to switch to
+        """
+        view = NewHostDetailsView(self.browser)
+        view.wait_displayed()
+        self.browser.plugin.ensure_page_safe()
+
+        # Use the breadcrumb switcher to select the host
+        view.breadcrumb_switcher.select_host(hostname)
+
+        # Wait for the page to update after switching hosts
+        self.browser.plugin.ensure_page_safe()
+        wait_for(lambda: view.is_displayed, timeout=10)
+
+    def read_current_insights_tab(self):
+        """Read the Insights tab content without navigating to a different page.
+
+        This method reads the currently displayed Insights tab data.
+        It does NOT navigate to a host's details page, but instead reads whatever
+        is currently shown on the page. This is useful for verifying that the
+        tab content updated correctly after using breadcrumb switcher.
+
+        Returns:
+            dict: The insights tab data currently displayed on the page
+        """
+        view = NewHostDetailsView(self.browser)
+        view.wait_displayed()
+        self.browser.plugin.ensure_page_safe()
+
+        # Make sure we're on the Insights tab
+        if hasattr(view, 'insights') and not view.insights.is_displayed:
+            view.insights.select()
+            wait_for(lambda: view.insights.is_displayed, timeout=10)
+
+        # Read the insights data that's currently displayed
+        wait_for(lambda: view.insights.recommendations_table.is_displayed, timeout=10)
+        return view.insights.read()
+
     def get_recommendations(self, entity_name):
         view = self.navigate_to(self, 'NewDetails', entity_name=entity_name)
         view.iop_recommendations.select()

--- a/airgun/views/host_new.py
+++ b/airgun/views/host_new.py
@@ -1,8 +1,8 @@
 import time
 
 from selenium.common.exceptions import NoSuchElementException
-from wait_for import wait_for
 from selenium.webdriver.common.by import By
+from wait_for import wait_for
 from widgetastic.utils import ParametrizedLocator
 from widgetastic.widget import (
     Checkbox,
@@ -273,6 +273,7 @@ class HostsView(BaseLoggedInView, SearchableViewMixinPF4):
 
 class BreadcrumbSwitcher(Widget):
     """Breadcrumb switcher widget for switching between hosts."""
+
     ROOT = './/div[contains(@class, "pf4-breadcrumb-switcher")]'
 
     # Toggle button to open/close the menu

--- a/airgun/views/host_new.py
+++ b/airgun/views/host_new.py
@@ -1,6 +1,7 @@
 import time
 
 from selenium.common.exceptions import NoSuchElementException
+from wait_for import wait_for
 from selenium.webdriver.common.by import By
 from widgetastic.utils import ParametrizedLocator
 from widgetastic.widget import (
@@ -270,8 +271,53 @@ class HostsView(BaseLoggedInView, SearchableViewMixinPF4):
         return self.title.is_displayed
 
 
+class BreadcrumbSwitcher(Widget):
+    """Breadcrumb switcher widget for switching between hosts."""
+    ROOT = './/div[contains(@class, "pf4-breadcrumb-switcher")]'
+
+    # Toggle button to open/close the menu
+    toggle_button = PF5OUIAButton(component_id='breadcrumb-button')
+
+    # Search input inside the menu
+    search_input = TextInput(locator='.//input[@aria-label="Filter breadcrumb items"]')
+
+    # Menu container
+    menu = PF5Menu(locator='.//div[@data-ouia-component-id="breadcrumb-menu"]')
+
+    # Locator template for menu items
+    MENU_ITEM_LOCATOR = './/a[contains(@href, "/new/hosts/{hostname}")]'
+
+    def select_host(self, hostname):
+        """Select a host from the breadcrumb switcher.
+
+        Args:
+            hostname: The hostname to select
+        """
+        # Open the menu by clicking the toggle button
+        self.toggle_button.click()
+
+        # Wait for menu to be displayed
+        wait_for(lambda: self.search_input.is_displayed, timeout=5)
+
+        # Use search to filter the host list
+        self.search_input.fill(hostname)
+
+        # Wait for search to filter the results
+        time.sleep(1)
+
+        # Click on the menu item for the desired host
+        menu_item_locator = self.MENU_ITEM_LOCATOR.format(hostname=hostname)
+        menu_item = self.browser.element(menu_item_locator)
+        self.browser.click(menu_item)
+
+        # Wait for page to update after navigation
+        time.sleep(3)
+
+
 class NewHostDetailsView(BaseLoggedInView):
     breadcrumb = BreadCrumb('breadcrumbs-list')
+    # Breadcrumb switcher for switching between hosts
+    breadcrumb_switcher = BreadcrumbSwitcher()
 
     @property
     def is_displayed(self):


### PR DESCRIPTION
## Problem

The host details page has a breadcrumb switcher that allows users to quickly navigate between hosts. However, there was no automation support to interact with this widget, making it impossible to write tests that verify the switcher's functionality.

## Solution

This PR adds the necessary widget definitions and entity methods to interact with the breadcrumb switcher on the host details page.

### Changes

**1. BreadcrumbSwitcher Widget (`airgun/views/host_new.py`)**
- New widget class with locators for:
  - Toggle button to open the dropdown menu
  - Search input for filtering hosts
  - Menu container
  - Menu item links
- `select_host(hostname)` method that:
  - Opens the breadcrumb menu
  - Searches for the specified hostname
  - Clicks on the matching menu item
  - Waits for page update

**2. Entity Methods (`airgun/entities/host_new.py`)**
- `select_host_from_breadcrumb(hostname)`: Switch to a different host using the breadcrumb switcher
- `read_current_insights_tab()`: Read the current Insights tab content without navigating

### Usage

```python
# Switch to a different host via breadcrumb
session.host_new.select_host_from_breadcrumb('hostname.example.com')

# Read current Insights tab data
insights_data = session.host_new.read_current_insights_tab()
```

## Related PR

This PR supports test coverage added in:
- robottelo PR: https://github.com/SatelliteQE/robottelo/pull/21461

## Supports

SAT-38703