### PR TITLE
update new_host delete method

### DIFF
--- a/airgun/entities/host_new.py
+++ b/airgun/entities/host_new.py
@@ -92,7 +92,7 @@ class NewHostEntity(HostEntity):
         view.wait_displayed()
         self.browser.plugin.ensure_page_safe()
         view.search(entity_name)
-        view.table.row(name=entity_name)[6].widget.item_select('Delete')
+        view.get_row_kebab(0).item_select('Delete')
         self.browser.handle_alert()
         self.browser.refresh()
 


### PR DESCRIPTION
A couple of compute resource tests are failing due to this recent change. While deleting a host, it is no longer fetching the toggle button class because it has been replaced by `get_row_kebab`. We need to update the delete method accordingly.
