### PR TITLE
Make all_hosts delete() entity more robust

### DIFF
--- a/airgun/entities/all_hosts.py
+++ b/airgun/entities/all_hosts.py
@@ -59,7 +59,7 @@ class AllHostsEntity(BaseEntity):
     def delete(self, host_name):
         """Delete host through table dropdown"""
         view = self.all_hosts_navigate_and_select_hosts_helper(host_names=host_name)
-        view.table[0][2].widget.item_select('Delete')
+        view.get_row_kebab(0).item_select('Delete')
         delete_modal = HostDeleteDialog(self.browser)
         if delete_modal.is_displayed:
             delete_modal.confirm_delete.click()

--- a/airgun/views/all_hosts.py
+++ b/airgun/views/all_hosts.py
@@ -34,7 +34,7 @@ from airgun.views.common import (
     SearchableViewMixinPF4,
     WizardStepView,
 )
-from airgun.views.host_new import ManageColumnsView, MenuToggleButtonMenu, PF5CheckboxTreeView
+from airgun.views.host_new import ManageColumnsView, PF5CheckboxTreeView
 from airgun.widgets import ItemsList, PF5NavSearchMenu, SearchInput
 
 
@@ -119,12 +119,29 @@ class AllHostsTableView(BaseLoggedInView, SearchableViewMixinPF4):
             'Name': Text(
                 './/a[contains(@href, "/new/hosts/") and not(contains(@href, "Red Hat Lightspeed"))]'
             ),
-            2: MenuToggleDropdownInTable(),
-            6: MenuToggleButtonMenu(),
         },
     )
     autocomplete_menu = PF5NavSearchMenu(component_id='search-autocomplete-menu')
     alert_message = Text('.//div[contains(@class, "pf-v5-c-alert")]')
+
+    def get_row_kebab(self, row_index):
+        """Get kebab menu widget for a specific row.
+
+        The kebab menu is always in the last column, but its position
+        varies based on which columns are visible via 'Manage columns'.
+
+        Args:
+            row_index: Index of the row in the table
+
+        Returns:
+            MenuToggleDropdownInTable widget for the specified row
+        """
+        row = self.table[row_index]
+        # Create a widget that finds the kebab in the last td of the row
+        # Using a custom locator that always targets the last column
+        return MenuToggleDropdownInTable(
+            parent=row, locator='.//td[last()]//button[contains(@class, "pf-v5-c-menu-toggle")]/..'
+        )
 
     # Host status icon and popover widgets
     status_icon = Text('.//svg[contains(@style, "fill:")]')


### PR DESCRIPTION
Remove hardcoded kebab menu index from AllHostsTableView.
Instead, entities that want to access all hosts table row kebab will use `get_row_kebab` helper.

PRT runs in https://github.com/SatelliteQE/robottelo/pull/22453