### PR TITLE
[6.19.z] update_table_info_in_AllHostsTableView

### DIFF
--- a/airgun/views/all_hosts.py
+++ b/airgun/views/all_hosts.py
@@ -34,7 +34,7 @@ from airgun.views.common import (
     SearchableViewMixinPF4,
     WizardStepView,
 )
-from airgun.views.host_new import ManageColumnsView, PF5CheckboxTreeView
+from airgun.views.host_new import ManageColumnsView, MenuToggleButtonMenu, PF5CheckboxTreeView
 from airgun.widgets import ItemsList, PF5NavSearchMenu, SearchInput
 
 
@@ -120,6 +120,7 @@ class AllHostsTableView(BaseLoggedInView, SearchableViewMixinPF4):
                 './/a[contains(@href, "/new/hosts/") and not(contains(@href, "Red Hat Lightspeed"))]'
             ),
             2: MenuToggleDropdownInTable(),
+            6: MenuToggleButtonMenu(),
         },
     )
     autocomplete_menu = PF5NavSearchMenu(component_id='search-autocomplete-menu')


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/airgun/pull/2498

Due to a recent [change](https://github.com/SatelliteQE/airgun/pull/2454) in the `host_new.py` module, specifically in the `ShowAllHosts` class, we are no longer using `HostsView` and have switched to `AllHostsTableView`.

Because of this change, a couple of tests are failing. The `HostsView` had a key-value pair that was missing from `AllHostsTableView`. When the tests attempt to delete the host, the deletion fails because this parameter is missing.

I have added the missing key-value pair to `AllHostsTableView`, which should allow the host to be deleted correctly.
