### PR TITLE
Make sure OUIA components are imported with OUIA prefix

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -171,7 +171,10 @@ from datetime import datetime
 
 # Third-party
 from widgetastic.widget import Text, TextInput, View
-from widgetastic_patternfly5 import PF5Button, PF5Table
+from widgetastic_patternfly5 import (
+    Button as PF5Button
+    Table as PF5Table
+    )
 
 # Airgun
 from airgun.entities.base import BaseEntity

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -171,7 +171,7 @@ from datetime import datetime
 
 # Third-party
 from widgetastic.widget import Text, TextInput, View
-from widgetastic_patternfly5 import Button, Table
+from widgetastic_patternfly5 import PF5Button, PF5Table
 
 # Airgun
 from airgun.entities.base import BaseEntity

--- a/airgun/views/acs.py
+++ b/airgun/views/acs.py
@@ -9,12 +9,12 @@ from widgetastic_patternfly5 import (
     Switch,
 )
 from widgetastic_patternfly5.ouia import (
-    Button as OUIAButton,
-    FormSelect as OUIAFormSelect,
-    PatternflyTable,
-    Switch as OUIASwitch,
-    Text as OUIAText,
-    TextInput as OUIATextInput,
+    Button as PF5OUIAButton,
+    FormSelect as PF5OUIAFormSelect,
+    PatternflyTable as PF5OUIAPatternflyTable,
+    Switch as PF5OUIASwitch,
+    Text as PF5OUIAText,
+    TextInput as PF5OUIATextInput,
 )
 
 from airgun.views.common import BaseLoggedInView, WizardStepView
@@ -26,11 +26,11 @@ class EditDetailsModal(EditModal):
 
     ROOT = '//div[@data-ouia-component-id="acs-edit-details-modal"]'
 
-    name = OUIATextInput('acs-edit-name-field')
+    name = PF5OUIATextInput('acs-edit-name-field')
     description = TextInput(locator='.//textarea[@id="acs_description_field"]')
 
-    edit_button = OUIAButton('edit-acs-details-submit')
-    cancel_button = OUIAButton('edit-acs-details-cancel')
+    edit_button = PF5OUIAButton('edit-acs-details-submit')
+    cancel_button = PF5OUIAButton('edit-acs-details-cancel')
 
 
 class EditCapsulesModal(DualListSelector):
@@ -40,8 +40,8 @@ class EditCapsulesModal(DualListSelector):
 
     use_http_proxies = Switch(locator='.//label[@for="use-http-proxies-switch"]')
 
-    edit_button = OUIAButton('edit-acs-smart-proxies-submit')
-    cancel_button = OUIAButton('edit-acs-smart-proxies-cancel')
+    edit_button = PF5OUIAButton('edit-acs-smart-proxies-submit')
+    cancel_button = PF5OUIAButton('edit-acs-smart-proxies-cancel')
 
 
 class EditUrlAndSubpathsModal(EditModal):
@@ -49,13 +49,13 @@ class EditUrlAndSubpathsModal(EditModal):
 
     ROOT = '//div[@data-ouia-component-id="acs-edit-url-paths-modal"]'
 
-    base_url = OUIATextInput('acs-base-url-field')
+    base_url = PF5OUIATextInput('acs-base-url-field')
     url_err = Text('.//div[contains(@id, "acs_base_url-helper")]')
     subpaths = TextInput(locator='.//textarea[@id="acs_subpath_field"]')
     paths_err = Text('.//div[contains(@id, "acs_subpaths-helper")]')
 
-    edit_button = OUIAButton('edit-acs-url-submit')
-    cancel_button = OUIAButton('edit-acs-url-cancel')
+    edit_button = PF5OUIAButton('edit-acs-url-submit')
+    cancel_button = PF5OUIAButton('edit-acs-url-cancel')
 
 
 class EditCredentialsModal(EditModal):
@@ -64,20 +64,20 @@ class EditCredentialsModal(EditModal):
     ROOT = '//div[@data-ouia-component-id="acs-edit-credentials-modal"]'
 
     verify_ssl_toggle = Switch(locator='.//label[@for="verify-ssl-switch"]')
-    select_ca_cert = OUIAFormSelect('sslCAcert-select')
+    select_ca_cert = PF5OUIAFormSelect('sslCAcert-select')
 
     manual_auth_radio_btn = Radio(id='manual_auth')
