### PR TITLE
Make sure PF5 components are imported with PF5 prefix

### DIFF
--- a/airgun/entities/all_hosts.py
+++ b/airgun/entities/all_hosts.py
@@ -3,7 +3,7 @@ import contextlib
 
 import anytree
 from widgetastic.exceptions import NoSuchElementException
-from widgetastic_patternfly5 import DropdownItemDisabled
+from widgetastic_patternfly5 import DropdownItemDisabled as PF5DropdownItemDisabled
 
 from airgun.entities.base import BaseEntity
 from airgun.navigation import NavigateStep, navigator
@@ -593,7 +593,7 @@ class AllHostsEntity(BaseEntity):
 
         # This step ensures deterministic state of the table
         # If 'Select none (0)' is disabled, it means nothing is selected, so we can continue
-        with contextlib.suppress(DropdownItemDisabled):
+        with contextlib.suppress(PF5DropdownItemDisabled):
             view.searchbar_dropdown.item_select('Select none (0)')
 
         if select_all_hosts:

--- a/airgun/views/acs.py
+++ b/airgun/views/acs.py
@@ -1,12 +1,12 @@
 from widgetastic.widget import Checkbox, Text, TextInput, View
 from widgetastic_patternfly5 import (
-    Button,
-    Drawer,
-    Dropdown,
-    FormSelect,
+    Button as PF5Button,
+    Drawer as PF5Drawer,
+    Dropdown as PF5Dropdown,
+    FormSelect as PF5FormSelect,
     Pagination as PF5Pagination,
-    Radio,
-    Switch,
+    Radio as PF5Radio,
+    Switch as PF5Switch,
 )
 from widgetastic_patternfly5.ouia import (
     Button as PF5OUIAButton,
@@ -38,7 +38,7 @@ class EditCapsulesModal(DualListSelector):
 
     ROOT = '//div[@data-ouia-component-id="acs-edit-smart-proxies-modal"]'
 
-    use_http_proxies = Switch(locator='.//label[@for="use-http-proxies-switch"]')
+    use_http_proxies = PF5Switch(locator='.//label[@for="use-http-proxies-switch"]')
 
     edit_button = PF5OUIAButton('edit-acs-smart-proxies-submit')
     cancel_button = PF5OUIAButton('edit-acs-smart-proxies-cancel')
@@ -63,18 +63,18 @@ class EditCredentialsModal(EditModal):
 
     ROOT = '//div[@data-ouia-component-id="acs-edit-credentials-modal"]'
 
-    verify_ssl_toggle = Switch(locator='.//label[@for="verify-ssl-switch"]')
+    verify_ssl_toggle = PF5Switch(locator='.//label[@for="verify-ssl-switch"]')
     select_ca_cert = PF5OUIAFormSelect('sslCAcert-select')
 
-    manual_auth_radio_btn = Radio(id='manual_auth')
+    manual_auth_radio_btn = PF5Radio(id='manual_auth')
     username = PF5OUIATextInput('acs-username-field')
     password = PF5OUIATextInput('acs-password-field')
 
-    content_credentials_radio_btn = Radio(id='content_credentials')
+    content_credentials_radio_btn = PF5Radio(id='content_credentials')
     ssl_client_cert = PF5OUIAFormSelect('ssl-client-cert-select')
     ssl_client_key = PF5OUIAFormSelect('ssl_client_key_select')
 
-    none_auth_radio_btn = Radio(id='none')
+    none_auth_radio_btn = PF5Radio(id='none')
 
     edit_button = PF5OUIAButton('edit-acs-credentials-submit')
     cancel_button = PF5OUIAButton('edit-acs-credentials-cancel')
@@ -113,7 +113,7 @@ class AddAlternateContentSourceModal(View):
     ROOT = '//div[contains(@data-ouia-component-id, "OUIA-Generated-Modal-large-")]'
 
     title = PF5OUIAText('wizard-header-text')
-    close_modal = Button(locator='.//button[@aria-label="Close"]')
+    close_modal = PF5Button(locator='.//button[@aria-label="Close"]')
 
     @View.nested
     class select_source_type(WizardStepView):
@@ -148,17 +148,19 @@ class AddAlternateContentSourceModal(View):
     class credentials(WizardStepView):
         expander = Text('.//button[contains(.,"Credentials")]')
         verify_ssl_toggle = PF5OUIASwitch('verify-ssl-switch')
-        select_ca_cert = FormSelect(locator='.//select[option[text()="Select a CA certificate"]]')
+        select_ca_cert = PF5FormSelect(
+            locator='.//select[option[text()="Select a CA certificate"]]'
+        )
 
-        manual_auth_radio_btn = Radio(id='manual_auth')
+        manual_auth_radio_btn = PF5Radio(id='manual_auth')
         username = PF5OUIATextInput('acs_username_field')
         password = PF5OUIATextInput('acs_password_field')
 
-        content_credentials_radio_btn = Radio(id='content_credentials')
+        content_credentials_radio_btn = PF5Radio(id='content_credentials')
         ssl_client_cert = PF5OUIAFormSelect('sslCert-select')
         ssl_client_key = PF5OUIAFormSelect('sslKey-select')
 
-        none_auth_radio_btn = Radio(id='none')
+        none_auth_radio_btn = PF5Radio(id='none')
 
     @View.nested
     class select_products(WizardStepView, DualListSelector):
@@ -167,8 +169,8 @@ class AddAlternateContentSourceModal(View):
     @View.nested
     class review_details(WizardStepView):
         expander = Text('.//button[contains(.,"Review details")]')
-        add_button = Button(locator='.//button[normalize-space(.)="Add"]')
-        cancel_button = Button(locator='.//button[normalize-space(.)="Cancel"]')
+        add_button = PF5Button(locator='.//button[normalize-space(.)="Add"]')
+        cancel_button = PF5Button(locator='.//button[normalize-space(.)="Cancel"]')
 
 
 class AcsStackItem:
@@ -208,7 +210,7 @@ class RowDrawer(View):
 
     title = PF5OUIAText('acs-name-text')
     refresh_resource = PF5OUIAButton('refresh-acs')
-    kebab_menu = Dropdown(locator='//button[contains(@aria-label, "details_actions")]')
+    kebab_menu = PF5Dropdown(locator='//button[contains(@aria-label, "details_actions")]')
     last_refresh = Text('//dd[contains(@aria-label, "last_refresh_text_value")]')
 
     @View.nested
@@ -220,7 +222,9 @@ class RowDrawer(View):
         )
 
         title = PF5OUIAText('expandable-details-text')
