### PR TITLE
Add BarChart widget and views for PF5 bar charts

### DIFF
--- a/airgun/views/dashboard.py
+++ b/airgun/views/dashboard.py
@@ -1,7 +1,7 @@
 from widgetastic.widget import Table, Text, View, Widget
 
 from airgun.views.common import BaseLoggedInView, SatTable, SearchableViewMixinPF4
-from airgun.widgets import ActionsDropdown, PieChart
+from airgun.widgets import ActionsDropdown, BarChart, PieChart
 
 
 class ItemValueList(Widget):
@@ -126,6 +126,38 @@ class DashboardView(BaseLoggedInView, SearchableViewMixinPF4):
     class HostConfigurationChart(View):
         ROOT = ".//li[@data-name='Host Configuration Chart for All']"
         chart = PieChart(".//div[@class='host-configuration-chart']")
+
+    @View.nested
+    class RunDistributionChart(View):
+        """Run Distribution Chart dashboard widgets.
+
+        There is one chart per registered report origin (e.g. Ansible, Puppet).
+        read() returns all of them keyed by origin name, e.g.
+        {'Ansible': {'30': 0, ..., '3': 1}, 'Puppet': {'30': 0, ..., '3': 0}}
+        """
+
+        ROOT = ".//li[contains(@data-name, 'Run Distribution Chart')]"
+        # Used by widgetastic for is_displayed checks
+        chart = BarChart(".//div[contains(@class, 'run-distribution-chart')]")
+
+        # Absolute XPath to find all origin-specific charts from page root
+        # (ROOT resolves to one <li> and can't contain sibling <li> elements)
+        ALL_CHARTS = "//li[contains(@data-name, 'Run Distribution Chart')]"
+
+        def read(self):
+            self.browser.plugin.ensure_page_safe()
+            results = {}
+            for widget_el in self.browser.elements(self.ALL_CHARTS):
+                origin = widget_el.get_attribute('data-name').replace(
+                    'Run Distribution Chart for ', ''
+                )
+                origin_chart = BarChart(
+                    self,
+                    f"//li[@data-name='Run Distribution Chart for {origin}']"
+                    "//div[contains(@class, 'run-distribution-chart')]",
+                )
+                results[origin] = origin_chart.read()
+            return results
 
     @View.nested
     class ContentViews(View):

--- a/airgun/views/oscapreport.py
+++ b/airgun/views/oscapreport.py
@@ -5,6 +5,7 @@ from widgetastic_patternfly5.ouia import FormSelect as PF5FormSelect
 from airgun.views.common import BaseLoggedInView, SearchableViewMixin, WizardStepView
 from airgun.widgets import (
     ActionsDropdown,
+    BarChart,
     SatTable,
 )
 
@@ -32,6 +33,9 @@ class SCAPReportView(BaseLoggedInView, SearchableViewMixin):
 
 class SCAPReportDetailsView(BaseLoggedInView):
     show_log_messages_label = Text('//span[normalize-space(.)="Show log messages:"]')
+    report_status_chart = BarChart(
+        ".//div[contains(@class, 'arf-report-rule-chart-col')]//div[contains(@class, 'stats-well')]"
+    )
     table = SatTable(
         './/table',
         column_widgets={

--- a/airgun/widgets.py
+++ b/airgun/widgets.py
@@ -1,3 +1,4 @@
+import json
 import time
 
 from cached_property import cached_property
@@ -2526,6 +2527,35 @@ class PieChart(GenericLocatorWidget):
         value as its value
         """
         return {self.chart_title_text.read(): self.chart_title_value.read()}
+
+
+class BarChart(GenericLocatorWidget):
+    """PF5 BarChart widget (PatternFly 5 / Victory charts).
+
+    Reads chart data from the data-props JSON attribute on the backing
+    foreman-react-component element. Waits for the SVG to render before
+    reading, which handles AJAX-loaded dashboard widgets.
+
+    Returns a dict mapping bar labels to their numeric values, e.g.
+    {'passed': 45, 'failed': 3, 'othered': 2}.
+    """
+
+    CHART_SVG = ".//*[name()='svg'][@role='img']"
+    REACT_COMPONENT = ".//foreman-react-component[@name='BarChart']"
+
+    @property
+    def is_displayed(self):
+        self.browser.plugin.ensure_page_safe()
+        return (
+            self.browser.wait_for_element(self.CHART_SVG, parent=self, exception=False) is not None
+        )
+
+    def read(self):
+        self.browser.plugin.ensure_page_safe()
+        self.browser.wait_for_element(self.CHART_SVG, parent=self, timeout=30)
+        component = self.browser.element(self.REACT_COMPONENT, parent=self)
+        props = json.loads(component.get_attribute('data-props'))
+        return {str(item[0]): item[1] for item in props.get('data', [])}
 
 
 class RemovableWidgetsItemsListView(View):


### PR DESCRIPTION
Foreman PR #10743 updated the BarChart component from PatternFly 3
to PatternFly 5. Add a reusable BarChart widget that reads chart data
from the foreman-react-component data-props attribute, and wire it
into the dashboard RunDistributionChart and OSCAP report detail views.
