### PR TITLE
Add support for IoP Vulnerability export menu

### DIFF
--- a/airgun/entities/cloud_vulnerabilities.py
+++ b/airgun/entities/cloud_vulnerabilities.py
@@ -1,3 +1,5 @@
+import time
+
 from wait_for import wait_for
 
 from airgun.entities.base import BaseEntity
@@ -424,6 +426,27 @@ class CloudVulnerabilityEntity(BaseEntity):
 
         modal.save.click()
         wait_for(lambda: not modal.is_displayed, timeout=10)
+
+    def export(self, export_format='csv'):
+        """
+        Export vulnerabilities data as CSV or JSON.
+
+        Args:
+            export_format (str): 'csv' or 'json'
+
+        Returns:
+            str: Path to the downloaded file
+        """
+        view = self.navigate_to(self, 'All')
+        wait_for(lambda: view.vulnerabilities_table.is_displayed, timeout=30)
+        format_map = {
+            'csv': 'Export to CSV',
+            'json': 'Export to JSON',
+        }
+        view.export_menu.item_select(format_map[export_format])
+
+        time.sleep(5)
+        return self.browser.save_downloaded_file()
 
 
 @navigator.register(CloudVulnerabilityEntity, 'All')

--- a/airgun/views/cloud_vulnerabilities.py
+++ b/airgun/views/cloud_vulnerabilities.py
@@ -113,6 +113,22 @@ class FilterTypeMenu(Widget):
         self.browser.click(item_locator)
 
 
+class ExportMenu(Widget):
+    """Export dropdown menu for downloading vulnerabilities data."""
+
+    ROOT = './/button[contains(@class, "pf-v5-c-menu-toggle") and @aria-label="Export"]'
+
+    def item_select(self, item):
+        """Open the export menu and click an item."""
+        self.browser.click(self)
+        item_locator = (
+            f'//div[@data-ouia-component-id="Export"]'
+            f'//span[contains(@class, "pf-v5-c-menu__item-text")'
+            f' and contains(text(), "{item}")]'
+        )
+        self.browser.click(item_locator)
+
+
 class CloudVulnerabilityView(BaseLoggedInView):
     """Main Insights Vulnerabilities view."""
 
@@ -133,6 +149,7 @@ class CloudVulnerabilityView(BaseLoggedInView):
     cve_menu_toggle = PF5Button('.//button[contains(@class, "pf-v5-c-menu-toggle")]')
     no_cves_found_message = Text('.//h5[contains(@class, "pf-v5-c-empty-state__title-text")]')
     no_authorized_header = Text('.//div[@data-ouia-component-id="NotAuthorized-header"]')
+    export_menu = ExportMenu()
 
     # OS Filter widgets
     # Multi-step conditional filter:


### PR DESCRIPTION
This PR adds support in the cloud_vulnerabilities entity and view for the export menu on the Lightspeed > Vulnerability page, which allows exporting vulnerability data as either JSON or CSV. Support for this widget is required by SAT-44422.