### PR TITLE
[6.18.z] Fix all hosts table name locator

### DIFF
--- a/airgun/views/all_hosts.py
+++ b/airgun/views/all_hosts.py
@@ -104,7 +104,9 @@ class AllHostsTableView(BaseLoggedInView, SearchableViewMixinPF4):
         component_id='table',
         column_widgets={
             0: Checkbox(locator='.//input[@type="checkbox"]'),
-            'Name': Text('./a'),
+            'Name': Text(
+                './/a[contains(@href, "/new/hosts/") and not(contains(@href, "Red Hat Lightspeed"))]'
+            ),
             2: MenuToggleDropdownInTable(),
         },
     )


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/airgun/pull/2477

Update all hosts page table Name column locator so it's more robust.