### PR TITLE
[6.18.z] Harden apply_erratas entity failed search

### DIFF
--- a/airgun/entities/host_new.py
+++ b/airgun/entities/host_new.py
@@ -478,6 +478,9 @@ class NewHostEntity(HostEntity):
         param: search (string): search value to filter results.
         example: search="errata_id == {ERRATA_ID}"
         default: None; all available errata are returned and installed.
+
+        Raises:
+            ValueError: If a search was provided but returned no matching errata.
         """
         view = self.navigate_to(self, 'NewDetails', entity_name=entity_name)
         view.wait_displayed()
@@ -490,6 +493,8 @@ class NewHostEntity(HostEntity):
         # wait for filter to apply
         view.content.errata.wait_displayed()
         self.browser.plugin.ensure_page_safe()
+        if search is not None and not view.content.errata.table.is_displayed:
+            raise ValueError(f'No errata found matching search: {search}')
         view.content.errata.select_all.click()
         view.content.errata.apply.fill('Apply')
         view.flash.assert_no_error()


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/airgun/pull/2474

Add error raise when search is provided by user and it finds nothing.