-    username = OUIATextInput('acs-username-field')
-    password = OUIATextInput('acs-password-field')
+    username = PF5OUIATextInput('acs-username-field')
+    password = PF5OUIATextInput('acs-password-field')
 
     content_credentials_radio_btn = Radio(id='content_credentials')
-    ssl_client_cert = OUIAFormSelect('ssl-client-cert-select')
-    ssl_client_key = OUIAFormSelect('ssl_client_key_select')
+    ssl_client_cert = PF5OUIAFormSelect('ssl-client-cert-select')
+    ssl_client_key = PF5OUIAFormSelect('ssl_client_key_select')
 
     none_auth_radio_btn = Radio(id='none')
 
-    edit_button = OUIAButton('edit-acs-credentials-submit')
-    cancel_button = OUIAButton('edit-acs-credentials-cancel')
+    edit_button = PF5OUIAButton('edit-acs-credentials-submit')
+    cancel_button = PF5OUIAButton('edit-acs-credentials-cancel')
 
 
 class EditProductsModal(DualListSelector):
@@ -85,8 +85,8 @@ class EditProductsModal(DualListSelector):
 
     ROOT = '//div[@data-ouia-component-id="acs-edit-products-modal"]'
 
-    edit_button = OUIAButton('edit-acs-products-submit')
-    cancel_button = OUIAButton('edit-acs-products-cancel')
+    edit_button = PF5OUIAButton('edit-acs-products-submit')
+    cancel_button = PF5OUIAButton('edit-acs-products-cancel')
 
 
 class AddAlternateContentSourceModal(View):
@@ -112,7 +112,7 @@ class AddAlternateContentSourceModal(View):
 
     ROOT = '//div[contains(@data-ouia-component-id, "OUIA-Generated-Modal-large-")]'
 
-    title = OUIAText('wizard-header-text')
+    title = PF5OUIAText('wizard-header-text')
     close_modal = Button(locator='.//button[@aria-label="Close"]')
 
     @View.nested
@@ -121,12 +121,12 @@ class AddAlternateContentSourceModal(View):
         custom_option = Text('//*[@id="custom"]')
         simplified_option = Text('//*[@id="simplified"]')
         rhui_option = Text('//*[@id="rhui"]')
-        content_type_select = OUIAFormSelect('content-type-select')
+        content_type_select = PF5OUIAFormSelect('content-type-select')
 
     @View.nested
     class name_source(WizardStepView):
         expander = Text('.//button[contains(.,"Name source")]')
-        name = OUIATextInput('acs_name_field')
+        name = PF5OUIATextInput('acs_name_field')
         description = TextInput(locator='.//textarea[@id="acs_description_field"]')
 
     @View.nested
@@ -134,12 +134,12 @@ class AddAlternateContentSourceModal(View):
         expander = Text(
             './/button[contains(.,"Select Smart proxy") or contains(.,"Select Capsule")]'
         )
-        use_http_proxies = OUIASwitch('use-http-proxies-switch')
+        use_http_proxies = PF5OUIASwitch('use-http-proxies-switch')
 
     @View.nested
     class url_and_paths(WizardStepView):
         expander = Text('.//button[contains(.,"URL and paths")]')
-        base_url = OUIATextInput('acs_base_url_field')
+        base_url = PF5OUIATextInput('acs_base_url_field')
         url_err = Text('.//div[contains(@id, "acs_base_url-helper")]')
         subpaths = TextInput(locator='.//textarea[@id="acs_subpath_field"]')
         paths_err = Text('.//div[contains(@id, "acs_subpaths-helper")]')
@@ -147,16 +147,16 @@ class AddAlternateContentSourceModal(View):
     @View.nested
     class credentials(WizardStepView):
         expander = Text('.//button[contains(.,"Credentials")]')
-        verify_ssl_toggle = OUIASwitch('verify-ssl-switch')
+        verify_ssl_toggle = PF5OUIASwitch('verify-ssl-switch')
         select_ca_cert = FormSelect(locator='.//select[option[text()="Select a CA certificate"]]')
 
         manual_auth_radio_btn = Radio(id='manual_auth')
-        username = OUIATextInput('acs_username_field')
-        password = OUIATextInput('acs_password_field')
+        username = PF5OUIATextInput('acs_username_field')
+        password = PF5OUIATextInput('acs_password_field')
 
         content_credentials_radio_btn = Radio(id='content_credentials')
-        ssl_client_cert = OUIAFormSelect('sslCert-select')
-        ssl_client_key = OUIAFormSelect('sslKey-select')
+        ssl_client_cert = PF5OUIAFormSelect('sslCert-select')
+        ssl_client_key = PF5OUIAFormSelect('sslKey-select')
 
         none_auth_radio_btn = Radio(id='none')
 
