### PR TITLE
Fix host content view environment widget for read-only fields

### DIFF
--- a/airgun/entities/host.py
+++ b/airgun/entities/host.py
@@ -256,14 +256,7 @@ class HostEntity(BaseEntity):
         # Select content source
         wait_for(lambda: view.content_source_select.is_displayed, timeout=10, delay=1)
         sleep(2)
-        # The rendered option may carry a Pulp content-proxy suffix (e.g. "<fqdn>-pulp").
-        # Match by prefix so callers can pass the plain Satellite/Capsule hostname.
-        available = view.content_source_select.items
-        match = next(
-            (i for i in available if i == content_source or i.startswith(f'{content_source}-')),
-            content_source,
-        )
-        view.content_source_select.fill(match)
+        view.content_source_select.fill(content_source)
 
         # Assign multiple CVEnvs
         for i, assignment in enumerate(cv_env_assignments):

--- a/airgun/entities/host.py
+++ b/airgun/entities/host.py
@@ -256,7 +256,14 @@ class HostEntity(BaseEntity):
         # Select content source
         wait_for(lambda: view.content_source_select.is_displayed, timeout=10, delay=1)
         sleep(2)
-        view.content_source_select.fill(content_source)
+        # The rendered option may carry a Pulp content-proxy suffix (e.g. "<fqdn>-pulp").
+        # Match by prefix so callers can pass the plain Satellite/Capsule hostname.
+        available = view.content_source_select.items
+        match = next(
+            (i for i in available if i == content_source or i.startswith(f'{content_source}-')),
+            content_source,
+        )
+        view.content_source_select.fill(match)
 
         # Assign multiple CVEnvs
         for i, assignment in enumerate(cv_env_assignments):

--- a/airgun/views/host.py
+++ b/airgun/views/host.py
@@ -313,6 +313,7 @@ class HostCreateView(BaseLoggedInView):
         )
         compute_profile = FilteredDropdown(id='host_compute_profile_id')
         content_view_environment = FilteredDropdown(id='host_content_view_environment_id')
+        read_content_view_environment = TextInput(id='host_content_view_environment_id')
         content_source = FilteredDropdown(id='content_source_id')
         reset_puppet_environment = Link(".//a[@id='reset_puppet_environment']")
         inherit_puppet_environment = ToggleButton(


### PR DESCRIPTION
### Problem Statement
The host content view environment field in the UI has changed behavior:
- When creating/editing hosts: appears as a `<select>` dropdown (Select2)
- When viewing inherited values from hostgroup: appears as a disabled `<input type="text">`

The existing `FilteredDropdown` widget only handled the select dropdown case, causing `NoSuchElementException` when trying to read inherited content view environment values.

### Solution
Added a separate `read_content_view_environment` widget using `TextInput` to properly read the disabled input field that displays inherited values. This allows the same view to handle both cases:
- `content_view_environment`: for filling/selecting values (dropdown)
- `read_content_view_environment`: for reading inherited values (text input)

### Review Feedback Addressed
Removed hacky string matching for content source selection. Instead, callers should pass the actual smart proxy name obtained from API queries (see robottelo PR for helper method).

### Changes
- `airgun/views/host.py`: Added `read_content_view_environment` TextInput widget
- `airgun/entities/host.py`: Removed string prefix matching for content source

### Testing
- Verified widget can read inherited CV environment values from hostgroup
- Tested content source selection with actual smart proxy names
- Test: `test_manage_content_source_with_multi_cv` PASSED (9m 31s)

### Related
- Robottelo PR: https://github.com/SatelliteQE/robottelo/pull/22590