### PR TITLE
Add cacert text input field to ldap auth source view

### DIFF
--- a/airgun/entities/ldap_authentication.py
+++ b/airgun/entities/ldap_authentication.py
@@ -57,7 +57,7 @@ class LDAPAuthenticationEntity(BaseEntity):
         """Testing FQDN for test connection"""
         view = self.navigate_to(self, 'New')
         view.fill(values)
-        view.ldap_server.text_connection.click()
+        view.ldap_server.test_connection.click()
         view.flash.assert_no_error()
 
     def read_auth_source_counts(self, auth_source_type):

--- a/airgun/views/ldapauthentication.py
+++ b/airgun/views/ldapauthentication.py
@@ -53,6 +53,7 @@ class LDAPAuthenticationCreateView(BaseLoggedInView):
         host = TextInput(id='auth_source_ldap_host')
         text_connection = Text('//a[@id="test_connection_button"]')
         ldaps = Checkbox(id='auth_source_ldap_tls')
+        cacert = TextInput(id='auth_source_ldap_cacert')
         port = TextInput(id='auth_source_ldap_port')
         server_type = FilteredDropdown(id='auth_source_ldap_server_type')
 

--- a/airgun/views/ldapauthentication.py
+++ b/airgun/views/ldapauthentication.py
@@ -51,7 +51,7 @@ class LDAPAuthenticationCreateView(BaseLoggedInView):
 
         name = TextInput(id='auth_source_ldap_name')
         host = TextInput(id='auth_source_ldap_host')
-        text_connection = Text('//a[@id="test_connection_button"]')
+        test_connection = Text('//a[@id="test_connection_button"]')
         ldaps = Checkbox(id='auth_source_ldap_tls')
         cacert = TextInput(id='auth_source_ldap_cacert')
         port = TextInput(id='auth_source_ldap_port')


### PR DESCRIPTION
https://github.com/theforeman/foreman/pull/11107 adds a cacert attribute to ldap auth servers. This extends the ldap authentication create view with the new input field.