@@ -206,8 +206,8 @@ class RowDrawer(View):
 
     """
 
-    title = OUIAText('acs-name-text')
-    refresh_resource = OUIAButton('refresh-acs')
+    title = PF5OUIAText('acs-name-text')
+    refresh_resource = PF5OUIAButton('refresh-acs')
     kebab_menu = Dropdown(locator='//button[contains(@aria-label, "details_actions")]')
     last_refresh = Text('//dd[contains(@aria-label, "last_refresh_text_value")]')
 
@@ -219,7 +219,7 @@ class RowDrawer(View):
             '//div[normalize-space(.)="Details" and contains(@class, "pf-v5-c-expandable-section")]'
         )
 
-        title = OUIAText('expandable-details-text')
+        title = PF5OUIAText('expandable-details-text')
         edit_details = Button(locator='//button[contains(@aria-label, "edit-details-pencil-edit")]')
 
         @View.nested
@@ -241,7 +241,7 @@ class RowDrawer(View):
             '//div[(normalize-space(.)="Capsules")'
             ' and contains(@class, "pf-v5-c-expandable-section")]'
         )
-        title = OUIAText('expandable-smart-proxies-text')
+        title = PF5OUIAText('expandable-smart-proxies-text')
         edit_capsules = Button(
             locator='//button[contains(@aria-label, "edit-smart-proxies-pencil-edit")]'
         )
@@ -267,7 +267,7 @@ class RowDrawer(View):
             'and contains(@class, "pf-v5-c-expandable-section")]'
         )
 
-        title = OUIAText('expandable-url-paths-text')
+        title = PF5OUIAText('expandable-url-paths-text')
         edit_url_and_subpaths = Button(
             locator='//button[contains(@aria-label, "edit-urls-pencil-edit")]'
         )
@@ -293,7 +293,7 @@ class RowDrawer(View):
             'and contains(@class, "pf-v5-c-expandable-section")]'
         )
 
-        title = OUIAText('expandable-credentials-text')
+        title = PF5OUIAText('expandable-credentials-text')
         edit_credentials = Button(
             locator='//button[contains(@aria-label, "edit-credentials-pencil-edit")]'
         )
@@ -320,7 +320,7 @@ class RowDrawer(View):
 
         ROOT = '//div[normalize-space(.)="Products" and contains(@class, "pf-v5-c-expandable-section")]'
 
-        title = OUIAText('expandable-products-text')
+        title = PF5OUIAText('expandable-products-text')
         edit_products = Button(
             locator='//button[contains(@aria-label, "edit-products-pencil-edit")]'
         )
@@ -348,12 +348,12 @@ class AlternateContentSourcesView(BaseLoggedInView):
         select_all = Checkbox(locator='//input[contains(@aria-label, "Select all")]')
         search_bar = SearchInput(locator='.//div[contains(@class, "pf-v5-c-input-group")]//input')
         clear_search_btn = Button(locator='//button[@aria-label="Reset search"]')
-        add_source = OUIAButton('create-acs')
+        add_source = PF5OUIAButton('create-acs')
         kebab_menu = Dropdown(
             locator='.//div[contains(@data-ouia-component-id, "acs-bulk-actions")]'
         )
 
-        content_table = PatternflyTable(
+        content_table = PF5OUIAPatternflyTable(
             component_id='alternate-content-sources-table',
             column_widgets={
                 0: Checkbox(locator='.//input[@type="checkbox"]'),
@@ -364,7 +364,7 @@ class AlternateContentSourcesView(BaseLoggedInView):
             },
         )
 
-        clear_search = OUIAButton('empty-state-secondary-action-router-link')
+        clear_search = PF5OUIAButton('empty-state-secondary-action-router-link')
         pagination = PF5Pagination()
 
     @property

--- a/airgun/views/bootc.py
+++ b/airgun/views/bootc.py
@@ -1,5 +1,5 @@
 from widgetastic.widget import Table, Text, View
-from widgetastic_patternfly5.ouia import ExpandableTable
+from widgetastic_patternfly5.ouia import ExpandableTable as PF5OUIAExpandableTable
 
 from airgun.views.common import (
     BaseLoggedInView,
@@ -21,7 +21,7 @@ class BootedContainerImagesView(BaseLoggedInView, SearchableViewMixinPF4):
         )
 
     # Passing in the nested table as content_view, refer to ExpandableTable docs for info
-    table = ExpandableTable(
+    table = PF5OUIAExpandableTable(
         component_id='booted-containers-table',
         column_widgets={
             'Image Name': Text('./a'),

--- a/airgun/views/capsule.py
+++ b/airgun/views/capsule.py
@@ -19,7 +19,7 @@ from widgetastic_patternfly5 import (
     Pagination as PF5Pagination,
 )
 from widgetastic_patternfly5.ouia import (
-    ExpandableTable as PF5ExpandableTable,
+    ExpandableTable as PF5OUIAExpandableTable,
 )
 
 from airgun.views.common import (
@@ -179,7 +179,7 @@ class CapsuleDetailsView(BaseLoggedInView):
     class content(SatTab):
         TAB_NAME = 'Content'
 
-        top_content_table = PF5ExpandableTable(
+        top_content_table = PF5OUIAExpandableTable(
             component_id='capsule-content-table',
             column_widgets={
                 0: PF5Button(locator='./button[@aria-label="Details"]'),
@@ -189,7 +189,7 @@ class CapsuleDetailsView(BaseLoggedInView):
             },
         )
 
-        mid_content_table = PF5ExpandableTable(
+        mid_content_table = PF5OUIAExpandableTable(
             component_id='expandable-content-views',
             column_widgets={
                 0: Button(locator='./button[@aria-label="Details"]'),

--- a/airgun/views/common.py
+++ b/airgun/views/common.py
@@ -16,7 +16,7 @@ from widgetastic_patternfly4.navigation import Navigation
 from widgetastic_patternfly5 import Dropdown as PF5Dropdown
 from widgetastic_patternfly5.ouia import (
     Dropdown as PF5OUIADropdown,
-    PatternflyTable,
+    PatternflyTable as PF5OUIAPatternflyTable,
     Select as PF5OUIASelect,
 )
 
@@ -481,7 +481,7 @@ class NewAddRemoveResourcesView(View):
     status = PF5OUIASelect(component_id='select Status')
     remove_button = PF5OUIADropdown(component_id='repositoies-bulk-actions')
     add_button = Button(locator='.//button[@data-ouia-component-id="add-repositories"]')
-    table = PatternflyTable(
+    table = PF5OUIAPatternflyTable(
         component_id='content-view-repositories-table',
         column_widgets={
             0: Checkbox(locator='.//input[@type="checkbox"]'),

--- a/airgun/views/contentview_new.py
+++ b/airgun/views/contentview_new.py
@@ -4,15 +4,15 @@ from widgetastic.widget import Checkbox, ParametrizedView, Text, TextInput, View
 from widgetastic_patternfly import BreadCrumb, Tab
 from widgetastic_patternfly5 import Alert as PF5Alert, Button, Modal, Radio as PF5Radio
 from widgetastic_patternfly5.ouia import (
-    Button as PF5Button,
-    Dropdown as PF5Dropdown,
-    ExpandableTable,
-    Modal as PF5Modal,
-    PatternflyTable,
-    Select as PF5Select,
-    Switch,
-    Text as PF5Text,
-    TextInput as PF5TextInput,
+    Button as PF5OUIAButton,
+    Dropdown as PF5OUIADropdown,
+    ExpandableTable as PF5OUIAExpandableTable,
+    Modal as PF5OUIAModal,
+    PatternflyTable as PF5OUIAPatternflyTable,
+    Select as PF5OUIASelect,
+    Switch as PF5OUIASwitch,
+    Text as PF5OUIAText,
+    TextInput as PF5OUIATextInput,
 )
 
 from airgun.views.common import (
@@ -34,9 +34,9 @@ LOCATION_NUM = 3
 
 
 class ContentViewAddResourcesView(NewAddRemoveResourcesView):
-    remove_button = PF5Dropdown('cv-components-bulk-actions')
-    add_button = PF5Button(component_id='add-content-views')
-    table = PatternflyTable(
+    remove_button = PF5OUIADropdown('cv-components-bulk-actions')
+    add_button = PF5OUIAButton(component_id='add-content-views')
+    table = PF5OUIAPatternflyTable(
         component_id='content-view-components-table',
         column_widgets={
             0: Checkbox(locator='.//input[@type="checkbox"]'),
@@ -58,10 +58,10 @@ class ContentViewAddResourcesView(NewAddRemoveResourcesView):
 
 class AddContentViewModal(BaseLoggedInView):
     title = Text('.//div[@data-ouia-component-id="add-content-views"]')
-    submit_button = PF5Button(component_id='add-components-modal-add')
-    cancel_button = PF5Button(component_id='add-components-modal-cancel')
+    submit_button = PF5OUIAButton(component_id='add-components-modal-add')
+    cancel_button = PF5OUIAButton(component_id='add-components-modal-cancel')
 
-    version_select = PF5Select(component_id='select-version')
+    version_select = PF5OUIASelect(component_id='select-version')
     always_update = Checkbox(locator='.//input[contains(@data-ouia-component-id, "latest-")]')
 
     @property
@@ -70,9 +70,9 @@ class AddContentViewModal(BaseLoggedInView):
 
 
 class ContentViewTableView(BaseLoggedInView, SearchableViewMixinPF4):
-    title = PF5Text(component_id='cvPageHeaderText')
-    create_content_view = PF5Button(component_id='create-content-view')
-    table = ExpandableTable(
+    title = PF5OUIAText(component_id='cvPageHeaderText')
+    create_content_view = PF5OUIAButton(component_id='create-content-view')
+    table = PF5OUIAExpandableTable(
         component_id='content-views-table',
         column_widgets={
             'Type': Text('./a'),
@@ -90,12 +90,12 @@ class ContentViewTableView(BaseLoggedInView, SearchableViewMixinPF4):
 
 
 class ContentViewCreateView(BaseLoggedInView):
-    title = PF5Modal(component_id='create-content-view-modal')
-    name = PF5TextInput(component_id='input_name')
-    label = PF5TextInput(component_id='input_label')
+    title = PF5OUIAModal(component_id='create-content-view-modal')
+    name = PF5OUIATextInput(component_id='input_name')
+    label = PF5OUIATextInput(component_id='input_label')
     description = TextInput(id='description')
-    submit = PF5Button(component_id='create-content-view-form-submit')
-    cancel = PF5Button(component_id='create-content-view-form-cancel')
+    submit = PF5OUIAButton(component_id='create-content-view-form-submit')
+    cancel = PF5OUIAButton(component_id='create-content-view-form-cancel')
 
     component_tile = Text('//div[contains(@id, "component")]')
     solve_dependencies = Checkbox(id='dependencies')
@@ -117,8 +117,8 @@ class ContentViewEditView(BaseLoggedInView):
     breadcrumb = BreadCrumb('breadcrumbs-list')
     search = PF4Search()
     dialog = ConfirmationDialog()
-    publish = PF5Button(component_id='cv-details-publish-button')
-    cv_actions = PF5Dropdown('cv-details-actions')
+    publish = PF5OUIAButton(component_id='cv-details-publish-button')
+    cv_actions = PF5OUIADropdown('cv-details-actions')
 
     # buttons for wizard: deleting a CV with Version promoted to environment(s)
     next_button = Button('Next')
@@ -142,8 +142,8 @@ class ContentViewEditView(BaseLoggedInView):
         type = ReadOnlyEntry(name='Composite?')
         description = EditableEntry(name='Description')
         # depSolv is maybe a conditionalswitch
-        solve_dependencies = Switch(name='solve_dependencies switch')
-        import_only = Switch(name='import_only_switch')
+        solve_dependencies = PF5OUIASwitch(name='solve_dependencies switch')
+        import_only = PF5OUIASwitch(name='import_only_switch')
 
     @View.nested
     class versions(Tab):
@@ -151,7 +151,7 @@ class ContentViewEditView(BaseLoggedInView):
             '//button[@data-ouia-component-id="routed-tabs-tab-versions"]'
         )
         searchbox = PF4Search()
-        table = PatternflyTable(
+        table = PF5OUIAPatternflyTable(
             component_id='content-view-versions-table',
             column_widgets={
                 0: Checkbox(locator='.//input[@type="checkbox"]'),
@@ -164,7 +164,7 @@ class ContentViewEditView(BaseLoggedInView):
                 7: TableRowKebabMenu(),
             },
         )
-        publishButton = PF5Button(component_id='cv-details-publish-button')
+        publishButton = PF5OUIAButton(component_id='cv-details-publish-button')
 
         def search(self, version_name):
             """Searches for content view version.
