### PR TITLE
Update Content Credentials navigation from Lab Features to Content menu

### DIFF
--- a/airgun/entities/contentcredential.py
+++ b/airgun/entities/contentcredential.py
@@ -150,8 +150,7 @@ class ShowAllContentCredentials(NavigateStep):
     VIEW = ContentCredentialsTableView
 
     def step(self, *args, **kwargs):
-        # TODO: Update menu path to 'Content', 'Content Credentials' once the page is moved out of /labs
-        self.view.menu.select('Lab Features', 'Content Credentials')
+        self.view.menu.select('Content', 'Content Credentials')
 
 
 @navigator.register(ContentCredentialEntity, 'Edit')

--- a/airgun/views/contentcredential.py
+++ b/airgun/views/contentcredential.py
@@ -16,7 +16,7 @@ from airgun.widgets import PF5EditableSpacedListItem, PF5SpacedListItem
 
 
 class ContentCredentialsTableView(BaseLoggedInView, SearchableViewMixinPF4):
-    """PF5 list page for Content Credentials at /labs/content_credentials."""
+    """PF5 list page for Content Credentials at /content_credentials."""
 
     title = Text('//h1[normalize-space(.)="Content Credentials"]')
     create_button = PF5OUIAButton('action-buttons-create')
@@ -64,7 +64,7 @@ class DeleteContentCredentialModal(PF5OUIAModal):
 
 
 class ContentCredentialEditView(BaseLoggedInView):
-    """PF5 details page for a Content Credential at /labs/content_credentials/:id."""
+    """PF5 details page for a Content Credential at /content_credentials/:id."""
 
     title = Text('.//h1[@data-ouia-component-id="credential-details-header-name"]')
     page_breadcrumb = PF5OUIABreadCrumb('content-credential-breadcrumb')


### PR DESCRIPTION
The new ContentCredential page has been moved out of `Labs` to `Content`, updating the navigation to make the tests pass again.