### PR TITLE
[6.19.z] Add views/entities for Inventory Upload in IoP scenario

### DIFF
--- a/airgun/entities/cloud_inventory.py
+++ b/airgun/entities/cloud_inventory.py
@@ -5,7 +5,7 @@ from widgetastic.exceptions import NoSuchElementException
 
 from airgun.entities.base import BaseEntity
 from airgun.navigation import NavigateStepWithWait as NavigateStep, navigator
-from airgun.views.cloud_inventory import CloudInventoryListView
+from airgun.views.cloud_inventory import CloudInventoryListView, IopCloudInventoryListView
 
 
 class CloudInventoryEntity(BaseEntity):
@@ -160,3 +160,23 @@ class ShowCloudInventoryListView(NavigateStep):
 
     def step(self, *args, **kwargs):
         self.view.menu.select('Red Hat Lightspeed', 'Inventory Upload')
+
+
+class IopCloudInventoryEntity(CloudInventoryEntity):
+    def read(self, entity_name=None):
+        """Read Inventory Upload page but skip elements not present in IoP scenario"""
+        view = self.navigate_to(self, 'All')
+        result = view.read()
+        view.inventory_list.toggle(entity_name)
+        result.update(view.inventory_list.read())
+        return result
+
+
+@navigator.register(IopCloudInventoryEntity, 'All')
+class ShowIopCloudInventoryListView(ShowCloudInventoryListView):
+    """Navigate to Inventory Upload page when IoP is enabled on Satellite"""
+
+    VIEW = IopCloudInventoryListView
+
+    def step(self, *args, **kwargs):
+        self.view.menu.select('Administer', 'Inventory Upload')

--- a/airgun/session.py
+++ b/airgun/session.py
@@ -22,7 +22,7 @@ from airgun.entities.bookmark import BookmarkEntity
 from airgun.entities.bootc import BootcEntity
 from airgun.entities.capsule import CapsuleEntity
 from airgun.entities.cloud_insights import CloudInsightsEntity, RecommendationsTabEntity
-from airgun.entities.cloud_inventory import CloudInventoryEntity
+from airgun.entities.cloud_inventory import CloudInventoryEntity, IopCloudInventoryEntity
 from airgun.entities.cloud_vulnerabilities import CloudVulnerabilityEntity
 from airgun.entities.computeprofile import ComputeProfileEntity
 from airgun.entities.computeresource import ComputeResourceEntity
@@ -394,6 +394,11 @@ class Session:
     def cloudinventory(self):
         """Instance of Insights Inventory Upload entity."""
         return self._open(CloudInventoryEntity)
+
+    @cached_property
+    def iopcloudinventory(self):
+        """Instance of Insights Inventory Upload entity in IoP scenario."""
+        return self._open(IopCloudInventoryEntity)
 
     @cached_property
     def recommendationstab(self):

--- a/airgun/views/cloud_inventory.py
+++ b/airgun/views/cloud_inventory.py
@@ -133,3 +133,26 @@ class CloudInventoryListView(BaseLoggedInView):
             final_dict['auto_update'] = self.auto_update.read()
 
         return final_dict
+
+
+class IopInventoryItemsView(InventoryItemsView):
+    """Item related to one organization on Red Hat Lightspeed Inventory Upload page
+    with IoP enabled on Satellite."""
+
+    def read(self):
+        """Read current state of view, skipping elements not present with IoP enabled."""
+        result = {
+            'report_saved_to': self.report_saved_to.read(),
+            'task_status': self.task_status.read(),
+        }
+        return result
+
+
+class IopCloudInventoryListView(CloudInventoryListView):
+    """Main Red Hat Lightspeed Inventory Upload view with IoP enabled on Satellite."""
+
+    inventory_list = View.nested(IopInventoryItemsView)
+
+    def read(self):
+        """Read current state of view, skipping elements not present with IoP enabled."""
+        return {'title': self.title.text}


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/airgun/pull/2460

When IoP is enabled on Satellite, the `Inventory Upload` navigation item is moved from being nested under the `Red Hat Lightspeed` navigation section to being nested under the `Administer` navigation section. This PR adds support for inventory upload workflows in the UI with the modified navigation path in IoP. It does so by subclassing the existing Cloud Inventory entities and views and modifying the methods and attributes needed by an end-to-end inventory upload test in the IoP scenario.

Please note that some page elements are present on the Inventory Upload page in the non-IoP scenario that are absent in the IoP scenario. This means that, to give one example, instances of `IopCloudInventoryEntity` will throw an exception if a test attempts to invoke `get_displayed_settings_options()`, since the toggles read by that method are not available in the IoP scenario. On the other hand, there should be no need to invoke `get_displayed_settings_options()` in the IoP scenario, precisely because those elements are not present on the page in that scenario.
