### PR TITLE
updated hostgroup ansiroles selection to dual list

### DIFF
--- a/airgun/entities/host_new.py
+++ b/airgun/entities/host_new.py
@@ -38,8 +38,9 @@ def navigate_to_edit_view(func):
         view.overview.details.edit.click()
         self.browser.switch_to_window(self.browser.window_handles[1])
         host_group_view = HostGroupEditView(self.browser)
+        host_group_view.wait_displayed()
         func(self, entity_name, role_name)
-        host_group_view.ansible_roles.submit.click()
+        host_group_view.submit.click()
         self.browser.switch_to_window(self.browser.window_handles[0])
         self.browser.close_window(self.browser.window_handles[1])
 
@@ -103,12 +104,10 @@ class NewHostEntity(HostEntity):
             role_name: Name of the ansible role
         """
         host_group_view = HostGroupEditView(self.browser)
-        host_group_view.ansible_roles.more_item.click()
-        host_group_view.ansible_roles.select_pages.click()
-        role_list = self.browser.elements(host_group_view.ansible_roles.available_role, parent=self)
-        for single_role in role_list[1:]:
-            if single_role.text.split('. ')[1] == role_name:
-                single_role.click()
+        host_group_view.ansible_roles.click()
+        roles_view = host_group_view.ansible_roles.resources
+        wait_for(lambda: roles_view.addAnsibleRole.is_displayed, timeout=30)
+        roles_view.fill([role_name])
 
     @navigate_to_edit_view
     def remove_hostgroup_role(self, entity_name, role_name):
@@ -119,29 +118,28 @@ class NewHostEntity(HostEntity):
             role_name: Name of the ansible role
         """
         host_group_view = HostGroupEditView(self.browser)
-        role_list = self.browser.elements(host_group_view.ansible_roles.assigned_role, parent=self)
-        for single_role in role_list[1:]:
-            if single_role.text.split('. ')[1] == role_name:
-                single_role.click()
+        host_group_view.ansible_roles.click()
+        roles_view = host_group_view.ansible_roles.resources
+        wait_for(lambda: roles_view.addAnsibleRole.is_displayed, timeout=30)
+        roles_view.unassign([role_name])
 
     @navigate_to_edit_view
     def assign_all_role_to_hostgroup(self, entity_name, role_name=None):
         """Assign all Ansible roles from the host group"""
         host_group_view = HostGroupEditView(self.browser)
-        host_group_view.ansible_roles.more_item.click()
-        host_group_view.ansible_roles.select_pages.click()
-        role_list = self.browser.elements(host_group_view.ansible_roles.available_role, parent=self)
-        for single_role in role_list:
-            single_role.click()
+        host_group_view.ansible_roles.click()
+        roles_view = host_group_view.ansible_roles.resources
+        wait_for(lambda: roles_view.addAnsibleRole.is_displayed, timeout=30)
+        roles_view.addAnsibleRole.move_all_items_right()
 
     @navigate_to_edit_view
     def remove_all_role_from_hostgroup(self, entity_name, role_name=None):
         """Remove all Ansible roles from the host group"""
         host_group_view = HostGroupEditView(self.browser)
         host_group_view.ansible_roles.click()
-        role_list = self.browser.elements(host_group_view.ansible_roles.assigned_role, parent=self)
-        for single_role in role_list:
-            single_role.click()
+        roles_view = host_group_view.ansible_roles.resources
+        wait_for(lambda: roles_view.addAnsibleRole.is_displayed, timeout=30)
+        roles_view.addAnsibleRole.move_all_items_left()
 
     def get_host_statuses(self, entity_name):
         """Read host statuses from Host Details page
@@ -625,7 +623,7 @@ class NewHostEntity(HostEntity):
         view.ansible.roles.edit.click()
         wait_for(lambda: EditAnsibleRolesView(self.browser).addAnsibleRole.is_displayed, timeout=10)
         edit_view = EditAnsibleRolesView(self.browser)
-        edit_view.addAnsibleRole.select_and_move([role])
+        edit_view.fill([role])
         edit_view.confirm.click()
 
     def get_ansible_roles(self, entity_name):

--- a/airgun/entities/hostgroup.py
+++ b/airgun/entities/hostgroup.py
@@ -1,5 +1,4 @@
 from navmazing import NavigateToSibling
-from wait_for import wait_for
 from widgetastic.exceptions import NoSuchElementException
 
 from airgun.entities.base import BaseEntity
@@ -72,15 +71,13 @@ class HostGroupEntity(BaseEntity):
         """Count of assigned role to the host group"""
         view = self.navigate_to(self, 'Edit', entity_name=entity_name)
         view.ansible_roles.click()
-        role_list = self.browser.elements(view.ansible_roles.assigned_ansible_role, parent=self)
-        wait_for(lambda: int(role_list[-1].text.split('. ')[0]), timeout=30)
-        return int(role_list[-1].text.split('. ')[0])
+        return view.ansible_roles.resources.read_assigned_count()
 
     def assign_role_to_hostgroup(self, entity_name, values):
         """Assign Ansible role(s) to the host group based on user input
         Args:
-            entity_name: Name of the host
-            values: Name of the ansible role
+            entity_name: Name of the host group
+            values: Ansible role name(s) or dict with ``ansible_roles`` key
         """
         view = self.navigate_to(self, 'Edit', entity_name=entity_name)
         view.fill(values)
@@ -91,16 +88,23 @@ class HostGroupEntity(BaseEntity):
     def remove_hostgroup_role(self, entity_name, values):
         """Remove Ansible role from the host group based on user input
         Args:
-            entity_name: Name of the host
-            values: Name of the ansible role
+            entity_name: Name of the host group
+            values: Name of the ansible role(s) to remove
         """
         view = self.navigate_to(self, 'Edit', entity_name=entity_name)
-        view.ansible_roles.resources.unassigned_values(values)
+        view.ansible_roles.click()
+        view.ansible_roles.resources.unassign(values)
         view.submit.click()
 
-    def read_role(self, entity_name, values):
-        """Return name of the assigned Ansible role(s) of the host group."""
+    def read_role(self, entity_name, values=None):
+        """Return assigned Ansible role name(s) of the host group.
+
+        Args:
+            entity_name: Name of the host group
+            values: Optional role name(s) to filter the result against
+        """
         view = self.navigate_to(self, 'Edit', entity_name=entity_name)
+        view.ansible_roles.click()
         return view.ansible_roles.resources.read_assigned_values(values)
 
 

--- a/airgun/views/host_new.py
+++ b/airgun/views/host_new.py
@@ -1130,6 +1130,100 @@ class EditAnsibleRolesView(View):
     )
     selectRoles = PF5Button(locator='.//button[@aria-label="Add selected"]')
     unselectRoles = PF5Button(locator='.//button[@aria-label="Remove selected"]')
+    CHOSEN_ITEMS = (
+        ".//div[contains(@class, 'pf-m-chosen')]"
+        "//button[contains(@class, 'dual-list-selector__item')]"
+    )
+    AVAILABLE_ITEMS = (
+        ".//div[contains(@class, 'pf-m-available')]"
+        "//button[contains(@class, 'dual-list-selector__item')]"
+    )
+    ROLE_NAME = './/span[1]//span[2]'
+
+    @property
+    def is_displayed(self):
+        return self.addAnsibleRole.is_displayed
+
+    def role_name_from_item(self, item):
+        try:
+            return self.browser.text(self.browser.element(self.ROLE_NAME, parent=item))
+        except NoSuchElementException:
+            return self.browser.text(item).strip()
+
+    def items_by_role_name(self, chosen=False):
+        items_locator = self.CHOSEN_ITEMS if chosen else self.AVAILABLE_ITEMS
+        items_by_name = {}
+        for item in self.browser.elements(items_locator, parent=self.addAnsibleRole):
+            role_name = self.role_name_from_item(item)
+            if role_name:
+                items_by_name[role_name] = item
+        return items_by_name
+
+    def select_roles(self, roles, chosen=False):
+        items_by_name = self.items_by_role_name(chosen=chosen)
+        pane = 'chosen' if chosen else 'available'
+        for role in roles:
+            item = items_by_name.get(role)
+            if not item:
+                raise ValueError(f'Role {role!r} not found in {pane} list')
+            self.browser.click(item)
+
+    def select_and_move_roles(self, roles, from_chosen=False):
+        self.select_roles(roles, chosen=from_chosen)
+        if from_chosen:
+            self.addAnsibleRole.move_selected_items_left()
+        else:
+            self.addAnsibleRole.move_selected_items_right()
+
+    def assigned_role_names(self):
+        return list(self.items_by_role_name(chosen=True).keys())
+
+    def roles_from_values(self, values):
+        if isinstance(values, dict):
+            roles = values.get('assigned') or values.get('resources')
+            if roles is None:
+                roles = list(values.values())
+        elif isinstance(values, (list, tuple)):
+            roles = values
+        elif values:
+            roles = [values]
+        else:
+            roles = ()
+        return [role for role in roles if role]
+
+    def fill(self, values):
+        """Assign ansible roles by moving them from available to chosen list."""
+        wait_for(lambda: self.addAnsibleRole.is_displayed, timeout=30, handle_exception=True)
+        roles = self.roles_from_values(values)
+        if roles:
+            self.select_and_move_roles(roles, from_chosen=False)
+        return True
+
+    def unassign(self, values):
+        """Remove ansible roles from the chosen list."""
+        wait_for(lambda: self.addAnsibleRole.is_displayed, timeout=30, handle_exception=True)
+        roles = self.roles_from_values(values)
+        if roles:
+            self.select_and_move_roles(roles, from_chosen=True)
+        return True
+
+    def read_assigned_values(self, values=None):
+        """Return assigned ansible role names, optionally filtered by values."""
+        wait_for(lambda: self.addAnsibleRole.is_displayed, timeout=30, handle_exception=True)
+        assigned = self.assigned_role_names()
+        if values is None:
+            return assigned
+        if isinstance(values, dict):
+            filter_values = values.values()
+        elif isinstance(values, str):
+            filter_values = [values]
+        else:
+            filter_values = values
+        return [role for role in assigned if role in filter_values]
+
+    def read_assigned_count(self):
+        wait_for(lambda: self.addAnsibleRole.is_displayed, timeout=30, handle_exception=True)
+        return len(self.assigned_role_names())
 
 
 class ModuleStreamDialog(Pf5ConfirmationDialog):

--- a/airgun/views/hostgroup.py
+++ b/airgun/views/hostgroup.py
@@ -3,17 +3,16 @@ from widgetastic_patternfly import BreadCrumb
 from widgetastic_patternfly5 import (
     Button as PF5Button,
     ChipGroup as PF5ChipGroup,
-    Pagination as PF5Pagination,
 )
 from widgetastic_patternfly5.ouia import Select as PF5OUIASelect
 
 from airgun.views.common import BaseLoggedInView, SatTab, SearchableViewMixinPF4
+from airgun.views.host_new import EditAnsibleRolesView
 from airgun.widgets import (
     ActionsDropdown,
     ConfigGroupMultiSelect,
     FilteredDropdown,
     MultiSelect,
-    MultiSelectNoFilter,
     PuppetClassesMultiSelect,
     RadioGroup,
 )
@@ -84,8 +83,10 @@ class HostGroupCreateView(BaseLoggedInView):
     @View.nested
     class ansible_roles(SatTab):
         TAB_NAME = 'Ansible Roles'
-        resources = MultiSelectNoFilter(id='ansible_roles')
-        pagination = PF5Pagination()
+
+        @View.nested
+        class resources(EditAnsibleRolesView):
+            pass
 
     @View.nested
     class puppet_enc(SatTab):
@@ -153,16 +154,3 @@ class HostGroupEditView(HostGroupCreateView):
             and self.breadcrumb.locations[0] == 'Host Groups'
             and self.breadcrumb.read().startswith('Edit ')
         )
-
-    @View.nested
-    class ansible_roles(SatTab):
-        TAB_NAME = 'Ansible Roles'
-        more_item = Text('//span[@class="pf-c-options-menu__toggle-button-icon"]')
-        select_pages = Text('//ul[@class="pf-c-options-menu__menu"]/li[6]/button')
-        available_role = '//div[@class="available-roles-container col-sm-6"]/div[2]/div'
-        assigned_role = '//div[@class="assigned-roles-container col-sm-6"]/div[2]/div'
-        assigned_ansible_role = '//div[@class="assigned-roles-container col-sm-6"]/div[2]/div'
-        no_of_available_role = Text('//span[@class="pf-c-options-menu__toggle-text"]//b[2]')
-        resources = MultiSelectNoFilter(id='ansible_roles')
-        submit = Text('//input[@name="commit"]')
-        pagination = PF5Pagination()


### PR DESCRIPTION
Adjusting for changes to be introduced in https://github.com/theforeman/foreman_ansible/pull/792 
Switching ansible roles in host and hostgroup create forms will look the same as dual list used in Host details ansible tab. This PR extends the EditAnsibleRolesView that represents that dual list (but doesn't drop anything so the previous uses within airgun should be unaffected) and uses it where due.

Not to be merged berfore upstream