### PR TITLE
SAT-50157 - Fix job invocation status keyerror

### DIFF
--- a/airgun/entities/hostcollection.py
+++ b/airgun/entities/hostcollection.py
@@ -119,9 +119,10 @@ class HostCollectionEntity(BaseEntity):
         # After this step the user is redirected to job status view.
         job_status_view = JobInvocationStatusView(view.browser)
         wait_for(
-            lambda: job_status_view.status.read()['In Progress'] != 1,
+            lambda: job_status_view.status.read().get('In Progress', 1) == 0,
             timeout=300,
             delay=10,
+            handle_exception=True,
             logger=view.logger,
         )
         return job_status_view.read()
@@ -177,11 +178,12 @@ class HostCollectionEntity(BaseEntity):
 
         # After this step the user is redirected to job status view.
         job_status_view = JobInvocationStatusView(view.browser)
-        wait_for(lambda: job_status_view.is_displayed, timeout=30, delay=5)
+        wait_for(lambda: job_status_view.is_displayed, timeout=30, delay=5, handle_exception=True)
         wait_for(
-            lambda: job_status_view.status.read()['In Progress'] != 1,
+            lambda: job_status_view.status.read().get('In Progress', 1) == 0,
             timeout=300,
             delay=10,
+            handle_exception=True,
             logger=view.logger,
         )
         return job_status_view.read()

--- a/airgun/entities/job_invocation.py
+++ b/airgun/entities/job_invocation.py
@@ -111,9 +111,10 @@ class JobInvocationEntity(BaseEntity):
         wait_for(lambda: view.leapp_preupgrade_report.fix_selected.is_displayed, timeout=10)
         view.leapp_preupgrade_report.fix_selected.click()
         wait_for(
-            lambda: view.overview.read()['job_status'] == expected_state,
+            lambda: view.overview.read().get('job_status') == expected_state,
             timeout=300,
             delay=10,
+            handle_exception=True,
             logger=view.logger,
         )
 

--- a/airgun/views/job_invocation.py
+++ b/airgun/views/job_invocation.py
@@ -333,12 +333,14 @@ class JobInvocationStatusView(BaseLoggedInView):
             lambda: self.is_displayed,
             timeout=timeout,
             delay=delay,
+            handle_exception=True,
             logger=self.logger,
         )
         wait_for(
-            lambda: self.status.read()['In Progress'] == 0,
+            lambda: self.status.read().get('In Progress', 1) == 0,
             timeout=timeout,
             delay=1,
+            handle_exception=True,
             logger=self.logger,
         )
         self.browser.refresh()


### PR DESCRIPTION
**Problem Statement**

UI flows that poll a Job Invocation status donut intermittently fail with `KeyError: 'In Progress'` (and are exposed to `StaleElementReferenceException` during PatternFly re-renders). `JobInvocationStatusView.status.read()` is documented to return an empty dict `{}` whenever the status-donut legend isn't currently rendered — mid re-render, or before a scheduled job starts. Several callers subscripted the result directly (`read()['In Progress']`) inside a `wait_for` lambda with no `handle_exception`, so a single transient empty read raised `KeyError`, aborted the wait, and failed the test.

This was root-caused from an IoP interop run of `test_iop_recommendations_e2e` (`SAT-50157`), but the same fragile pattern existed in four places:
- `JobInvocationStatusView.wait_for_result` (both the `is_displayed` and `status.read()` waits)
- Host Collection job execution (two waits)
- LEAPP preupgrade job-status wait (`overview.read()['job_status']`)

**Solution**

- Read the status/overview dict defensively with `.get(...)` and a default chosen so a transient empty read evaluates as "not ready yet" (keeps polling) rather than raising or falsely exiting early:
  - `status.read().get('In Progress', 1)` — default `1` keeps `!= 1` / `== 0` comparisons waiting through an empty read.
  - `overview.read().get('job_status')` — None correctly fails the `== expected_state` check so it keeps waiting.

- Add `handle_exception=True` to these `wait_for` calls (including the standalone `job_status_view.is_displayed` wait in `install_errata`) as a backstop for other transient DOM errors (e.g. `StaleElementReferenceException`) during re-render, matching the pattern already used elsewhere in `entities/cloud_insights.py`.

No locator or behavioral changes — purely hardening the polling against transient empty reads.

**PRT Example**
```
trigger: test-robottelo
pytest: tests/foreman/ui/test_rhcloud_iop.py::test_iop_recommendations_e2e
```