### PR TITLE
Wait for flash notification when sending email

### DIFF
--- a/airgun/entities/settings.py
+++ b/airgun/entities/settings.py
@@ -1,3 +1,5 @@
+from wait_for import wait_for
+
 from airgun.entities.base import BaseEntity
 from airgun.navigation import NavigateStep, navigator
 from airgun.utils import retry_navigation
@@ -32,7 +34,8 @@ class SettingsEntity(BaseEntity):
         view = self.navigate_to(self, 'All')
         view.search(property_name)
         view.Email.test_email_button.click()
-        return view.flash.read()
+        result, _ = wait_for(lambda: view.flash.read(), timeout=60, delay=2)  # noqa: PLW0108
+        return result
 
     def permission_denied(self):
         """Return permission denied error text"""


### PR DESCRIPTION
Fixing occasional failures of test_positive_update_email_delivery_method_sendmail. Sometimes the notification is not shown immediately. Added wait_for to process sending of the email and render the flash notification.

Related JIRA issue: SAT-45643