-        edit_details = Button(locator='//button[contains(@aria-label, "edit-details-pencil-edit")]')
+        edit_details = PF5Button(
+            locator='//button[contains(@aria-label, "edit-details-pencil-edit")]'
+        )
 
         @View.nested
         class details_stack_content(View):
@@ -242,7 +246,7 @@ class RowDrawer(View):
             ' and contains(@class, "pf-v5-c-expandable-section")]'
         )
         title = PF5OUIAText('expandable-smart-proxies-text')
-        edit_capsules = Button(
+        edit_capsules = PF5Button(
             locator='//button[contains(@aria-label, "edit-smart-proxies-pencil-edit")]'
         )
 
@@ -268,7 +272,7 @@ class RowDrawer(View):
         )
 
         title = PF5OUIAText('expandable-url-paths-text')
-        edit_url_and_subpaths = Button(
+        edit_url_and_subpaths = PF5Button(
             locator='//button[contains(@aria-label, "edit-urls-pencil-edit")]'
         )
 
@@ -294,7 +298,7 @@ class RowDrawer(View):
         )
 
         title = PF5OUIAText('expandable-credentials-text')
-        edit_credentials = Button(
+        edit_credentials = PF5Button(
             locator='//button[contains(@aria-label, "edit-credentials-pencil-edit")]'
         )
 
@@ -321,7 +325,7 @@ class RowDrawer(View):
         ROOT = '//div[normalize-space(.)="Products" and contains(@class, "pf-v5-c-expandable-section")]'
 
         title = PF5OUIAText('expandable-products-text')
-        edit_products = Button(
+        edit_products = PF5Button(
             locator='//button[contains(@aria-label, "edit-products-pencil-edit")]'
         )
 
@@ -342,14 +346,14 @@ class AlternateContentSourcesView(BaseLoggedInView):
     blank_page = Text("//div[contains(@class, 'pf-v5-c-empty-state')]")
 
     @View.nested
-    class acs_drawer(Drawer):
+    class acs_drawer(PF5Drawer):
         """Class that describes drawer of the Alternate Content Sources page"""
 
         select_all = Checkbox(locator='//input[contains(@aria-label, "Select all")]')
         search_bar = SearchInput(locator='.//div[contains(@class, "pf-v5-c-input-group")]//input')
-        clear_search_btn = Button(locator='//button[@aria-label="Reset search"]')
+        clear_search_btn = PF5Button(locator='//button[@aria-label="Reset search"]')
         add_source = PF5OUIAButton('create-acs')
-        kebab_menu = Dropdown(
+        kebab_menu = PF5Dropdown(
             locator='.//div[contains(@data-ouia-component-id, "acs-bulk-actions")]'
         )
 
@@ -360,7 +364,7 @@ class AlternateContentSourcesView(BaseLoggedInView):
                 'Name': Text('.//a[contains(@data-ouia-component-id, "acs-link-text-")]'),
                 'Type': Text('.//td[3]'),
                 'LastRefresh': Text('.//td[4]'),
-                4: Dropdown(locator='.//div[contains(@class, "pf-v5-c-dropdown")]'),
+                4: PF5Dropdown(locator='.//div[contains(@class, "pf-v5-c-dropdown")]'),
             },
         )
 

--- a/airgun/views/ansible_role.py
+++ b/airgun/views/ansible_role.py
@@ -1,7 +1,7 @@
 from widgetastic.widget import Checkbox, Table, Text
 from widgetastic_patternfly import BreadCrumb
 from widgetastic_patternfly5 import (
-    Button as PF5button,
+    Button as PF5Button,
     CompactPagination as PF5CompactPagination,
     Pagination as PF5Pagination,
     PatternflyTable as PF5PatternflyTable,
@@ -18,7 +18,7 @@ class AnsibleRolesView(BaseLoggedInView, SearchableViewMixin):
 
     title = Text("//h1[contains(normalize-space(.),'Ansible Roles')]")
     import_button = Text("//a[contains(@href, '/ansible_roles/import')]")
-    submit = PF5button('Submit')
+    submit = PF5Button('Submit')
     table = Table(
         './/table',
         column_widgets={
@@ -49,8 +49,8 @@ class AnsibleRolesImportView(BaseLoggedInView):
     dropdown = Text("//button[contains(@class, 'pf-v5-c-menu-toggle')]")
     max_per_pg = Text("//ul[contains(@class, 'pf-v5-c-menu__list')]/li[6]")
     pagination = PF5CompactPagination()
-    submit = PF5button('Submit')
-    cancel = PF5button('Cancel')
+    submit = PF5Button('Submit')
+    cancel = PF5Button('Cancel')
 
     @property
     def is_displayed(self):

--- a/airgun/views/cloud_inventory.py
+++ b/airgun/views/cloud_inventory.py
@@ -3,7 +3,7 @@ from widgetastic.utils import ParametrizedLocator
 from widgetastic.widget import Text, View
 from widgetastic_patternfly import Tab
 from widgetastic_patternfly4.switch import Switch
-from widgetastic_patternfly5 import Button as PF5Button, Menu
+from widgetastic_patternfly5 import Button as PF5Button, Menu as PF5Menu
 from widgetastic_patternfly5.ouia import Text as PF5OUIAText
 
 from airgun.exceptions import ReadOnlyWidgetError
@@ -11,7 +11,7 @@ from airgun.views.common import BaseLoggedInView
 from airgun.widgets import Accordion
 
 
-class DataCollectionMenu(Menu):
+class DataCollectionMenu(PF5Menu):
     """ """
 
     IS_ALWAYS_OPEN = False

--- a/airgun/views/contentcredential.py
+++ b/airgun/views/contentcredential.py
@@ -1,7 +1,7 @@
 from widgetastic.utils import ParametrizedLocator
 from widgetastic.widget import Text, TextInput, View
 from widgetastic_patternfly import Tab
-from widgetastic_patternfly5.components.forms.form_select import FormSelect
+from widgetastic_patternfly5.components.forms.form_select import FormSelect as PF5FormSelect
 from widgetastic_patternfly5.ouia import (
     BreadCrumb as PF5OUIABreadCrumb,
     Button as PF5OUIAButton,
@@ -40,7 +40,7 @@ class CreateContentCredentialModal(PF5OUIAModal):
     OUIA_ID = 'create-content-credential-modal'
 
     name_input = PF5OUIATextInput('name-input')
-    content_type = FormSelect(locator='.//select[@id="content_type"]')
+    content_type = PF5FormSelect(locator='.//select[@id="content_type"]')
     content_text_box = TextInput(locator='.//textarea[@aria-label="content"]')
     create_button = PF5OUIAButton('create-button')
     cancel_button = PF5OUIAButton('cancel-button')

--- a/airgun/views/contentview_new.py
+++ b/airgun/views/contentview_new.py
@@ -2,7 +2,12 @@ from wait_for import wait_for
 from widgetastic.utils import ParametrizedLocator
 from widgetastic.widget import Checkbox, ParametrizedView, Text, TextInput, View
 from widgetastic_patternfly import BreadCrumb, Tab
-from widgetastic_patternfly5 import Alert as PF5Alert, Button, Modal, Radio as PF5Radio
+from widgetastic_patternfly5 import (
+    Alert as PF5Alert,
+    Button as PF5Button,
+    Modal as PF5Modal,
+    Radio as PF5Radio,
+)
 from widgetastic_patternfly5.ouia import (
     Button as PF5OUIAButton,
     Dropdown as PF5OUIADropdown,
@@ -121,11 +126,11 @@ class ContentViewEditView(BaseLoggedInView):
     cv_actions = PF5OUIADropdown('cv-details-actions')
 
     # buttons for wizard: deleting a CV with Version promoted to environment(s)
-    next_button = Button('Next')
-    delete_finish = Button('Delete')
-    back_button = Button('Back')
-    cancel_button = Button('Cancel')
-    close_button = Button('Close')
+    next_button = PF5Button('Next')
+    delete_finish = PF5Button('Delete')
+    back_button = PF5Button('Back')
+    cancel_button = PF5Button('Cancel')
+    close_button = PF5Button('Close')
 
     @property
     def is_displayed(self):
@@ -231,14 +236,14 @@ class ContentViewVersionPublishView(BaseLoggedInView):
     description = TextInput(id='description')
     promote = PF5OUIASwitch('promote-switch')
 
-    next_button = Button('Next')
-    finish_button = Button('Finish')
-    back_button = Button('Back')
-    cancel_button = Button('Cancel')
-    close_button = Button('Close')
+    next_button = PF5Button('Next')
+    finish_button = PF5Button('Finish')
+    back_button = PF5Button('Back')
+    cancel_button = PF5Button('Cancel')
+    close_button = PF5Button('Close')
     progressbar = PF5ProgressBar()
     lce_selector = ParametrizedView.nested(PF5LCECheckSelectorGroup)
-    close = Button('Close')
+    close = PF5Button('Close')
 
     @property
     def is_displayed(self):
@@ -265,13 +270,13 @@ class ContentViewVersionPublishView(BaseLoggedInView):
         )
 
 
-class ContentViewVersionPromoteView(Modal):
+class ContentViewVersionPromoteView(PF5Modal):
     ROOT = './/div[@data-ouia-component-id="promote-version"]'
 
     description = Text('.//h2[@data-ouia-component-id="description-text-value"]')
     lce_selector = ParametrizedView.nested(PF5LCECheckSelectorGroup)
-    promote_btn = Button(locator='//button[normalize-space(.)="Promote"]')
-    cancel_btn = Button(locator='//button[normalize-space(.)="Cancel"]')
+    promote_btn = PF5Button(locator='//button[normalize-space(.)="Promote"]')
+    cancel_btn = PF5Button(locator='//button[normalize-space(.)="Cancel"]')
 
 
 class ContentViewVersionDetailsView(BaseLoggedInView):
@@ -281,11 +286,11 @@ class ContentViewVersionDetailsView(BaseLoggedInView):
     promoteButton = PF5OUIAButton(component_id='cv-details-publish-button')
     editDescription = PF5OUIAButton(component_id='edit-button-description')
     # buttons for wizard: deleting a version promoted to environment(s)
-    next_button = Button('Next')
-    delete_finish = Button('Delete')
-    back_button = Button('Back')
-    cancel_button = Button('Cancel')
-    close_button = Button('Close')
+    next_button = PF5Button('Next')
+    delete_finish = PF5Button('Delete')
+    back_button = PF5Button('Back')
+    cancel_button = PF5Button('Cancel')
+    close_button = PF5Button('Close')
     progressbar = PF5ProgressBar()
 
     @View.nested

--- a/airgun/views/flatpak.py
+++ b/airgun/views/flatpak.py
@@ -5,7 +5,7 @@ from widgetastic_patternfly5 import (
     Button as PF5Button,
     Menu as PF5Menu,
     Modal as PF5Modal,
-    Pagination,
+    Pagination as PF5Pagination,
 )
 from widgetastic_patternfly5.ouia import (
     PatternflyTable as PF5OUIATable,
@@ -36,7 +36,7 @@ class FlatpakRemotesView(BaseLoggedInView, SearchableViewMixinPF4):
             2: PF5Menu(locator='.//div[contains(@class, "pf-v5-c-menu")]'),
         },
     )
-    pagination = Pagination()
+    pagination = PF5Pagination()
 
     @property
     def is_displayed(self):
@@ -66,7 +66,7 @@ class FlatpakRemoteDetailsView(BaseLoggedInView, SearchableViewMixinPF4):
             'Mirror': PF5Button('Mirror'),
         },
     )
-    pagination = Pagination("//div[@class = 'pf-v5-c-pagination pf-m-bottom tfm-pagination']")
+    pagination = PF5Pagination("//div[@class = 'pf-v5-c-pagination pf-m-bottom tfm-pagination']")
 
     @property
     def is_displayed(self):

--- a/airgun/views/host.py
+++ b/airgun/views/host.py
@@ -21,7 +21,7 @@ from widgetastic_patternfly4.ouia import (
     BreadCrumb as PF4BreadCrumb,
     Button as PF4Button,
 )
-from widgetastic_patternfly5.components.tabs import Tab
+from widgetastic_patternfly5.components.tabs import Tab as PF5Tab
 from widgetastic_patternfly5.ouia import (
     Button as PF5OUIAButton,
     Dropdown as PF5OUIADropdown,
@@ -590,7 +590,7 @@ class HostRegisterView(BaseLoggedInView):
     registration_command = TextInput(locator="//input[@aria-label='Copyable input']")
 
     @View.nested
-    class general(Tab):
+    class general(PF5Tab):
         TAB_NAME = 'General'
         TAB_LOCATOR = ParametrizedLocator(
             './/div[contains(@class, "pf-v5-c-tabs")]//ul'
@@ -612,7 +612,7 @@ class HostRegisterView(BaseLoggedInView):
         new_activation_key_link = Link('//a[normalize-space(.)="Create new activation key"]')
 
     @View.nested
-    class advanced(Tab):
+    class advanced(PF5Tab):
         TAB_NAME = 'Advanced'
         TAB_LOCATOR = ParametrizedLocator(
             './/div[contains(@class, "pf-v5-c-tabs")]//ul'

--- a/airgun/views/job_invocation.py
+++ b/airgun/views/job_invocation.py
@@ -6,7 +6,7 @@ from widgetastic.widget import Checkbox, Text, TextInput, View
 from widgetastic_patternfly import BreadCrumb
 from widgetastic_patternfly5 import (
     ChipGroup as PF5ChipGroup,
-    DescriptionList,
+    DescriptionList as PF5DescriptionList,
     Radio as PF5Radio,
 )
 from widgetastic_patternfly5.charts.donut_chart import DonutCircle, DonutLegend
@@ -391,7 +391,7 @@ class JobInvocationStatusView(BaseLoggedInView):
                 return {}
 
     @View.nested
-    class overview(DescriptionList):
+    class overview(PF5DescriptionList):
         ROOT = ".//dl[contains(@class, 'job-overview-description-list')]"
 
         def read(self):

--- a/airgun/views/job_invocation.py
+++ b/airgun/views/job_invocation.py
@@ -9,7 +9,10 @@ from widgetastic_patternfly5 import (
     DescriptionList as PF5DescriptionList,
     Radio as PF5Radio,
 )
-from widgetastic_patternfly5.charts.donut_chart import DonutCircle, DonutLegend
+from widgetastic_patternfly5.charts.donut_chart import (
+    DonutCircle as PF5DonutCircle,
+    DonutLegend as PF5DonutLegend,
+)
 from widgetastic_patternfly5.ouia import (
     Button as PF5OUIAButton,
     Dropdown as PF5OUIADropdown,
@@ -341,7 +344,7 @@ class JobInvocationStatusView(BaseLoggedInView):
         self.browser.refresh()
 
     @View.nested
-    class overall_status(DonutCircle):
+    class overall_status(PF5DonutCircle):
         """The donut circle with the overall job status of '{succeeded hosts}/{total hosts}'"""
 
         def read(self):
@@ -364,7 +367,7 @@ class JobInvocationStatusView(BaseLoggedInView):
                 return {}
 
     @View.nested
-    class status(DonutLegend):
+    class status(PF5DonutLegend):
         """System status panel."""
 
         ROOT = ".//div[contains(@class, 'chart-legend')]"

--- a/airgun/views/sync_status.py
+++ b/airgun/views/sync_status.py
@@ -2,7 +2,10 @@ from wait_for import wait_for
 from widgetastic.exceptions import NoSuchElementException
 from widgetastic.widget import Text, Widget
 from widgetastic_patternfly5 import Button as PF5Button
-from widgetastic_patternfly5.components.table import PatternflyTable, PatternflyTableRow
+from widgetastic_patternfly5.components.table import (
+    PatternflyTable as PF5PatternflyTable,
+    PatternflyTableRow as PF5PatternflyTableRow,
+)
 from widgetastic_patternfly5.ouia import Switch as PF5OUIASwitch
 
 from airgun.views.common import BaseLoggedInView
@@ -12,7 +15,7 @@ class NodeNotFoundError(Exception):
     """Raise when a node was not found"""
 
 
-class SyncStatusTreeRow(PatternflyTableRow):
+class SyncStatusTreeRow(PF5PatternflyTableRow):
     """A row in the PF5 tree table that supports aria-based tree attributes.
 
     In the Sync Status tree table all ``<tr>`` rows live inside a single
@@ -105,7 +108,7 @@ class SyncStatusTreeRow(PatternflyTableRow):
         return self['Progress / Result'].read()
 
 
-class SyncStatusTreeTable(PatternflyTable):
+class SyncStatusTreeTable(PF5PatternflyTable):
     """PF5 tree table for Sync Status page.
 
     The table has ``role="treegrid"`` with a single ``<tbody>`` containing

--- a/airgun/views/usergroup.py
+++ b/airgun/views/usergroup.py
@@ -1,6 +1,6 @@
 from widgetastic.widget import Checkbox, Table, Text, TextInput, View
 from widgetastic_patternfly import BreadCrumb
-from widgetastic_patternfly5 import Button
+from widgetastic_patternfly5 import Button as PF5Button
 
 from airgun.views.common import BaseLoggedInView, SatTab, SearchableViewMixinPF4
 from airgun.widgets import FilteredDropdown, MultiSelect
@@ -8,7 +8,7 @@ from airgun.widgets import FilteredDropdown, MultiSelect
 
 class UserGroupsView(BaseLoggedInView, SearchableViewMixinPF4):
     title = Text("//h1[normalize-space(.)='User Groups']")
-    new_on_blank_page = Button('Create User group')
+    new_on_blank_page = PF5Button('Create User group')
     new = Text("//a[contains(@href, '/usergroups/new')]")
     table = Table(
         './/table',

--- a/airgun/widgets.py
+++ b/airgun/widgets.py
@@ -36,9 +36,9 @@ from widgetastic_patternfly5 import (
     Button as PF5Button,
     Dropdown as PF5Dropdown,
     ExpandableSection as PF5ExpandableSection,
-    FormSelect,
+    FormSelect as PF5FormSelect,
     Progress as PF5Progress,
-    RowNotExpandable,
+    RowNotExpandable as PF5RowNotExpandable,
 )
 from widgetastic_patternfly5.components.table import (
     PatternflyTable,
@@ -2842,7 +2842,7 @@ class FieldWithEditButton(Widget):
     ROOT = '//td[2]'
     text_input = TextInput(locator=".//input[@data-ouia-component-type='PF5/TextInput']")
     text_area = TextInput(locator='.//textarea')
-    drop_down = FormSelect(locator=".//select[@data-ouia-component-type='PF5/FormSelect']")
+    drop_down = PF5FormSelect(locator=".//select[@data-ouia-component-type='PF5/FormSelect']")
     edit_button = PF5Button(locator=".//button[contains(@data-ouia-component-id, 'edit-row')]")
     confirm_button = PF5OUIAButton('submit-edit-btn')
     cancel_button = PF5OUIAButton('cancel-edit-btn')
@@ -3142,7 +3142,7 @@ class CompoundExpandableTableRow(PatternflyTableRow):
 
     def _check_expandable(self):
         if not self.is_expandable:
-            raise RowNotExpandable(self)
+            raise PF5RowNotExpandable(self)
 
     @property
     def is_expanded(self):

--- a/airgun/widgets.py
+++ b/airgun/widgets.py
@@ -41,8 +41,8 @@ from widgetastic_patternfly5 import (
     RowNotExpandable as PF5RowNotExpandable,
 )
 from widgetastic_patternfly5.components.table import (
-    PatternflyTable,
-    PatternflyTableRow,
+    PatternflyTable as PF5PatternflyTable,
+    PatternflyTableRow as PF5PatternflyTableRow,
 )
 from widgetastic_patternfly5.ouia import (
     BaseSelect as PF5OUIABaseSelect,
@@ -3130,7 +3130,7 @@ class PF5DataList(Widget):
         return dict(zip(items, values))
 
 
-class CompoundExpandableTableRow(PatternflyTableRow):
+class CompoundExpandableTableRow(PF5PatternflyTableRow):
     """Extends PatternflyTableRow with some functionality from ExpandableTableRow"""
 
     EXPANDABLE_CONTENT = './tr[contains(@class, "child-manifest-row")'
@@ -3172,7 +3172,7 @@ class CompoundExpandableTableRow(PatternflyTableRow):
         return result
 
 
-class CompoundExpandableTable(PatternflyTable):
+class CompoundExpandableTable(PF5PatternflyTable):
     """PatternFly table with inline expandable child rows.
 
     This handles tables where each row group is in its own <tbody>,


### PR DESCRIPTION
Similar PR to https://github.com/SatelliteQE/airgun/pull/2512 but now for PF5 imports.

Importing widgets from `widgetastic_patternfly5` follow naming with PF5 prefix like:
```
from widgetastic_patternfly5 import Button as PF5Button
```

As this PR just renames the widgets no automation effects are expected.