### PR TITLE
Fix EOL banner locator

### DIFF
--- a/airgun/views/eol_banner.py
+++ b/airgun/views/eol_banner.py
@@ -3,7 +3,7 @@ from widgetastic.widget import ClickableMixin, Text, View
 
 class EOLBannerView(View, ClickableMixin):
     name = Text('//div[@id="satellite-eol-banner"]')
-    dismiss_button = Text('//*[@id="satellite-oel-banner-dismiss-button"]')
+    dismiss_button = Text('//*[@id="satellite-eol-banner-dismiss-button"]')
     LIFECYCLE_LINK = '//a[text()[normalize-space(.) = "Red Hat Satellite Product Life Cycle"]]'
     HELPER_LINK = '//a[text()[normalize-space(.) = "Red Hat Satellite Upgrade Helper."]]'
 


### PR DESCRIPTION
Fix to typo in EOL banner element locator: `satellite-oel-banner-dismiss-button` should now be `satellite-eol-banner-dismiss-button`.

Can be merged once https://github.com/RedHatSatellite/foreman_theme_satellite/pull/332 is merged and a new stream snap of Satellite has been created.