### PR TITLE
Support PF5 SetOrganization component (Katello PR #11734)

### DIFF
--- a/airgun/entities/organization.py
+++ b/airgun/entities/organization.py
@@ -1,4 +1,5 @@
 from navmazing import NavigateToSibling
+from wait_for import wait_for
 
 from airgun.entities.base import BaseEntity
 from airgun.navigation import NavigateStep, navigator
@@ -8,6 +9,7 @@ from airgun.views.organization import (
     OrganizationCreateView,
     OrganizationEditView,
     OrganizationsView,
+    SelectOrganizationContextView,
 )
 
 
@@ -120,11 +122,57 @@ class SelectOrganizationContext(NavigateStep):
         self.view.taxonomies.select_org(org_name)
 
     def post_navigate(self, _tries, *args, **kwargs):
-        """Handle alert screen if it's present"""
+        """Handle alert screen and 'Select an Organization' page if present"""
+        # Handle WrongContextAlert
         wrong_context_view = WrongContextAlert(self.view.browser)
         if wrong_context_view.is_displayed:
             wrong_context_view.back.click()
             self.view.browser.wait_for_element(
                 self.view.menu, exception=False, ensure_page_safe=True
             )
+
+        # Handle 'Select an Organization' page
+        # This appears when navigating to org-specific pages from 'Any Organization' context
+        set_org_view = SelectOrganizationContextView(self.view.browser)
+        if set_org_view.is_displayed:
+            self._handle_set_organization_page(set_org_view, *args, **kwargs)
+
         super().post_navigate(_tries, *args, **kwargs)
+
+    def _handle_set_organization_page(self, set_org_view, *args, **kwargs):
+        """Handle the 'Select an Organization' PF5 page using the view.
+
+        This method handles the organization selection page introduced in
+        Katello PR #11734 (SetOrganization PF3 to PF5 migration).
+
+        Args:
+            set_org_view: Instance of SelectOrganizationContextView
+            *args: Additional positional arguments
+            **kwargs: Keyword arguments including 'org_name'
+        """
+        org_name = kwargs.get('org_name')
+
+        # Wait for page title to be visible
+        wait_for(
+            lambda: set_org_view.title.is_displayed,
+            timeout=10,
+            delay=0.5,
+            message='Waiting for SetOrganization page title',
+        )
+
+        # Select organization using widgetastic Select widget
+        set_org_view.organization_select.fill(org_name)
+
+        # Wait for Submit button to become enabled
+        wait_for(
+            lambda: set_org_view.submit_button.is_enabled,
+            timeout=10,
+            delay=0.5,
+            message='Waiting for Submit button to be enabled',
+        )
+
+        # Click the Submit button
+        set_org_view.submit_button.click()
+
+        # Wait for navigation to complete
+        set_org_view.browser.plugin.ensure_page_safe(timeout=30)

--- a/airgun/views/organization.py
+++ b/airgun/views/organization.py
@@ -1,5 +1,5 @@
-from widgetastic.widget import Checkbox, Table, Text, TextInput, View
-from widgetastic_patternfly import BreadCrumb
+from widgetastic.widget import Checkbox, Select, Table, Text, TextInput, View
+from widgetastic_patternfly import BreadCrumb, Button
 
 from airgun.views.common import BaseLoggedInView, SatVerticalTab, SearchableViewMixinPF4
 from airgun.widgets import (
@@ -146,3 +146,45 @@ class OrganizationEditView(BaseLoggedInView):
     @View.nested
     class parameters(SatVerticalTab):
         resources = CustomParameter(id='global_parameters_table')
+
+
+class SelectOrganizationContextView(View):
+    """
+    This view appears when navigating to organization-specific pages from
+    'Any Organization' context. It provides UI selectors for the organization
+    selection page.
+    """
+
+    # Root container - Card with id='select-org'
+    ROOT = "//div[@id='select-org']"
+
+    # Using OUIA component IDs for reliable selection (PF5 pattern)
+    card = Text("//div[@data-ouia-component-id='select-org-card' or @id='select-org']")
+    title = Text(
+        "//h1[@data-ouia-component-id='select-org-title'] | "
+        "//h1[contains(text(), 'Select an organization')]"
+    )
+
+    # Organization dropdown - PF5 FormSelect component
+    organization_select = Select(
+        locator=(
+            "//select[@data-ouia-component-id='select-org-select'] | //select[@id='organization']"
+        )
+    )
+
+    # Submit button - PF5 Button with primary variant
+    submit_button = Button(
+        locator=(
+            "//button[@data-ouia-component-id='select-org-button'] | "
+            "//button[contains(., 'Select')]"
+        )
+    )
+
+    @property
+    def is_displayed(self):
+        """Check if the 'Select an Organization' page is currently displayed.
+
+        Returns:
+            bool: True if the page is displayed, False otherwise
+        """
+        return self.browser.wait_for_element(self.ROOT, exception=False, timeout=3) is not None


### PR DESCRIPTION
In Katello, updated `SetOrganization` from pf3 to pf5 (https://github.com/Katello/katello/pull/11734) so need to add new test coverage accordingly
[SAT-32072](https://redhat.atlassian.net/browse/SAT-32072)

Related robottelo PR https://github.com/SatelliteQE/robottelo/pull/21731

  - Add `SelectOrganizationContextView` with OUIA selectors
  - Refactor `SelectOrganizationContext` to use view class
  - Auto-handle `SetOrganization` page in organization selection

