### PR TITLE
Fix TaskDetailsView and SatFlashMessages for PF5 UI updates

### DIFF
--- a/airgun/views/task.py
+++ b/airgun/views/task.py
@@ -1,7 +1,7 @@
 from wait_for import wait_for
 from widgetastic.widget import Table, Text, View
 from widgetastic_patternfly import BreadCrumb, Button
-from widgetastic_patternfly5 import Pagination as PF5Pagination, Tab as PF5Tab
+from widgetastic_patternfly5 import Button as PF5Button, Pagination as PF5Pagination
 
 from airgun.views.common import BaseLoggedInView, SearchableViewMixinPF4
 from airgun.widgets import (
@@ -21,9 +21,11 @@ TASKS_PAGINATION_LOCATOR = (
 
 class TaskReadOnlyEntry(ReadOnlyEntry):
     BASE_LOCATOR = (
-        "//span[contains(., '{}') and contains(@class, 'list-group-item-heading')]//parent::div"
-        '/following-sibling::div/span'
+        "//small[normalize-space(.)='{}']/parent::div/following-sibling::div"
     )
+
+    def read(self):
+        return super().read().lower()
 
 
 class TaskReadOnlyEntryError(ReadOnlyEntry):
@@ -90,27 +92,31 @@ class TaskDetailsView(BaseLoggedInView):
         )
 
     @View.nested
-    class task(PF5Tab):
-        name = TaskReadOnlyEntry(name='Name')
+    class task(View):
+        ROOT = '//section[contains(@class, "task-details-overview-section")]'
         result = TaskReadOnlyEntry(name='Result')
         triggered_by = TaskReadOnlyEntry(name='Triggered by')
         execution_type = TaskReadOnlyEntry(name='Execution type')
         start_at = TaskReadOnlyEntry(name='Start at')
         started_at = TaskReadOnlyEntry(name='Started at')
         ended_at = TaskReadOnlyEntry(name='Ended at')
-        start_before = TaskReadOnlyEntry(name='Start before')
-        state = Text("//div[contains(@class, 'progress-description')]")
-        progressbar = ProgressBar(locator='//div[contains(@class,"progress__bar")]')
-        output = TaskReadOnlyEntry(name='Output')
+        state = Text(
+            "//p[@data-ouia-component-id='task-info-running-state-summary']"
+        )
+        progressbar = ProgressBar(
+            locator='//div[contains(@class,"pf-v5-c-progress__bar")]'
+        )
+        output = ReadOnlyEntry(
+            locator="//strong[normalize-space(.)='Output']/parent::div/following-sibling::div"
+        )
         errors = TaskReadOnlyEntryError(name='Errors')
-        dynflow_console = Button('Dynflow console')
+        dynflow_console = PF5Button('Dynflow console')
 
     def wait_for_result(self, timeout=60, delay=1):
         """Wait for invocation job to finish"""
         wait_for(
             lambda: (
                 self.is_displayed
-                and self.task.progressbar.is_displayed
                 and self.task.result.read() == 'success'
             ),
             timeout=timeout,

--- a/airgun/views/task.py
+++ b/airgun/views/task.py
@@ -20,9 +20,7 @@ TASKS_PAGINATION_LOCATOR = (
 
 
 class TaskReadOnlyEntry(ReadOnlyEntry):
-    BASE_LOCATOR = (
-        "//small[normalize-space(.)='{}']/parent::div/following-sibling::div"
-    )
+    BASE_LOCATOR = "//small[normalize-space(.)='{}']/parent::div/following-sibling::div"
 
     def read(self):
         return super().read().lower()
@@ -100,12 +98,8 @@ class TaskDetailsView(BaseLoggedInView):
         start_at = TaskReadOnlyEntry(name='Start at')
         started_at = TaskReadOnlyEntry(name='Started at')
         ended_at = TaskReadOnlyEntry(name='Ended at')
-        state = Text(
-            "//p[@data-ouia-component-id='task-info-running-state-summary']"
-        )
-        progressbar = ProgressBar(
-            locator='//div[contains(@class,"pf-v5-c-progress__bar")]'
-        )
+        state = Text("//p[@data-ouia-component-id='task-info-running-state-summary']")
+        progressbar = ProgressBar(locator='//div[contains(@class,"pf-v5-c-progress__bar")]')
         output = ReadOnlyEntry(
             locator="//strong[normalize-space(.)='Output']/parent::div/following-sibling::div"
         )
@@ -115,10 +109,7 @@ class TaskDetailsView(BaseLoggedInView):
     def wait_for_result(self, timeout=60, delay=1):
         """Wait for invocation job to finish"""
         wait_for(
-            lambda: (
-                self.is_displayed
-                and self.task.result.read() == 'success'
-            ),
+            lambda: self.is_displayed and self.task.result.read() == 'success',
             timeout=timeout,
             delay=delay,
             logger=self.logger,


### PR DESCRIPTION
## Summary
- **TaskDetailsView**: The task details page no longer uses a "Task" tab. Metadata (Result, State, etc.) is now displayed in an overview section using `<small>` labels instead of `<span class="list-group-item-heading">`. The progress bar disappears on task completion, and result text is now capitalized ("Success" instead of "success").
- **SatFlashMessages**: The flash container `<ul>` gained an extra `foreman-toast-group` class, breaking the exact `@class=` XPath match in the ROOT locator.

## Changes

### `airgun/views/task.py`
- Changed `task` nested class from `PF5Tab` to plain `View` (no "Task" tab exists anymore)
- Updated `TaskReadOnlyEntry.BASE_LOCATOR` for `<small>` label pattern
- Added `TaskReadOnlyEntry.read()` to normalize values to lowercase for backward compatibility
- Removed `progressbar.is_displayed` check from `wait_for_result` (progress bar disappears on completion)
- Updated locators for `state`, `progressbar`, `output`, `dynflow_console`
- Changed `dynflow_console` from PF4 `Button` to PF5 `Button` (now an `<a>` tag)

### `airgun/widgets.py`
- Changed `SatFlashMessages.ROOT` from exact `@class=` to `contains()` match

## Test commands
```
pytest tests/foreman/ui/test_hostcollection.py::test_negative_hosts_limit
pytest tests/foreman/ui/test_hostcollection.py::test_positive_change_assigned_content
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)