@@ -198,9 +198,9 @@ class ContentViewEditView(BaseLoggedInView):
         TAB_LOCATOR = ParametrizedLocator(
             '//button[@data-ouia-component-id="routed-tabs-tab-filters"]'
         )
-        new_filter = PF5Button(component_id='create-filter-button')
+        new_filter = PF5OUIAButton(component_id='create-filter-button')
         searchbox = PF4Search()
-        table = PatternflyTable(
+        table = PF5OUIAPatternflyTable(
             component_id='content-view-filters-table',
             column_widgets={
                 0: Checkbox(locator='.//input[@type="checkbox"]'),
@@ -229,7 +229,7 @@ class ContentViewVersionPublishView(BaseLoggedInView):
     )
     # publishing screen
     description = TextInput(id='description')
-    promote = Switch('promote-switch')
+    promote = PF5OUIASwitch('promote-switch')
 
     next_button = Button('Next')
     finish_button = Button('Finish')
@@ -277,9 +277,9 @@ class ContentViewVersionPromoteView(Modal):
 class ContentViewVersionDetailsView(BaseLoggedInView):
     breadcrumb = BreadCrumb()
     version = Text(locator='.//h2[@data-ouia-component-id="cv-version"]')
-    version_dropdown = PF5Dropdown('cv-version-header-actions-dropdown')
-    promoteButton = PF5Button(component_id='cv-details-publish-button')
-    editDescription = PF5Button(component_id='edit-button-description')
+    version_dropdown = PF5OUIADropdown('cv-version-header-actions-dropdown')
+    promoteButton = PF5OUIAButton(component_id='cv-details-publish-button')
+    editDescription = PF5OUIAButton(component_id='edit-button-description')
     # buttons for wizard: deleting a version promoted to environment(s)
     next_button = Button('Next')
     delete_finish = Button('Delete')
@@ -294,7 +294,7 @@ class ContentViewVersionDetailsView(BaseLoggedInView):
             './/button[@data-ouia-component-id="cv-version-details-tabs-tab-repositories"]'
         )
         searchbox = PF4Search()
-        table = PatternflyTable(
+        table = PF5OUIAPatternflyTable(
             component_id='content-view-version-details-repositories-table',
             column_widgets={
                 'Name': Text('.//a'),
@@ -310,7 +310,7 @@ class ContentViewVersionDetailsView(BaseLoggedInView):
             './/button[@data-ouia-component-id="cv-version-details-tabs-tab-rpmPackages"]'
         )
         searchbox = PF4Search()
-        table = PatternflyTable(
+        table = PF5OUIAPatternflyTable(
             component_id='content-view-version-details-rpm-packages-table',
             column_widgets={
                 'Name': Text('.//a'),
@@ -327,7 +327,7 @@ class ContentViewVersionDetailsView(BaseLoggedInView):
             './/button[@data-ouia-component-id="cv-version-details-tabs-tab-rpmPackageGroups"]'
         )
         searchbox = PF4Search()
-        table = PatternflyTable(
+        table = PF5OUIAPatternflyTable(
             component_id='content-view-version-details-rpm-package-groups-table',
             column_widgets={
                 'Name': Text('.//a'),
@@ -341,7 +341,7 @@ class ContentViewVersionDetailsView(BaseLoggedInView):
             './/button[@data-ouia-component-id="cv-version-details-tabs-tab-errata"]'
         )
         searchbox = PF4Search()
-        table = PatternflyTable(
+        table = PF5OUIAPatternflyTable(
             component_id='content-view-version-details-errata-table',
             column_widgets={
                 'Errata ID': Text('.//a'),
@@ -370,29 +370,29 @@ class CreateFilterView(View):
     ROOT = './/div[@data-ouia-component-id="create-filter-modal"]'
 
     name = TextInput(id='name')
-    filterType = PF5Select(component_id='content_type')
+    filterType = PF5OUIASelect(component_id='content_type')
     includeFilter = PF5Radio(label_text='Include filter')
     excludeFilter = PF5Radio(label_test='Exclude filter')
-    create = PF5Button(component_id='create-filter-form-submit-button')
-    cancel = PF5Button(component_id='create-filter-form-cancel-button')
+    create = PF5OUIAButton(component_id='create-filter-form-submit-button')
+    cancel = PF5OUIAButton(component_id='create-filter-form-cancel-button')
 
 
 class EditFilterView(View):
     name = Text('.//h2[@data-ouia-component-id="name-text-value"]')
-    editName = PF5Button(component_id='edit-button-name')
+    editName = PF5OUIAButton(component_id='edit-button-name')
     nameInput = TextInput('name text input')
-    submitName = PF5Button(component_id='submit-button-name')
-    clearName = PF5Button(component_id='clear-button-name')
+    submitName = PF5OUIAButton(component_id='submit-button-name')
+    clearName = PF5OUIAButton(component_id='clear-button-name')
     description = Text('.//h2[@data-ouia-component-id="description-text-value"]')
-    editDescription = PF5Button(component_id='edit-button-description')
+    editDescription = PF5OUIAButton(component_id='edit-button-description')
     descriptionInput = TextInput(locator='.//textarea[@aria-label="description text area"]')
 
     # Below this, the fields are generally not shared by each Filter Type
 
     # RPM Rule
     search = PF4Search()
-    addRpmRule = PF5Button(component_id='add-rpm-rule-button')
-    rpmRuleTable = PatternflyTable(
+    addRpmRule = PF5OUIAButton(component_id='add-rpm-rule-button')
+    rpmRuleTable = PF5OUIAPatternflyTable(
         component_id='content-view-rpm-filter-table',
         column_widgets={
             0: Checkbox(locator='.//input[@type="checkbox"]'),
@@ -404,8 +404,8 @@ class EditFilterView(View):
     )
 
     # Container Image Tag Rule
-    addTagRule = PF5Button(component_id='add-content-view-container-image-filter-button')
-    tagRuleTable = PatternflyTable(
+    addTagRule = PF5OUIAButton(component_id='add-content-view-container-image-filter-button')
+    tagRuleTable = PF5OUIAPatternflyTable(
         component_id='content-view-container-image-filter',
         column_widgets={
             0: Checkbox(locator='.//input[@type="checkbox"]'),
@@ -415,9 +415,9 @@ class EditFilterView(View):
     )
 
     # Package Group Rule
-    addPackageGroupRule = PF5Button(component_id='add-package-group-filter-rule-button')
-    removePackageGroupRule = PF5Dropdown('cv-package-group-filter-bulk-actions-dropdown')
-    packageGroupRuleTable = PatternflyTable(
+    addPackageGroupRule = PF5OUIAButton(component_id='add-package-group-filter-rule-button')
+    removePackageGroupRule = PF5OUIADropdown('cv-package-group-filter-bulk-actions-dropdown')
+    packageGroupRuleTable = PF5OUIAPatternflyTable(
         component_id='content-view-package-group-filter-table',
         column_widgets={
             0: Checkbox(locator='.//input[@type="checkbox"]'),
@@ -431,9 +431,9 @@ class EditFilterView(View):
     )
 
     # Module Streams Rule
-    addModuleStreamRule = PF5Button(component_id='add-module-stream-rule-button')
-    removeModuleStreamRule = PF5Dropdown('bulk-actions-dropdown')
-    moduleStreamRuleTable = PatternflyTable(
+    addModuleStreamRule = PF5OUIAButton(component_id='add-module-stream-rule-button')
+    removeModuleStreamRule = PF5OUIADropdown('bulk-actions-dropdown')
+    moduleStreamRuleTable = PF5OUIAPatternflyTable(
         component_id='content-view-module-stream-filter-table',
         column_widgets={
             0: Checkbox(locator='.//input[@type="checkbox"]'),
@@ -447,9 +447,9 @@ class EditFilterView(View):
     )
 
     # Errata Rule
-    addErrataRule = PF5Button(component_id='add-errata-id-button')
-    removeErratRule = PF5Dropdown('cv-errata-id-bulk-action-dropdown')
-    moduleErrataTable = PatternflyTable(
+    addErrataRule = PF5OUIAButton(component_id='add-errata-id-button')
+    removeErratRule = PF5OUIADropdown('cv-errata-id-bulk-action-dropdown')
+    moduleErrataTable = PF5OUIAPatternflyTable(
         component_id='content-view-errata-by-id-filter-table',
         column_widgets={
             0: Checkbox(locator='.//input[@type="checkbox"]'),
@@ -466,8 +466,8 @@ class EditFilterView(View):
 
     # Errata by Date Range
 
-    saveErrataByDate = PF5Button(component_id='save-filter-rule-button')
-    cancelErrataByDate = PF5Button(component_id='cancel-save-filter-rule-button')
+    saveErrataByDate = PF5OUIAButton(component_id='save-filter-rule-button')
+    cancelErrataByDate = PF5OUIAButton(component_id='cancel-save-filter-rule-button')
 
     @property
     def is_displayed(self):
@@ -484,9 +484,9 @@ class AddRPMRuleView(View):
         locator=".//div[contains(.//span, 'Architecture') and @class='pf-v5-c-form__group']/*//input"
     )
 
-    versions = PF5Select(component_id='version-comparator')
-    addEdit = PF5Button(component_id='add-edit-package-modal-submit')
-    cancel = PF5Button(component_id='add-edit-package-modal-cancel')
+    versions = PF5OUIASelect(component_id='version-comparator')
+    addEdit = PF5OUIAButton(component_id='add-edit-package-modal-submit')
+    cancel = PF5OUIAButton(component_id='add-edit-package-modal-cancel')
 
 
 class AddContainerTagRuleView(View):
@@ -496,5 +496,5 @@ class AddContainerTagRuleView(View):
         locator=".//div[contains(.//span, 'Tag name') and @class='pf-v5-c-form__group']/*//input"
     )
 
-    addEdit = PF5Button(component_id='add-edit-container-tag-filter-rule-submit')
-    cancel = PF5Button(component_id='add-edit-container-tag-filter-rule-cancel')
+    addEdit = PF5OUIAButton(component_id='add-edit-container-tag-filter-rule-submit')
+    cancel = PF5OUIAButton(component_id='add-edit-container-tag-filter-rule-cancel')

--- a/airgun/views/host_new.py
+++ b/airgun/views/host_new.py
@@ -36,7 +36,7 @@ from widgetastic_patternfly5 import (
 )
 from widgetastic_patternfly5.ouia import (
     Alert as PF5OUIAAlert,
-    BreadCrumb,
+    BreadCrumb as PF5OUIABreadCrumb,
     Button as PF5OUIAButton,
     Dropdown as PF5OUIADropdown,
     ExpandableTable as PF5OUIAExpandableTable,
@@ -315,7 +315,7 @@ class BreadcrumbSwitcher(Widget):
 
 
 class NewHostDetailsView(BaseLoggedInView):
-    breadcrumb = BreadCrumb('breadcrumbs-list')
+    breadcrumb = PF5OUIABreadCrumb('breadcrumbs-list')
     # Breadcrumb switcher for switching between hosts
     breadcrumb_switcher = BreadcrumbSwitcher()
 

--- a/airgun/views/oscapreport.py
+++ b/airgun/views/oscapreport.py
@@ -1,6 +1,6 @@
 from widgetastic.widget import Text, View
 from widgetastic_patternfly4 import Button
-from widgetastic_patternfly5.ouia import FormSelect as PF5FormSelect
+from widgetastic_patternfly5.ouia import FormSelect as PF5OUIAFormSelect
 
 from airgun.views.common import BaseLoggedInView, SearchableViewMixin, WizardStepView
 from airgun.widgets import (
@@ -70,7 +70,7 @@ class RemediateModal(View):
         expander = Text(
             './/button[contains(@class,"pf-v5-c-wizard__nav-link") and contains(.,"Select snippet")]'
         )
-        snippet = PF5FormSelect('snippet-select')
+        snippet = PF5OUIAFormSelect('snippet-select')
 
     @View.nested
     class name_source(WizardStepView):

--- a/airgun/widgets.py
+++ b/airgun/widgets.py
@@ -45,10 +45,10 @@ from widgetastic_patternfly5.components.table import (
     PatternflyTableRow,
 )
 from widgetastic_patternfly5.ouia import (
-    BaseSelect as PF5BaseSelect,
+    BaseSelect as PF5OUIABaseSelect,
     Button as PF5OUIAButton,
     Dropdown as PF5OUIADropdown,
-    Menu as PF5Menu,
+    Menu as PF5OUIAMenu,
     OUIAGenericWidget,
 )
 
@@ -997,7 +997,7 @@ class PF4Search(Search):
             self.search_button.click()
 
 
-class PF5NavSearchMenu(PF5Menu, OUIAGenericWidget):
+class PF5NavSearchMenu(PF5OUIAMenu, OUIAGenericWidget):
     """PF5 vertical navigation dropdown menu with search results."""
 
     @property
@@ -2918,7 +2918,7 @@ class Accordion(View, ClickableMixin):
         self.browser.click(self.ITEM.format(value))
 
 
-class BaseMultiSelect(PF5BaseSelect, PF5OUIADropdown):
+class BaseMultiSelect(PF5OUIABaseSelect, PF5OUIADropdown):
     """Represents the Patternfly Multi Select.
 
     https://www.patternfly.org/v4/documentation/react/components/select#multiple


### PR DESCRIPTION
## Problem
In some cases in Airgun, the custom of importing PF5 OUIA components with `PF5OUIA` was not honored and might cause confusion and inconsistencies.

## Solution
This PR fixes that, and now all the imported PF5 OUIA widgets have `PF5OUIA` prefix.
This change is just renaming so no test impact is expected.