### PR TITLE
Change route to no longer reference labs.

### DIFF
--- a/airgun/entities/contentcredential.py
+++ b/airgun/entities/contentcredential.py
@@ -14,8 +14,7 @@ from airgun.views.product import ProductEditView
 
 
 class ContentCredentialEntity(BaseEntity):
-    # TODO: Update to '/content_credentials' once the React page is moved out of /labs
-    endpoint_path = '/labs/content_credentials'
+    endpoint_path = '/content_credentials'
 
     def create(self, values):
         """Create new content credentials entity via modal.


### PR DESCRIPTION
https://redhat.atlassian.net/browse/SAT-47544 moved the PF5 Content Credentials page to live, so this changes the route in airgun to reference that.

Related: https://github.com/SatelliteQE/robottelo/pull/22302