### PR TITLE
[6.19.z] Update ConfirmationDialog on BaseLoggedInView to PF5

### DIFF
--- a/airgun/views/common.py
+++ b/airgun/views/common.py
@@ -28,8 +28,8 @@ from airgun.widgets import (
     GenericRemovableWidgetItem,
     ItemsList,
     LCESelector,
-    Pf4ConfirmationDialog,
     PF4Search,
+    Pf5ConfirmationDialog as ConfirmationDialog,
     PF5LCECheckSelector,
     PF5LCESelector,
     PF5NavSearch,
@@ -51,7 +51,7 @@ class BaseLoggedInView(View):
     taxonomies = ContextSelector()
     flash = SatFlashMessages()
     validations = ValidationErrors()
-    dialog = Pf4ConfirmationDialog()
+    dialog = ConfirmationDialog()
     logout = Text("//a[@href='/users/logout']")
     current_user = PF5OUIADropdown('user-info-dropdown')
     account_menu = PF5OUIADropdown('user-info-dropdown')


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/airgun/pull/2425

Update the confirmation dialog component used in `BaseLoggedInView` to PF5, to reflect the change in Satellite 6.18 and above.

Related robottelo PR: https://github.com/SatelliteQE/robottelo/pull/21505
Related issue: SAT-43368