### PR TITLE
[6.20.z] Add get_row_kebab_tom HostsView in hosts.py

### DIFF
--- a/airgun/entities/host.py
+++ b/airgun/entities/host.py
@@ -153,7 +153,7 @@ class HostEntity(BaseEntity):
         """Delete host from the system"""
         view = self.navigate_to(self, 'All')
         view.search(entity_name)
-        view.table.row(name=entity_name)[6].widget.item_select('Delete')
+        view.get_row_kebab(0).item_select('Delete')
         self.browser.handle_alert()
         self.browser.refresh()
         # Workaround for SAT-38950: Flash message may not appear properly
@@ -547,7 +547,7 @@ class EditHost(NavigateStep):
     def step(self, *args, **kwargs):
         entity_name = kwargs.get('entity_name')
         self.parent.search(entity_name)
-        self.parent.table.row(name=entity_name)[6].widget.item_select('Edit')
+        self.parent.get_row_kebab(0).item_select('Edit')
         self.view.wait_displayed()
 
 

--- a/airgun/views/host.py
+++ b/airgun/views/host.py
@@ -243,10 +243,28 @@ class HostsView(BaseLoggedInView, SearchableViewMixinPF4):
                 ".//a[contains(@href, '/new/hosts/') and not(contains(@href, 'Red Hat Lightspeed'))]"
             ),
             'Recommendations': Text('./a'),
-            6: MenuToggleButtonMenu(),
         },
     )
     displayed_table_headers = './/table/thead/tr/th[not(@hidden)]'
+
+    def get_row_kebab(self, row_index):
+        """Get kebab menu widget for a specific row.
+
+        The kebab menu is always in the last column, but its position
+        varies based on which columns are visible via 'Manage columns'.
+
+        Args:
+            row_index: Index of the row in the table
+
+        Returns:
+            MenuToggleButtonMenu widget for the specified row
+        """
+        row = self.table[row_index]
+        return MenuToggleButtonMenu(
+            parent=row,
+            locator='.//td[last()]//button[contains(@class, "pf-v5-c-menu-toggle")]/..',
+        )
+
     host_status = "//span[contains(@class, 'host-status')]"
     actions = PF5OUIADropdown(component_id='legacy-ui-kebab')
     dialog = Pf4ConfirmationDialog()


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/airgun/pull/2514

Similar PR as https://github.com/SatelliteQE/airgun/pull/2505

It adds `get_row_kebab` to the HostsView so that the entities that want to access all hosts table row kebab will use get_row_kebab helper.