### PR TITLE
Use OUIAIDs for IOP tables

### DIFF
--- a/airgun/views/cloud_vulnerabilities.py
+++ b/airgun/views/cloud_vulnerabilities.py
@@ -1,12 +1,12 @@
 from widgetastic.widget import Checkbox, Select, Text, TextInput, Widget
 from widgetastic_patternfly5 import (
     Button as PF5Button,
-    Dropdown as PF5OUIADropdown,
-    ExpandableTable as PF5OUIAExpandableTable,
+    Dropdown as PF5Dropdown,
+    ExpandableTable as PF5ExpandableTable,
     FormSelect as PF5FormSelect,
     Modal as PF5Modal,
     Pagination as PF5Pagination,
-    PatternflyTable as PF5OUIAPatternflyTable,
+    PatternflyTable as PF5PatternflyTable,
 )
 
 from airgun.views.common import BaseLoggedInView
@@ -167,8 +167,8 @@ class CloudVulnerabilityView(BaseLoggedInView):
     edit_business_risk_modal = EditBusinessRiskModal()
     edit_status_modal = EditStatusModal()
 
-    vulnerabilities_table = PF5OUIAExpandableTable(
-        component_id='cves-table',
+    vulnerabilities_table = PF5ExpandableTable(
+        locator='.//table[contains(@data-ouia-component-id, "cves-table")]',
         column_widgets={
             0: Checkbox(locator='.//label/input[@type="checkbox"]'),
             1: PF5Button(locator='.//button[@aria-label="Details"]'),
@@ -220,11 +220,11 @@ class CVEDetailsView(BaseLoggedInView):
     edit_business_risk_modal = EditBusinessRiskModal()
     edit_status_modal = EditStatusModal()
 
-    actions = PF5OUIADropdown(
+    actions = PF5Dropdown(
         locator='.//div[./button[contains(@class, "pf-v5-c-menu-toggle") and contains(., "Actions")]]'
     )
-    affected_hosts_table = PF5OUIAPatternflyTable(
-        component_id='systems-table',
+    affected_hosts_table = PF5PatternflyTable(
+        locator='.//table[contains(@data-ouia-component-id, "systems-table")]',
         column_widgets={
             'Name': Text('./a'),
             'OS': Text('.//td[contains(@data-label, "OS")]'),

--- a/airgun/views/cloud_vulnerabilities.py
+++ b/airgun/views/cloud_vulnerabilities.py
@@ -2,11 +2,12 @@ from widgetastic.widget import Checkbox, Select, Text, TextInput, Widget
 from widgetastic_patternfly5 import (
     Button as PF5Button,
     Dropdown as PF5Dropdown,
-    ExpandableTable as PF5ExpandableTable,
     FormSelect as PF5FormSelect,
     Modal as PF5Modal,
     Pagination as PF5Pagination,
-    PatternflyTable as PF5PatternflyTable,
+)
+from widgetastic_patternfly5.ouia import (
+    ExpandableTable as PF5OUIAExpandableTable,
 )
 
 from airgun.views.common import BaseLoggedInView
@@ -167,8 +168,8 @@ class CloudVulnerabilityView(BaseLoggedInView):
     edit_business_risk_modal = EditBusinessRiskModal()
     edit_status_modal = EditStatusModal()
 
-    vulnerabilities_table = PF5ExpandableTable(
-        locator='.//table[contains(@data-ouia-component-id, "cves-table")]',
+    vulnerabilities_table = PF5OUIAExpandableTable(
+        component_id='cves-table',
         column_widgets={
             0: Checkbox(locator='.//label/input[@type="checkbox"]'),
             1: PF5Button(locator='.//button[@aria-label="Details"]'),
@@ -223,8 +224,8 @@ class CVEDetailsView(BaseLoggedInView):
     actions = PF5Dropdown(
         locator='.//div[./button[contains(@class, "pf-v5-c-menu-toggle") and contains(., "Actions")]]'
     )
-    affected_hosts_table = PF5PatternflyTable(
-        locator='.//table[contains(@data-ouia-component-id, "systems-table")]',
+    affected_hosts_table = PF5OUIAExpandableTable(
+        component_id='systems-table',
         column_widgets={
             'Name': Text('./a'),
             'OS': Text('.//td[contains(@data-label, "OS")]'),

--- a/airgun/views/cloud_vulnerabilities.py
+++ b/airgun/views/cloud_vulnerabilities.py
@@ -168,8 +168,7 @@ class CloudVulnerabilityView(BaseLoggedInView):
     edit_status_modal = EditStatusModal()
 
     vulnerabilities_table = PF5OUIAExpandableTable(
-        # component_id='OUIA-Generated-Table-1',
-        locator='.//table[contains(@class, "pf-v5-c-table")]',
+        component_id='cves-table',
         column_widgets={
             0: Checkbox(locator='.//label/input[@type="checkbox"]'),
             1: PF5Button(locator='.//button[@aria-label="Details"]'),
@@ -225,8 +224,7 @@ class CVEDetailsView(BaseLoggedInView):
         locator='.//div[./button[contains(@class, "pf-v5-c-menu-toggle") and contains(., "Actions")]]'
     )
     affected_hosts_table = PF5OUIAPatternflyTable(
-        # component_id='OUIA-Generated-Table-1',
-        locator='.//table[contains(@class, "pf-v5-c-table")]',
+        component_id='systems-table',
         column_widgets={
             'Name': Text('./a'),
             'OS': Text('.//td[contains(@data-label, "OS")]'),

--- a/airgun/views/host_new.py
+++ b/airgun/views/host_new.py
@@ -30,7 +30,6 @@ from widgetastic_patternfly5 import (
     CompactPagination as PF5Pagination,
     Dropdown as PF5Dropdown,
     DualListSelector as PF5DualListSelector,
-    ExpandableTable as PF5ExpandableTable,
     Menu as PF5Menu,
     Modal as PF5Modal,
     Tab as PF5Tab,
@@ -974,8 +973,8 @@ class NewHostDetailsView(BaseLoggedInView):
         cve_menu_toggle = PF5Button(".//button[contains(@class, 'pf-v5-c-menu-toggle')]")
         no_cves_found_message = Text('.//h5[contains(@class, "pf-v5-c-empty-state__title-text")]')
 
-        vulnerabilities_table = PF5ExpandableTable(
-            locator='.//table[contains(@data-ouia-component-id, "cves-table")]',
+        vulnerabilities_table = PF5OUIAExpandableTable(
+            component_id='cves-table',
             column_widgets={
                 0: PF5Button(locator='.//button[@aria-label="Details"]'),
                 'CVE ID': Text('.//td[contains(@data-label, "CVE ID")]'),

--- a/airgun/views/host_new.py
+++ b/airgun/views/host_new.py
@@ -975,8 +975,7 @@ class NewHostDetailsView(BaseLoggedInView):
         no_cves_found_message = Text('.//h5[contains(@class, "pf-v5-c-empty-state__title-text")]')
 
         vulnerabilities_table = PF5ExpandableTable(
-            # component_id='OUIA-Generated-Table-2',
-            locator='.//table[contains(@class, "pf-v5-c-table")]',
+            component_id='cves-table',
             column_widgets={
                 0: PF5Button(locator='.//button[@aria-label="Details"]'),
                 'CVE ID': Text('.//td[contains(@data-label, "CVE ID")]'),

--- a/airgun/views/host_new.py
+++ b/airgun/views/host_new.py
@@ -975,7 +975,7 @@ class NewHostDetailsView(BaseLoggedInView):
         no_cves_found_message = Text('.//h5[contains(@class, "pf-v5-c-empty-state__title-text")]')
 
         vulnerabilities_table = PF5ExpandableTable(
-            component_id='cves-table',
+            locator='.//table[contains(@data-ouia-component-id, "cves-table")]',
             column_widgets={
                 0: PF5Button(locator='.//button[@aria-label="Details"]'),
                 'CVE ID': Text('.//td[contains(@data-label, "CVE ID")]'),


### PR DESCRIPTION
This PR completes [SAT-48610](https://redhat.atlassian.net/browse/SAT-48610) (Update test locators to use the ouia-ids of the new CVE table)