### PR TITLE
Fix for Task progressbar locator

### DIFF
--- a/airgun/views/task.py
+++ b/airgun/views/task.py
@@ -100,7 +100,7 @@ class TaskDetailsView(BaseLoggedInView):
         ended_at = TaskReadOnlyEntry(name='Ended at')
         start_before = TaskReadOnlyEntry(name='Start before')
         state = Text("//div[contains(@class, 'progress-description')]")
-        progressbar = ProgressBar(locator='//div[contains(@class,"progress-bar")]')
+        progressbar = ProgressBar(locator='//div[contains(@class,"progress__bar")]')
         output = TaskReadOnlyEntry(name='Output')
         errors = TaskReadOnlyEntryError(name='Errors')
         dynflow_console = Button('Dynflow console')


### PR DESCRIPTION
### Problem statement
Due to change in progress-bar locator test case were failing with below error message
```

    def wait_for_result(self, timeout=60, delay=1):
        """Wait for invocation job to finish"""
        import ipdb;ipdb.set_trace()
>       wait_for(
            lambda: (
                self.is_displayed
                and self.task.progressbar.is_displayed
                and self.task.result.read() == 'success'
            ),
            timeout=timeout,
            delay=delay,
            logger=self.logger,
        )
E       wait_for.TimedOutError: Could not do 'lambda defined as `lambda: (
E                       self.is_displayed
E                       and self.task.progressbar.is_displayed
E                       and self.task.result.read() == 'success'
E                   ),`' at /home/jnagare/workspace/airgun/airgun/views/task.py:112 in time

../airgun/airgun/views/task.py:111: TimedOutError
```
### Solution
Updated locator to` locator='//div[contains(@class,"progress__bar")]'`